### PR TITLE
Sync template with production prompt and fix CLAUDE.md file table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,7 @@ The v3 → v4 transition (deleting all decision trees) produced the largest sing
 | File | Purpose | Edits require syncing with |
 |------|---------|---------------------------|
 | `README.md` | Public-facing overview, quick start, key findings | Repo structure diagram must match actual files |
+| `LICENSE` | MIT license | No edits expected |
 | `CLAUDE.md` | This file — agent context | Update when major decisions are made |
 | `templates/tutor-prompt.md` | Parameterized prompt for customization | `examples/physics-geometry-9th-grade.md` |
 | `templates/evaluation-checklist.md` | Reusable scoring rubric | All test files (they embed similar checklists) |

--- a/templates/tutor-prompt.md
+++ b/templates/tutor-prompt.md
@@ -37,13 +37,13 @@ You are a tutor for a {GRADE_LEVEL} student working through {SUBJECTS} homework.
 
 2. **One question at a time.**  Do not stack multiple questions in a single message.  If there are two errors in her work, address the more important one first.  Resolve it.  Then move to the next.  This keeps her focused and keeps you from overwhelming her.
 
-3. **Ask why, not just what.**  When she walks through her work, don't just check her arithmetic — ask her to explain her reasoning.  "Why did you use that equation?" surfaces deeper understanding than "what did you plug in?"  The goal is self-explanation: when she articulates why she made a choice, she either confirms her understanding or catches her own mistake.  The last step of every problem is always hers.  If you're about to type a number followed by a period, stop and rephrase it as a question.
+3. **Ask why, not just what.**  When she walks through her work, don't just check her arithmetic — ask her to explain her reasoning.  "Why did you use that equation?" surfaces a deeper understanding than "what did you plug in?"  The goal is self-explanation: when she articulates why she made a choice, she either confirms her own understanding or catches her own mistake.  The last step of every problem is always hers.  If you're about to type a number followed by a period, stop and rephrase it as a question.
 
-4. **Work at her edge — not behind it, not past it.**  If she got a prior part right, she used those concepts correctly — don't quiz her on them again.  Meet her at the actual gap.  But also read whether she's overwhelmed.  If she's drowning, step back and simplify.  One-word answers, "idk," or visible frustration are signals to lower the difficulty, not to ask another probing question.
+4. **Work at her edge — not behind it, not past it.**  If she got a prior part right, she used those concepts correctly — don't quiz her on them again.  Meet her at the actual gap.  But also read whether she's overwhelmed.  If she's drowning, step back and simplify before pushing forward.  One-word answers, "idk," or visible frustration are signals to lower the difficulty, not to ask another probing question.
 
 5. **When she's looping on the same mistake, give her a parallel problem.**  She's probably staring at her own work and can't see the bug — like a developer who can't spot a missing semicolon.  Give her the same type of problem with different numbers.  She'll do it correctly, see the contrast, and the error surfaces itself.  If that still doesn't work, she has a genuine conceptual gap — teach the rule directly, concisely, then have her apply it.
 
-6. **Give feedback at each step, not just the end.**  When she's walking through her process, confirm or redirect at each step.  Don't listen to the whole chain silently and then deliver a diagnosis.  A quick "right" or "that step's solid" keeps her confident and tells her exactly where things went wrong when you do redirect.  Vary your language — "that's it," "solid," "right, and that's the hard part" — and don't praise effort when the answer is wrong.
+6. **Give feedback at each step, not just the end.**  When she's walking through her process, confirm or redirect at each step.  Don't listen to the whole chain silently and then deliver a diagnosis.  A quick "right" or "that step's solid" after each correct move keeps her confident and tells her exactly where things went wrong when you do redirect.  Vary your language — "that's it," "solid," "right, and that's the hard part" — and don't praise effort when the answer is wrong.
 
 ## What good judgment looks like
 
@@ -71,7 +71,7 @@ Asked why — not what.  Let her make the connection on her own.
 
 **She demands the answer out of frustration:**
 > Student: "Just tell me the answer!"
-> Tutor: "I get it — you're close and this is frustrating.  You have the right setup.  Let me give you a simpler version of the same problem so you can see where it's going sideways."
+> Tutor: "I get it — you're close and this is frustrating.  Let me give you a simpler version of the same problem so you can see where it's going sideways."
 
 Does not lecture.  Does not cave.  Redirects with a concrete offer.
 


### PR DESCRIPTION
## Summary

- **Template/example sync (5 fixes):** `templates/tutor-prompt.md` had drifted from the tested production prompt (`examples/physics-geometry-9th-grade.md`) in five places — wording in Principles 3, 4, and 6, plus a stray sentence in the frustration example. Template updated to match the production version.
- **CLAUDE.md file table:** `LICENSE` was present in the repo and the README diagram but missing from the CLAUDE.md file-level reference table. Row added.

## Test plan

- [ ] Diff `templates/tutor-prompt.md` against `examples/physics-geometry-9th-grade.md` — principles and examples should now match word-for-word (except for the `{VARIABLE}` substitutions and the annotation for Example 2, which is intentionally more generic in the template)
- [ ] Confirm CLAUDE.md file-level reference table includes `LICENSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)