### PR TITLE
Add end-session email workflow

### DIFF
--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -49,6 +49,18 @@ const session = new Session();
 session.addUserMessage("Hi", "Hi");
 const text = session.addAssistantResponse(response.content);
 const transcript = session.getTranscript();
+
+// File tracking (web app — buffers held in memory for the session lifetime)
+session.addFile("photo.jpg", "image/jpeg", buffer);
+
+// Activity and client info (web app)
+session.touchActivity();
+session.setClientInfo({ ip: "1.2.3.4", geo: { city: "Brooklyn" }, userAgent: "..." });
+
+// Email guard
+session.markEmailSent();      // prevents double-send
+const summary = session.getSessionSummary(); // { transcript, filesMetadata, clientInfo, startedAt, lastActivityAt, durationMs }
+
 session.reset();
 ```
 

--- a/apps/core/session.js
+++ b/apps/core/session.js
@@ -13,6 +13,11 @@ export class Session {
   constructor() {
     this.messages = [];
     this.transcript = [];
+    this.files = [];
+    this.startedAt = new Date();
+    this.lastActivityAt = new Date();
+    this.clientInfo = {};
+    this.emailSent = false;
   }
 
   /**
@@ -46,8 +51,58 @@ export class Session {
     return this.transcript;
   }
 
+  /**
+   * Store an uploaded file buffer.
+   * Note: files are held in memory for the life of the session.  Acceptable
+   * for single-student use; not acceptable at scale.
+   * @param {string} filename
+   * @param {string} mimetype
+   * @param {Buffer} buffer
+   */
+  addFile(filename, mimetype, buffer) {
+    this.files.push({ filename, mimetype, buffer });
+  }
+
+  /** Update lastActivityAt to the current time. */
+  touchActivity() {
+    this.lastActivityAt = new Date();
+  }
+
+  /**
+   * Store client metadata: IP, approximate geo location, user agent.
+   * @param {{ ip: string, geo: object|null, userAgent: string }} info
+   */
+  setClientInfo(info) {
+    this.clientInfo = info;
+  }
+
+  /** Prevent double-send. */
+  markEmailSent() {
+    this.emailSent = true;
+  }
+
+  /**
+   * Returns a plain object summarizing the session for email.
+   * @returns {{ transcript: Array, filesMetadata: Array, clientInfo: object, startedAt: Date, lastActivityAt: Date, durationMs: number }}
+   */
+  getSessionSummary() {
+    return {
+      transcript: this.transcript,
+      filesMetadata: this.files.map((f) => ({ filename: f.filename, mimetype: f.mimetype, size: f.buffer.length })),
+      clientInfo: this.clientInfo,
+      startedAt: this.startedAt,
+      lastActivityAt: this.lastActivityAt,
+      durationMs: this.lastActivityAt - this.startedAt,
+    };
+  }
+
   reset() {
     this.messages = [];
     this.transcript = [];
+    this.files = [];
+    this.startedAt = new Date();
+    this.lastActivityAt = new Date();
+    this.clientInfo = {};
+    this.emailSent = false;
   }
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,3 +21,11 @@ EXTENDED_THINKING=true
 # Port for the web server
 # Default: 3000
 PORT=3000
+
+# Resend API key — required for session email summaries
+# Get yours at https://resend.com/
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxx
+
+# Email recipient for session summaries
+# Default: me@schmim.com
+PARENT_EMAIL=me@schmim.com

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,6 +8,8 @@ Express server with a single-page chat interface.  The student types messages an
 - **Language:** JavaScript (ES modules)
 - **Server:** Express 4
 - **File uploads:** Multer (in-memory storage)
+- **Email:** Resend SDK
+- **Geo lookup:** geoip-lite (local database, no external API)
 - **Frontend:** Single HTML file — no build step, no dependencies, no framework
 
 ## Dependencies
@@ -16,11 +18,15 @@ Express server with a single-page chat interface.  The student types messages an
 |---------|---------|---------|
 | `@ai-tutor/core` | workspace | Shared tutor logic (Anthropic SDK, session management, config) |
 | `express` | ^4.21.0 | HTTP server and routing |
+| `geoip-lite` | ^1.4.10 | IP-to-location lookup (local database) |
 | `multer` | ^1.4.5-lts.1 | Multipart file upload handling |
+| `resend` | ^4.0.0 | Email delivery for session summaries |
 
 ## Design methodology
 
-The web app is a thin HTTP layer over the shared core.  Express handles routing and static file serving.  Multer handles file uploads in memory — files are held only for the duration of the API call, then discarded.  Sessions are stored in memory keyed by UUID, generated client-side.  Restarting the server clears all sessions.
+The web app is a thin HTTP layer over the shared core.  Express handles routing and static file serving.  Multer handles file uploads in memory — files are stored in the session for later email attachment.  Sessions are stored in memory keyed by UUID, generated client-side.  Restarting the server clears all sessions.
+
+When a session ends (via "End session" button, "New session" button, tab close, or 10-minute inactivity timeout), the server packages the full transcript and any uploaded files into an email and sends it via Resend.  The `emailSent` flag on each session prevents double-sends.
 
 The frontend is a single `index.html` file containing HTML, CSS, and JavaScript together.  This was a deliberate choice: no build step means no toolchain to maintain, and the chat interface is simple enough that a framework would add complexity without value.
 
@@ -67,8 +73,10 @@ Open `http://localhost:3000` in your browser.
 - **Chat interface** — student messages on the right, tutor on the left.
 - **File uploads** — click the paperclip icon or drag-and-drop to attach images (jpg, png, gif, webp) or PDFs.  Up to 5 files per message, 10 MB max each.
 - **Transcript export** — click "Transcript" to view the full session, copy it to clipboard.
-- **New session** — click "New session" to clear the conversation and start fresh.
+- **End session** — click "End session" to email the session summary and start fresh.
+- **New session** — click "New session" to clear the conversation and start fresh (also emails the summary).
 - **Model indicator** — shows which model and whether extended thinking is active.
+- **Automatic session capture** — sessions idle for 10 minutes are emailed and reaped server-side.
 
 ### Using a specific prompt
 
@@ -84,7 +92,8 @@ Or set it in your `.env` file.
 |--------|------|-------------|
 | `POST` | `/api/chat` | Send a message with optional file attachments |
 | `GET` | `/api/transcript/:sessionId` | Export a session transcript |
-| `POST` | `/api/reset` | Clear a session |
+| `POST` | `/api/end-session` | Email session summary and delete session |
+| `POST` | `/api/reset` | Clear a session (also emails summary if not already sent) |
 | `GET` | `/api/config` | Expose non-sensitive config (model, extended thinking) |
 
 ## Configuration
@@ -96,3 +105,5 @@ Or set it in your `.env` file.
 | `MODEL` | `claude-sonnet-4-6` | Model to use |
 | `EXTENDED_THINKING` | `true` | Enable extended thinking (set to `false` to disable) |
 | `PORT` | `3000` | Port for the web server |
+| `RESEND_API_KEY` | (required for email) | Resend API key for session email summaries |
+| `PARENT_EMAIL` | `me@schmim.com` | Email address for session summaries |

--- a/apps/web/email.js
+++ b/apps/web/email.js
@@ -1,0 +1,158 @@
+import { Resend } from "resend";
+
+const RESEND_ATTACHMENT_LIMIT = 40 * 1024 * 1024; // 40 MB
+
+/**
+ * Format milliseconds as a human-readable duration string (e.g. "12 min 34 sec").
+ */
+function formatDuration(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds} sec`;
+  return `${minutes} min ${seconds} sec`;
+}
+
+/**
+ * Format a Date as a readable local string.
+ */
+function formatDate(date) {
+  return date.toLocaleString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+/**
+ * Build the HTML email body from a session summary.
+ */
+function buildEmailHtml(summary) {
+  const { transcript, filesMetadata, clientInfo, startedAt, durationMs } = summary;
+  const exchangeCount = Math.floor(transcript.length / 2);
+
+  const geoStr = clientInfo.geo
+    ? [clientInfo.geo.city, clientInfo.geo.region, clientInfo.geo.country].filter(Boolean).join(", ")
+    : "Unknown";
+
+  const transcriptHtml = transcript
+    .map((entry) => {
+      const isStudent = entry.role === "Student";
+      const bg = isStudent ? "#eef0f5" : "#f7f5f0";
+      const label = isStudent ? "Student" : "Tutor";
+      const text = entry.text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\n/g, "<br>");
+      return `
+        <div style="margin-bottom:16px;">
+          <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#8a8580;margin-bottom:4px;">${label}</div>
+          <div style="background:${bg};border-radius:8px;padding:12px 16px;font-size:14px;line-height:1.6;color:#2c2a27;">${text}</div>
+        </div>`;
+    })
+    .join("");
+
+  const filesHtml =
+    filesMetadata.length > 0
+      ? filesMetadata
+          .map((f) => `<li style="margin-bottom:4px;">${f.filename} (${f.mimetype}, ${Math.round(f.size / 1024)} KB)</li>`)
+          .join("")
+      : "<li>None</li>";
+
+  return `
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="font-family:'DM Sans',sans-serif;background:#faf8f5;margin:0;padding:24px;">
+  <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:12px;border:1px solid #e8e4df;overflow:hidden;">
+
+    <div style="background:#5a7a64;padding:24px 28px;">
+      <h1 style="margin:0;font-size:20px;color:#ffffff;font-weight:600;">Tutoring Session Summary</h1>
+      <p style="margin:6px 0 0;color:#c8d8cc;font-size:13px;">${formatDate(startedAt)}</p>
+    </div>
+
+    <div style="padding:24px 28px;">
+
+      <h2 style="font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#8a8580;margin:0 0 12px;">Session Details</h2>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;margin-bottom:24px;">
+        <tr><td style="padding:6px 0;color:#8a8580;width:140px;">Start time</td><td style="padding:6px 0;color:#2c2a27;">${formatDate(startedAt)}</td></tr>
+        <tr><td style="padding:6px 0;color:#8a8580;">Duration</td><td style="padding:6px 0;color:#2c2a27;">${formatDuration(durationMs)}</td></tr>
+        <tr><td style="padding:6px 0;color:#8a8580;">Exchanges</td><td style="padding:6px 0;color:#2c2a27;">${exchangeCount}</td></tr>
+      </table>
+
+      <h2 style="font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#8a8580;margin:0 0 12px;">Client Info</h2>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;margin-bottom:24px;">
+        <tr><td style="padding:6px 0;color:#8a8580;width:140px;">IP address</td><td style="padding:6px 0;color:#2c2a27;">${clientInfo.ip || "Unknown"}</td></tr>
+        <tr><td style="padding:6px 0;color:#8a8580;">Location</td><td style="padding:6px 0;color:#2c2a27;">${geoStr}</td></tr>
+        <tr><td style="padding:6px 0;color:#8a8580;">User agent</td><td style="padding:6px 0;color:#2c2a27;word-break:break-all;">${clientInfo.userAgent || "Unknown"}</td></tr>
+      </table>
+
+      <h2 style="font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#8a8580;margin:0 0 12px;">Uploaded Files</h2>
+      <ul style="font-size:14px;color:#2c2a27;margin:0 0 24px;padding-left:20px;">
+        ${filesHtml}
+      </ul>
+
+      <h2 style="font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:#8a8580;margin:0 0 16px;">Transcript</h2>
+      ${transcriptHtml}
+
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * Send a session summary email via Resend.
+ *
+ * Wraps in try/catch — logs errors but does not throw.  A failed email
+ * should never crash the server or block a session reset.
+ *
+ * @param {import("@ai-tutor/core").Session} session
+ * @param {{ resendApiKey: string, parentEmail: string }} emailConfig
+ */
+export async function sendSessionEmail(session, emailConfig) {
+  const { resendApiKey, parentEmail } = emailConfig;
+
+  if (!resendApiKey) {
+    console.warn("RESEND_API_KEY not set — skipping session email.");
+    return;
+  }
+
+  const summary = session.getSessionSummary();
+
+  if (summary.transcript.length === 0) {
+    console.log("Session has no messages — skipping email.");
+    return;
+  }
+
+  const date = summary.startedAt.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+  const duration = formatDuration(summary.durationMs);
+  const subject = `Tutoring session — ${date} — ${duration}`;
+
+  // Build attachments — skip if total size exceeds Resend's 40MB limit
+  const totalSize = session.files.reduce((sum, f) => sum + f.buffer.length, 0);
+  let attachments = [];
+  if (totalSize <= RESEND_ATTACHMENT_LIMIT) {
+    attachments = session.files.map((f) => ({
+      filename: f.filename,
+      content: f.buffer,
+    }));
+  } else {
+    console.warn(`Session file attachments total ${Math.round(totalSize / 1024 / 1024)} MB — exceeds 40MB Resend limit.  Sending transcript only.`);
+  }
+
+  try {
+    const resend = new Resend(resendApiKey);
+    await resend.emails.send({
+      from: "tutor@tutor.schmim.com",
+      to: parentEmail,
+      subject,
+      html: buildEmailHtml(summary),
+      attachments,
+    });
+    console.log(`Session email sent to ${parentEmail} (${summary.transcript.length} transcript entries).`);
+  } catch (err) {
+    console.error("Failed to send session email:", err.message);
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "@ai-tutor/core": "*",
     "express": "^4.21.0",
-    "multer": "^1.4.5-lts.1"
+    "geoip-lite": "^1.4.10",
+    "multer": "^1.4.5-lts.1",
+    "resend": "^4.0.0"
   },
   "license": "MIT"
 }

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -518,6 +518,7 @@
     </div>
     <div class="header-actions">
       <button class="btn-subtle" id="transcript-btn">Transcript</button>
+      <button class="btn-subtle" id="end-session-btn">End session</button>
       <button class="btn-subtle" id="new-session-btn">New session</button>
     </div>
   </header>
@@ -576,6 +577,7 @@
     const sendBtn = document.getElementById("send-btn");
     const modelLabel = document.getElementById("model-label");
     const transcriptBtn = document.getElementById("transcript-btn");
+    const endSessionBtn = document.getElementById("end-session-btn");
     const newSessionBtn = document.getElementById("new-session-btn");
     const transcriptModal = document.getElementById("transcript-modal");
     const transcriptContent = document.getElementById("transcript-content");
@@ -870,14 +872,8 @@
       });
     });
 
-    // New session
-    newSessionBtn.addEventListener("click", () => {
-      fetch("/api/reset", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId }),
-      });
-
+    // Reset the UI to the empty state and generate a new session ID
+    function resetUI() {
       sessionId = crypto.randomUUID();
       pendingFiles = [];
       renderFilePreview();
@@ -885,6 +881,38 @@
       emptyState.style.display = "";
       chatEl.appendChild(emptyState);
       input.focus();
+    }
+
+    // End session — emails the summary, then resets the UI
+    endSessionBtn.addEventListener("click", async () => {
+      const currentId = sessionId;
+      resetUI();
+      try {
+        await fetch("/api/end-session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionId: currentId }),
+        });
+      } catch {
+        // Best-effort — server-side sweep will catch it after 10 minutes
+      }
+    });
+
+    // New session — server emails and clears session, frontend resets
+    newSessionBtn.addEventListener("click", () => {
+      const currentId = sessionId;
+      resetUI();
+      fetch("/api/reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: currentId }),
+      }).catch(() => {});
+    });
+
+    // Best-effort email on tab close — server-side sweep catches failures at 10 min
+    window.addEventListener("beforeunload", () => {
+      const blob = new Blob([JSON.stringify({ sessionId })], { type: "application/json" });
+      navigator.sendBeacon("/api/end-session", blob);
     });
 
     // Focus input on load

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -1,5 +1,6 @@
 import express from "express";
 import multer from "multer";
+import geoip from "geoip-lite";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import {
@@ -8,6 +9,7 @@ import {
   Session,
   createTutorClient,
 } from "@ai-tutor/core";
+import { sendSessionEmail } from "./email.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,6 +17,11 @@ const __dirname = dirname(__filename);
 const config = loadConfig();
 const systemPrompt = loadSystemPrompt(config.systemPromptPath);
 const tutor = createTutorClient(config, systemPrompt);
+
+const emailConfig = {
+  resendApiKey: process.env.RESEND_API_KEY || "",
+  parentEmail: process.env.PARENT_EMAIL || "me@schmim.com",
+};
 
 // File upload config — store in memory, 10MB limit
 const upload = multer({
@@ -99,6 +106,23 @@ app.post("/api/chat", upload.array("files", 5), async (req, res) => {
   }
 
   const session = getSession(sessionId);
+
+  // Capture client info on the first message of this session
+  if (session.transcript.length === 0) {
+    const ip = (req.headers["x-forwarded-for"] || req.ip || "").split(",")[0].trim();
+    const geo = geoip.lookup(ip);
+    session.setClientInfo({ ip, geo, userAgent: req.headers["user-agent"] || "" });
+  }
+
+  // Store uploaded file buffers in the session for later email attachment
+  if (req.files && req.files.length > 0) {
+    for (const file of req.files) {
+      session.addFile(file.originalname, file.mimetype, file.buffer);
+    }
+  }
+
+  session.touchActivity();
+
   const userContent = buildUserContent(message, req.files);
 
   // Build transcript text (files referenced by name)
@@ -142,10 +166,34 @@ app.get("/api/transcript/:sessionId", (req, res) => {
   res.json({ transcript: session.getTranscript() });
 });
 
-// POST /api/reset — clear a session
-app.post("/api/reset", (req, res) => {
+// POST /api/end-session — email the session summary and clear the session
+// Accepts both normal fetch (express.json parses) and sendBeacon (Blob with application/json,
+// also parsed by express.json since the Content-Type matches).
+app.post("/api/end-session", async (req, res) => {
+  const { sessionId } = req.body || {};
+
+  if (!sessionId || !sessions.has(sessionId)) {
+    return res.json({ ok: true });
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session.emailSent) {
+    await sendSessionEmail(session, emailConfig);
+    session.markEmailSent();
+  }
+  sessions.delete(sessionId);
+  res.json({ ok: true });
+});
+
+// POST /api/reset — clear a session (also emails if not already sent)
+app.post("/api/reset", async (req, res) => {
   const { sessionId } = req.body;
   if (sessionId && sessions.has(sessionId)) {
+    const session = sessions.get(sessionId);
+    if (!session.emailSent) {
+      await sendSessionEmail(session, emailConfig);
+      session.markEmailSent();
+    }
     sessions.delete(sessionId);
   }
   res.json({ ok: true });
@@ -158,6 +206,20 @@ app.get("/api/config", (req, res) => {
     extendedThinking: config.extendedThinking,
   });
 });
+
+// Inactivity sweep — reap sessions idle for more than 10 minutes
+const INACTIVITY_MS = 10 * 60 * 1000;
+setInterval(async () => {
+  const now = Date.now();
+  for (const [id, session] of sessions.entries()) {
+    if (!session.emailSent && now - session.lastActivityAt > INACTIVITY_MS) {
+      console.log(`Session ${id} reaped after 10 minutes of inactivity.`);
+      await sendSessionEmail(session, emailConfig);
+      session.markEmailSent();
+      sessions.delete(id);
+    }
+  }
+}, 60 * 1000);
 
 app.listen(config.port, () => {
   console.log(`AI Tutor running at http://localhost:${config.port}`);


### PR DESCRIPTION
## Summary

Implements a complete session capture and email workflow:

### Core Changes
- **Session tracking**: Added file storage, activity timestamps, client info (IP/geo/user agent), and email guard to `Session` class
- **Email service**: New `email.js` module sends formatted HTML emails via Resend with session transcript and file attachments
- **Session endpoints**: Added `/api/end-session` to explicitly email and clear sessions; `/api/reset` now also emails before clearing
- **Inactivity sweep**: Server-side reaper emails and removes sessions idle for 10+ minutes
- **Frontend UX**: New "End session" button; "New session" button now emails; tab close triggers best-effort email via sendBeacon

### Dependencies
- Added `resend@^4.0.0` for email delivery
- Added `geoip-lite@^1.4.10` for IP-to-location lookup

### Configuration
- `RESEND_API_KEY`: Required for email functionality
- `PARENT_EMAIL`: Recipient for session summaries (defaults to `me@schmim.com`)

### Email Features
- Beautifully formatted HTML emails with session metadata, transcript, and client info
- File attachments with 40MB total limit
- Double-send prevention via `emailSent` flag
- Graceful error handling — failed emails don't crash the server