### PR TITLE
Phase 2: Static web frontend

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,6 @@
 import express from "express";
+import { fileURLToPath } from "url";
+import path from "path";
 import {
   loadConfig,
   loadSystemPrompt,
@@ -15,6 +17,8 @@ import { createConfigRouter } from "./routes/config.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 const config = loadConfig();
 const systemPrompt = loadSystemPrompt(config.systemPromptPath);
 const tutorClient = createTutorClient(config, systemPrompt);
@@ -30,6 +34,10 @@ const app = express();
 
 app.use(corsMiddleware);
 app.use(express.json());
+
+// Serve the static web frontend.
+// __dirname is apps/api/dist/ at runtime, so ../../web/public resolves to apps/web/public/.
+app.use(express.static(path.join(__dirname, "../../web/public")));
 
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db));

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,44 @@
+# @ai-tutor/web
+
+Static web frontend for the AI Tutor.  No framework, no build step — a single HTML file served directly by the API server.
+
+## Structure
+
+```
+apps/web/
+├── public/
+│   └── index.html   ← All HTML, CSS, and JS in one file
+├── package.json
+└── README.md
+```
+
+## Usage
+
+Start the API server — it serves this frontend automatically:
+
+```bash
+npm run api          # from monorepo root
+```
+
+Then open <http://localhost:3000>.
+
+## CDN dependencies
+
+Loaded via `<script>` and `<link>` tags in `index.html`:
+
+| Library | Purpose |
+|---------|---------|
+| [KaTeX](https://katex.org/) | Render LaTeX math in tutor responses |
+| [marked](https://marked.js.org/) | Render Markdown in tutor responses |
+
+## Features
+
+- **Streaming chat** — responses stream token-by-token via SSE
+- **Markdown + math** — marked + KaTeX auto-render after each message
+- **File attachments** — images and PDFs via click or drag-and-drop
+- **Transcript viewer** — modal with copy-to-clipboard
+- **Session end detection** — sentinel-based with inline wrap-up banner
+- **Inactivity timeout** — auto-emails transcript after 10 minutes of idle
+- **Per-message feedback** — thumbs up/down shown after session ends
+- **New session** — one-click reset with automatic prior session cleanup
+- **Model indicator** — shows current model and extended thinking status

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@ai-tutor/web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Static web frontend for AI Tutor — no build step required"
+}

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -1,0 +1,1227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Tutor</title>
+
+  <!-- KaTeX -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" crossorigin="anonymous" onload="initKaTeX()"></script>
+
+  <!-- marked -->
+  <script defer src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js" crossorigin="anonymous"></script>
+
+  <style>
+    /* ── CSS variables ─────────────────────────────────────────────────────── */
+    :root {
+      --bg:            #faf8f5;
+      --surface:       #ffffff;
+      --surface-alt:   #f2ede6;
+      --border:        #e0d8cf;
+      --text:          #2d2a26;
+      --text-muted:    #8a8070;
+      --accent:        #7c6f5b;
+      --accent-light:  #ece6dd;
+      --accent-dark:   #5c5244;
+      --user-bg:       #e8e0d4;
+      --danger:        #c0392b;
+      --success:       #27ae60;
+      --font-serif:    Georgia, 'Times New Roman', serif;
+      --font-sans:     -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      --font-mono:     'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      --radius:        12px;
+      --radius-sm:     6px;
+      --shadow:        0 1px 3px rgba(0,0,0,0.07);
+      --shadow-md:     0 4px 16px rgba(0,0,0,0.12);
+    }
+
+    /* ── Reset ─────────────────────────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      height: 100%;
+      font-family: var(--font-sans);
+      background: var(--bg);
+      color: var(--text);
+      font-size: 15px;
+      line-height: 1.6;
+    }
+
+    /* ── Top-level layout ──────────────────────────────────────────────────── */
+    body {
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+      overflow: hidden;
+    }
+
+    /* ── Header ────────────────────────────────────────────────────────────── */
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+      gap: 12px;
+    }
+
+    .header-title {
+      font-family: var(--font-serif);
+      font-size: 1.2rem;
+      font-weight: 600;
+      color: var(--accent-dark);
+      letter-spacing: -0.01em;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .model-badge {
+      font-size: 0.73rem;
+      color: var(--text-muted);
+      background: var(--surface-alt);
+      padding: 3px 9px;
+      border-radius: 20px;
+      border: 1px solid var(--border);
+      white-space: nowrap;
+    }
+    .model-badge.extended::after {
+      content: ' · thinking';
+      color: var(--accent);
+    }
+
+    /* ── Main ──────────────────────────────────────────────────────────────── */
+    main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    /* ── Chat container (scrollable area + drag overlay) ──────────────────── */
+    #chat-container {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      position: relative;
+    }
+
+    #chat-area {
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      padding: 24px 20px;
+      scroll-behavior: smooth;
+    }
+
+    /* ── Empty state ───────────────────────────────────────────────────────── */
+    #empty-state {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      color: var(--text-muted);
+      text-align: center;
+    }
+
+    #empty-state .empty-icon {
+      font-size: 2.4rem;
+      opacity: 0.35;
+    }
+
+    #empty-state .empty-prompt {
+      font-family: var(--font-serif);
+      font-size: 1.1rem;
+      color: var(--text-muted);
+    }
+
+    /* ── Messages list ─────────────────────────────────────────────────────── */
+    #messages {
+      display: none; /* toggled by JS */
+      flex-direction: column;
+      gap: 18px;
+      max-width: 800px;
+      margin: 0 auto;
+      width: 100%;
+      padding-bottom: 4px;
+    }
+
+    /* ── Individual message ────────────────────────────────────────────────── */
+    .msg {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .msg.user  { align-items: flex-end; }
+    .msg.tutor { align-items: flex-start; }
+
+    .msg-label {
+      font-size: 0.68rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--text-muted);
+    }
+
+    .msg-bubble {
+      max-width: 82%;
+      padding: 11px 15px;
+      border-radius: var(--radius);
+      line-height: 1.65;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+    }
+
+    .msg.user  .msg-bubble {
+      background: var(--user-bg);
+      border-bottom-right-radius: 3px;
+    }
+
+    .msg.tutor .msg-bubble {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-bottom-left-radius: 3px;
+      box-shadow: var(--shadow);
+    }
+
+    /* Markdown inside tutor bubbles */
+    .msg-bubble p                { margin: 0 0 0.55em; }
+    .msg-bubble p:last-child     { margin-bottom: 0; }
+    .msg-bubble h1,
+    .msg-bubble h2,
+    .msg-bubble h3,
+    .msg-bubble h4               { font-family: var(--font-serif); margin: 0.9em 0 0.35em; }
+    .msg-bubble h1:first-child,
+    .msg-bubble h2:first-child,
+    .msg-bubble h3:first-child   { margin-top: 0; }
+    .msg-bubble ul,
+    .msg-bubble ol               { margin: 0.35em 0 0.55em 1.3em; }
+    .msg-bubble li               { margin-bottom: 0.2em; }
+    .msg-bubble code             {
+      background: var(--surface-alt);
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 0.87em;
+      font-family: var(--font-mono);
+    }
+    .msg-bubble pre {
+      background: #1b1e23;
+      color: #cdd6f4;
+      padding: 12px 14px;
+      border-radius: var(--radius-sm);
+      overflow-x: auto;
+      margin: 0.55em 0;
+    }
+    .msg-bubble pre code         { background: none; padding: 0; color: inherit; font-size: 0.85em; }
+    .msg-bubble blockquote       {
+      border-left: 3px solid var(--border);
+      padding-left: 12px;
+      color: var(--text-muted);
+      margin: 0.55em 0;
+    }
+    .msg-bubble table            { border-collapse: collapse; width: 100%; margin: 0.55em 0; }
+    .msg-bubble th,
+    .msg-bubble td               { border: 1px solid var(--border); padding: 5px 10px; text-align: left; }
+    .msg-bubble th               { background: var(--surface-alt); font-weight: 600; }
+    .msg-bubble a                { color: var(--accent); text-decoration: underline; }
+    .msg-bubble strong           { font-weight: 600; }
+    .msg-bubble em               { font-style: italic; }
+    .msg-bubble hr               { border: none; border-top: 1px solid var(--border); margin: 0.8em 0; }
+
+    /* ── Typing indicator ──────────────────────────────────────────────────── */
+    .typing-dots {
+      display: inline-flex;
+      gap: 5px;
+      align-items: center;
+      padding: 4px 0;
+    }
+
+    .typing-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--text-muted);
+      animation: bounce 1.3s infinite ease-in-out;
+    }
+    .typing-dot:nth-child(2) { animation-delay: 0.18s; }
+    .typing-dot:nth-child(3) { animation-delay: 0.36s; }
+
+    @keyframes bounce {
+      0%, 60%, 100% { transform: translateY(0);    opacity: 0.5; }
+      30%            { transform: translateY(-6px); opacity: 1; }
+    }
+
+    /* ── Per-message feedback ──────────────────────────────────────────────── */
+    .msg-feedback {
+      display: none;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 5px;
+    }
+    .msg-feedback.active { display: flex; }
+
+    .fb-group {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+      background: var(--surface-alt);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 3px 8px;
+    }
+    .fb-label {
+      font-size: 0.67rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      margin-right: 2px;
+    }
+    .fb-btn {
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 2px 3px;
+      border-radius: 4px;
+      font-size: 0.82rem;
+      opacity: 0.55;
+      transition: opacity 0.15s, background 0.15s;
+      line-height: 1;
+    }
+    .fb-btn:hover  { opacity: 1; background: var(--border); }
+    .fb-btn.chosen { opacity: 1; background: var(--accent-light); }
+
+    /* ── Drag overlay ──────────────────────────────────────────────────────── */
+    #drag-overlay {
+      display: none;
+      position: absolute;
+      inset: 8px;
+      border: 2px dashed var(--accent);
+      border-radius: var(--radius);
+      background: rgba(124,111,91,0.06);
+      z-index: 20;
+      pointer-events: none;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.95rem;
+      color: var(--accent);
+      gap: 8px;
+    }
+    #drag-overlay.active { display: flex; }
+
+    /* ── End-session banner ────────────────────────────────────────────────── */
+    #end-banner {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      padding: 10px 20px;
+      background: #eef7ee;
+      border-top: 1px solid #c3dfc3;
+      border-bottom: 1px solid #c3dfc3;
+      font-size: 0.88rem;
+      flex-shrink: 0;
+    }
+    #end-banner.active { display: flex; }
+
+    /* ── Input wrapper ─────────────────────────────────────────────────────── */
+    #input-wrapper {
+      flex-shrink: 0;
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+    }
+
+    /* ── File preview strip ────────────────────────────────────────────────── */
+    #file-strip {
+      display: none;
+      flex-wrap: wrap;
+      gap: 7px;
+      padding: 8px 16px 0;
+      max-width: 840px;
+      margin: 0 auto;
+    }
+    #file-strip.active { display: flex; }
+
+    .file-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 4px 8px;
+      font-size: 0.8rem;
+    }
+    .file-chip img {
+      width: 26px;
+      height: 26px;
+      object-fit: cover;
+      border-radius: 3px;
+    }
+    .file-icon { font-size: 1.15rem; line-height: 1; }
+    .file-name {
+      max-width: 120px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--text);
+    }
+    .chip-remove {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--text-muted);
+      font-size: 1rem;
+      line-height: 1;
+      padding: 0 2px;
+      transition: color 0.15s;
+    }
+    .chip-remove:hover { color: var(--danger); }
+
+    /* ── Input row ─────────────────────────────────────────────────────────── */
+    #input-row {
+      display: flex;
+      align-items: flex-end;
+      gap: 8px;
+      padding: 10px 16px 14px;
+      max-width: 840px;
+      margin: 0 auto;
+      width: 100%;
+    }
+
+    #msg-input {
+      flex: 1;
+      resize: none;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 9px 13px;
+      font-family: var(--font-sans);
+      font-size: 0.93rem;
+      line-height: 1.5;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 42px;
+      max-height: 180px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    #msg-input:focus        { border-color: var(--accent); }
+    #msg-input::placeholder { color: var(--text-muted); }
+
+    /* ── Buttons ───────────────────────────────────────────────────────────── */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 5px;
+      padding: 7px 13px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      font-family: var(--font-sans);
+      font-size: 0.86rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      white-space: nowrap;
+      line-height: 1;
+    }
+    .btn:hover    { background: var(--surface-alt); }
+    .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    .btn-primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--accent-dark); border-color: var(--accent-dark); }
+
+    .btn-sm {
+      padding: 5px 10px;
+      font-size: 0.8rem;
+    }
+
+    .btn-icon {
+      padding: 8px;
+      width: 40px;
+      height: 40px;
+      font-size: 1rem;
+    }
+
+    #btn-attach, #btn-send { height: 40px; }
+    #btn-send { padding: 0 16px; }
+
+    /* ── Modal backdrop ────────────────────────────────────────────────────── */
+    .modal-backdrop {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.42);
+      z-index: 100;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+    .modal-backdrop.active { display: flex; }
+
+    .modal-card {
+      background: var(--surface);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-md);
+      max-width: 600px;
+      width: 100%;
+      max-height: 80vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .modal-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 15px 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .modal-head h2 {
+      font-family: var(--font-serif);
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+
+    .modal-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    }
+
+    .modal-foot {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      padding: 12px 20px;
+      border-top: 1px solid var(--border);
+    }
+
+    /* Transcript entries */
+    .tx-entry { margin-bottom: 14px; }
+    .tx-entry:last-child { margin-bottom: 0; }
+    .tx-role {
+      font-size: 0.69rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      margin-bottom: 3px;
+      color: var(--text-muted);
+    }
+    .tx-entry.student .tx-role { color: var(--accent-dark); }
+    .tx-text {
+      white-space: pre-wrap;
+      font-size: 0.88rem;
+      line-height: 1.55;
+    }
+
+    /* ── Toast notification ────────────────────────────────────────────────── */
+    #toast {
+      position: fixed;
+      bottom: 72px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #2d2a26;
+      color: #faf8f5;
+      padding: 9px 18px;
+      border-radius: var(--radius-sm);
+      font-size: 0.86rem;
+      z-index: 500;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s;
+      max-width: 90vw;
+      text-align: center;
+      white-space: nowrap;
+    }
+    #toast.show { opacity: 1; }
+
+    /* ── Responsive ────────────────────────────────────────────────────────── */
+    @media (max-width: 600px) {
+      header       { padding: 10px 14px; }
+      #chat-area   { padding: 16px 14px; }
+      .msg-bubble  { max-width: 93%; }
+      #input-row   { padding: 8px 12px 12px; }
+      #file-strip  { padding: 8px 12px 0; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- ── Header ─────────────────────────────────────────────────────────── -->
+  <header>
+    <span class="header-title">AI Tutor</span>
+    <div class="header-right">
+      <span id="model-badge" class="model-badge" style="display:none"></span>
+      <button class="btn btn-sm" id="btn-transcript">Transcript</button>
+      <button class="btn btn-sm" id="btn-new-session">New session</button>
+    </div>
+  </header>
+
+  <!-- ── Main ───────────────────────────────────────────────────────────── -->
+  <main>
+    <div id="chat-container">
+      <div id="chat-area">
+        <div id="empty-state">
+          <div class="empty-icon">✏️</div>
+          <p class="empty-prompt">What are you working on?</p>
+        </div>
+        <div id="messages"></div>
+      </div>
+      <div id="drag-overlay">📎 Drop files here</div>
+    </div>
+
+    <!-- End-session banner -->
+    <div id="end-banner">
+      <span>Looks like we've solved it — ready to wrap up?</span>
+      <button class="btn btn-primary btn-sm" id="btn-end-session">End session</button>
+    </div>
+
+    <!-- Input wrapper -->
+    <div id="input-wrapper">
+      <div id="file-strip"></div>
+      <div id="input-row">
+        <button class="btn btn-icon" id="btn-attach" title="Attach files (images or PDF)">📎</button>
+        <input type="file" id="file-input" multiple
+               accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
+        <textarea id="msg-input" placeholder="Ask your tutor…" rows="1"></textarea>
+        <button class="btn btn-primary" id="btn-send">Send</button>
+      </div>
+    </div>
+  </main>
+
+  <!-- ── Transcript modal ────────────────────────────────────────────────── -->
+  <div class="modal-backdrop" id="modal-transcript">
+    <div class="modal-card">
+      <div class="modal-head">
+        <h2>Session Transcript</h2>
+        <button class="btn btn-icon" id="btn-close-tx">✕</button>
+      </div>
+      <div class="modal-body" id="tx-body">
+        <p style="color:var(--text-muted);font-size:.88rem">Loading…</p>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-sm" id="btn-copy-tx">Copy to clipboard</button>
+        <button class="btn btn-sm" id="btn-close-tx2">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Toast ───────────────────────────────────────────────────────────── -->
+  <div id="toast"></div>
+
+  <script>
+  // ── KaTeX init (called by auto-render.min.js onload) ──────────────────────
+  let katexReady = false;
+  let katexQueue = []; // elements waiting for KaTeX render
+
+  function initKaTeX() {
+    katexReady = true;
+    for (const el of katexQueue) renderKaTeX(el);
+    katexQueue = [];
+  }
+
+  function renderKaTeX(el) {
+    if (!katexReady) { katexQueue.push(el); return; }
+    renderMathInElement(el, {
+      delimiters: [
+        { left: '$$', right: '$$', display: true },
+        { left: '$',  right: '$',  display: false },
+        { left: '\\(', right: '\\)', display: false },
+        { left: '\\[', right: '\\]', display: true },
+      ],
+      throwOnError: false,
+    });
+  }
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  let sessionId         = crypto.randomUUID();
+  let msgList           = []; // {id, role, bubbleEl, feedbackEl}
+  let attachments       = []; // {file, chipEl}
+  let isStreaming       = false;
+  let endAvailable      = false;
+  let sessionEnded      = false;
+  let inactivityTimer   = null;
+  let appConfig         = { model: '', extendedThinking: false };
+  let msgCounter        = 0;
+
+  const INACTIVITY_MS  = 10 * 60 * 1000;
+  const END_SENTINEL   = '[END_SESSION_AVAILABLE]';
+  const MAX_FILES      = 5;
+  const MAX_FILE_BYTES = 10 * 1024 * 1024;
+  const ALLOWED_TYPES  = new Set([
+    'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf',
+  ]);
+
+  // ── DOM refs ──────────────────────────────────────────────────────────────
+  const $ = id => document.getElementById(id);
+  const chatArea       = $('chat-area');
+  const emptyState     = $('empty-state');
+  const messagesEl     = $('messages');
+  const msgInput       = $('msg-input');
+  const btnSend        = $('btn-send');
+  const btnAttach      = $('btn-attach');
+  const fileInput      = $('file-input');
+  const fileStrip      = $('file-strip');
+  const endBanner      = $('end-banner');
+  const btnEndSession  = $('btn-end-session');
+  const btnTranscript  = $('btn-transcript');
+  const btnNewSession  = $('btn-new-session');
+  const modelBadge     = $('model-badge');
+  const modalTranscript = $('modal-transcript');
+  const txBody         = $('tx-body');
+  const btnCloseTx     = $('btn-close-tx');
+  const btnCloseTx2    = $('btn-close-tx2');
+  const btnCopyTx      = $('btn-copy-tx');
+  const dragOverlay    = $('drag-overlay');
+  const toast          = $('toast');
+
+  // ── Config ────────────────────────────────────────────────────────────────
+  async function fetchConfig() {
+    try {
+      const res = await fetch('/api/config');
+      if (!res.ok) return;
+      appConfig = await res.json();
+      if (appConfig.model) {
+        // Strip date suffix and "claude-" prefix for compact display
+        let label = appConfig.model
+          .replace(/^claude-/, '')
+          .replace(/-\d{8}$/, '');
+        modelBadge.textContent = label;
+        modelBadge.classList.toggle('extended', !!appConfig.extendedThinking);
+        modelBadge.title = appConfig.model +
+          (appConfig.extendedThinking ? ' — extended thinking on' : '');
+        modelBadge.style.display = '';
+      }
+    } catch { /* no config available */ }
+  }
+
+  // ── Empty-state toggle ────────────────────────────────────────────────────
+  function showEmpty() {
+    emptyState.style.display = '';
+    messagesEl.style.display = 'none';
+  }
+  function hideEmpty() {
+    emptyState.style.display = 'none';
+    messagesEl.style.display = 'flex';
+  }
+
+  // ── Append messages ───────────────────────────────────────────────────────
+  function appendUserMsg(text, files) {
+    hideEmpty();
+    const id = `m${++msgCounter}`;
+    const div = document.createElement('div');
+    div.className = 'msg user';
+    div.id = id;
+
+    const label = document.createElement('div');
+    label.className = 'msg-label';
+    label.textContent = 'You';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'msg-bubble';
+    bubble.textContent = text;
+
+    if (files.length > 0) {
+      const note = document.createElement('div');
+      note.style.cssText = 'margin-top:6px;font-size:.77rem;color:var(--text-muted)';
+      note.textContent = `${files.length} attachment${files.length > 1 ? 's' : ''}: ` +
+        files.map(f => f.name).join(', ');
+      bubble.appendChild(note);
+    }
+
+    div.appendChild(label);
+    div.appendChild(bubble);
+    messagesEl.appendChild(div);
+    msgList.push({ id, role: 'user', bubbleEl: bubble, feedbackEl: null });
+    scrollBottom();
+    return id;
+  }
+
+  function appendTutorPlaceholder() {
+    hideEmpty();
+    const id = `m${++msgCounter}`;
+    const div = document.createElement('div');
+    div.className = 'msg tutor';
+    div.id = id;
+
+    const label = document.createElement('div');
+    label.className = 'msg-label';
+    label.textContent = 'Tutor';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'msg-bubble';
+    bubble.innerHTML = '<div class="typing-dots">' +
+      '<div class="typing-dot"></div>' +
+      '<div class="typing-dot"></div>' +
+      '<div class="typing-dot"></div>' +
+      '</div>';
+
+    const feedbackEl = document.createElement('div');
+    feedbackEl.className = 'msg-feedback';
+    feedbackEl.dataset.msgId = id;
+    feedbackEl.innerHTML = buildFeedbackHTML(id);
+
+    div.appendChild(label);
+    div.appendChild(bubble);
+    div.appendChild(feedbackEl);
+    messagesEl.appendChild(div);
+
+    const entry = { id, role: 'tutor', bubbleEl: bubble, feedbackEl };
+    msgList.push(entry);
+    scrollBottom();
+    return entry;
+  }
+
+  function buildFeedbackHTML(msgId) {
+    return [
+      { key: 'accuracy',    label: 'Accuracy'  },
+      { key: 'usefulness',  label: 'Helpful'   },
+      { key: 'tone',        label: 'Tone'      },
+    ].map(c => `
+      <div class="fb-group">
+        <span class="fb-label">${c.label}</span>
+        <button class="fb-btn" data-mid="${msgId}" data-cat="${c.key}" data-val="up"   title="Good">👍</button>
+        <button class="fb-btn" data-mid="${msgId}" data-cat="${c.key}" data-val="down" title="Not great">👎</button>
+      </div>`).join('');
+  }
+
+  function finalizeTutor(entry, rawText) {
+    const hasSentinel = rawText.includes(END_SENTINEL);
+    const clean = rawText.replace(END_SENTINEL, '').trim();
+
+    // Render markdown (marked is defer-loaded; should be ready by first message)
+    const html = (typeof marked !== 'undefined')
+      ? marked.parse(clean)
+      : `<p>${escHtml(clean)}</p>`;
+
+    entry.bubbleEl.innerHTML = html;
+    renderKaTeX(entry.bubbleEl);
+
+    if (hasSentinel && !endAvailable && !sessionEnded) {
+      endAvailable = true;
+      endBanner.classList.add('active');
+    }
+
+    scrollBottom();
+  }
+
+  function scrollBottom() {
+    chatArea.scrollTop = chatArea.scrollHeight;
+  }
+
+  function escHtml(s) {
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+            .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+  }
+
+  // ── Send message / SSE stream ─────────────────────────────────────────────
+  async function sendMessage() {
+    const text = msgInput.value.trim();
+    if (!text || isStreaming || sessionEnded) return;
+
+    isStreaming = true;
+    setInputDisabled(true);
+
+    const files = attachments.map(a => a.file);
+    appendUserMsg(text, files);
+    const tutorEntry = appendTutorPlaceholder();
+
+    // Build multipart form
+    const fd = new FormData();
+    fd.append('sessionId', sessionId);
+    fd.append('message', text);
+    for (const f of files) fd.append('files', f);
+
+    // Clear input
+    msgInput.value = '';
+    resizeInput();
+    clearAttachments();
+    resetInactivityTimer();
+
+    let rawText = '';
+    let gotToken = false;
+
+    try {
+      const resp = await fetch('/api/chat', { method: 'POST', body: fd });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({ error: resp.statusText }));
+        throw new Error(err.error || resp.statusText);
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split('\n');
+        buf = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const payload = line.slice(6).trim();
+          if (!payload) continue;
+          let event;
+          try { event = JSON.parse(payload); } catch { continue; }
+
+          if (event.type === 'text_delta') {
+            if (!gotToken) {
+              gotToken = true;
+              tutorEntry.bubbleEl.innerHTML = '';
+            }
+            rawText += event.text;
+            // Show plain text live (strip sentinel for display)
+            tutorEntry.bubbleEl.textContent =
+              rawText.replace(END_SENTINEL, '').trimEnd();
+            scrollBottom();
+          } else if (event.type === 'message_stop') {
+            finalizeTutor(tutorEntry, rawText);
+          } else if (event.type === 'error') {
+            throw new Error(event.message || 'Streaming error');
+          }
+        }
+      }
+
+      // Fallback: finalize if stream ended without message_stop
+      if (rawText && !tutorEntry.bubbleEl.querySelector('p, ul, ol, pre, h1, h2, h3')) {
+        finalizeTutor(tutorEntry, rawText);
+      }
+
+    } catch (err) {
+      tutorEntry.bubbleEl.innerHTML =
+        `<span style="color:var(--danger)">Error: ${escHtml(err.message)}</span>`;
+    } finally {
+      isStreaming = false;
+      setInputDisabled(false);
+      msgInput.focus();
+    }
+  }
+
+  function setInputDisabled(disabled) {
+    btnSend.disabled    = disabled;
+    msgInput.disabled   = disabled;
+    btnAttach.disabled  = disabled;
+  }
+
+  // ── Inactivity timer ──────────────────────────────────────────────────────
+  function resetInactivityTimer() {
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+    if (sessionEnded) return;
+    inactivityTimer = setTimeout(onInactivityTimeout, INACTIVITY_MS);
+  }
+
+  async function onInactivityTimeout() {
+    if (sessionEnded || msgList.length === 0) return;
+    sessionEnded = true;
+    try { await fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' }); }
+    catch { /* ignore */ }
+    endBanner.classList.remove('active');
+    lockSession('Session ended due to inactivity. Your transcript has been emailed.');
+  }
+
+  // ── End session ───────────────────────────────────────────────────────────
+  async function endSession() {
+    if (sessionEnded) return;
+    sessionEnded = true;
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+    endBanner.classList.remove('active');
+    try { await fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' }); }
+    catch { /* ignore */ }
+    lockSession('Session ended. Transcript has been emailed.');
+    showFeedback();
+  }
+
+  function lockSession(message) {
+    msgInput.disabled = true;
+    btnSend.disabled  = true;
+    btnAttach.disabled = true;
+    msgInput.placeholder = 'Session ended.';
+    showToast(message, 5000);
+  }
+
+  function showFeedback() {
+    for (const entry of msgList) {
+      if (entry.role === 'tutor' && entry.feedbackEl) {
+        entry.feedbackEl.classList.add('active');
+      }
+    }
+  }
+
+  // ── Feedback ──────────────────────────────────────────────────────────────
+  async function submitFeedback(msgId, category, value) {
+    const rating = value === 'up' ? 5 : 1;
+    const comment = `msg:${msgId} category:${category} sentiment:${value}`;
+    try {
+      await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, rating, comment }),
+      });
+    } catch { /* fire-and-forget */ }
+  }
+
+  // ── Transcript modal ──────────────────────────────────────────────────────
+  async function openTranscript() {
+    modalTranscript.classList.add('active');
+    txBody.innerHTML = '<p style="color:var(--text-muted);font-size:.88rem">Loading…</p>';
+    try {
+      const res = await fetch(`/api/transcript/${sessionId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const { transcript } = await res.json();
+      if (!transcript?.length) {
+        txBody.innerHTML = '<p style="color:var(--text-muted);font-size:.88rem">No messages yet.</p>';
+        return;
+      }
+      txBody.innerHTML = transcript.map(e => `
+        <div class="tx-entry ${e.role === 'Student' ? 'student' : ''}">
+          <div class="tx-role">${escHtml(e.role)}</div>
+          <div class="tx-text">${escHtml(e.text)}</div>
+        </div>`).join('');
+    } catch {
+      txBody.innerHTML = '<p style="color:var(--danger);font-size:.88rem">Could not load transcript.</p>';
+    }
+  }
+
+  function closeTranscript() {
+    modalTranscript.classList.remove('active');
+  }
+
+  async function copyTranscript() {
+    const entries = txBody.querySelectorAll('.tx-entry');
+    if (!entries.length) return;
+    const text = Array.from(entries).map(el => {
+      const role    = el.querySelector('.tx-role')?.textContent ?? '';
+      const content = el.querySelector('.tx-text')?.textContent ?? '';
+      return `${role}:\n${content}`;
+    }).join('\n\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast('Copied to clipboard!');
+    } catch {
+      showToast('Copy failed — try selecting text manually.');
+    }
+  }
+
+  // ── New session ───────────────────────────────────────────────────────────
+  async function newSession() {
+    if (isStreaming) return;
+    // End previous session if it had activity
+    if (msgList.length > 0 && !sessionEnded) {
+      try { await fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' }); }
+      catch { /* ignore */ }
+    }
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+
+    // Reset state
+    sessionId       = crypto.randomUUID();
+    msgList         = [];
+    attachments     = [];
+    isStreaming     = false;
+    endAvailable    = false;
+    sessionEnded    = false;
+    msgCounter      = 0;
+
+    // Reset UI
+    messagesEl.innerHTML = '';
+    showEmpty();
+    endBanner.classList.remove('active');
+    fileStrip.innerHTML = '';
+    fileStrip.classList.remove('active');
+    msgInput.value = '';
+    msgInput.placeholder = 'Ask your tutor…';
+    msgInput.disabled = false;
+    btnSend.disabled = false;
+    btnAttach.disabled = false;
+    resizeInput();
+    msgInput.focus();
+  }
+
+  // ── File attachments ──────────────────────────────────────────────────────
+  function addFiles(fileList) {
+    for (const file of Array.from(fileList)) {
+      if (attachments.length >= MAX_FILES) {
+        showToast(`Maximum ${MAX_FILES} files per message.`);
+        break;
+      }
+      if (!ALLOWED_TYPES.has(file.type)) {
+        showToast(`${file.name}: unsupported type. Use images (JPEG, PNG, GIF, WebP) or PDF.`);
+        continue;
+      }
+      if (file.size > MAX_FILE_BYTES) {
+        showToast(`${file.name} exceeds the 10 MB limit.`);
+        continue;
+      }
+      buildChip(file);
+    }
+    renderStrip();
+  }
+
+  function buildChip(file) {
+    const chip = document.createElement('div');
+    chip.className = 'file-chip';
+
+    if (file.type.startsWith('image/')) {
+      const img = document.createElement('img');
+      img.src = URL.createObjectURL(file);
+      img.alt = file.name;
+      chip.appendChild(img);
+    } else {
+      const icon = document.createElement('span');
+      icon.className = 'file-icon';
+      icon.textContent = '📄';
+      chip.appendChild(icon);
+    }
+
+    const name = document.createElement('span');
+    name.className = 'file-name';
+    name.textContent = file.name;
+    chip.appendChild(name);
+
+    const rm = document.createElement('button');
+    rm.className = 'chip-remove';
+    rm.textContent = '×';
+    rm.title = 'Remove';
+    rm.addEventListener('click', () => removeFile(file));
+    chip.appendChild(rm);
+
+    attachments.push({ file, chipEl: chip });
+  }
+
+  function removeFile(file) {
+    const idx = attachments.findIndex(a => a.file === file);
+    if (idx === -1) return;
+    const [removed] = attachments.splice(idx, 1);
+    if (file.type.startsWith('image/')) {
+      const img = removed.chipEl.querySelector('img');
+      if (img) URL.revokeObjectURL(img.src);
+    }
+    renderStrip();
+  }
+
+  function clearAttachments() {
+    for (const a of attachments) {
+      if (a.file.type.startsWith('image/')) {
+        const img = a.chipEl.querySelector('img');
+        if (img) URL.revokeObjectURL(img.src);
+      }
+    }
+    attachments = [];
+    renderStrip();
+    fileInput.value = '';
+  }
+
+  function renderStrip() {
+    fileStrip.innerHTML = '';
+    if (!attachments.length) { fileStrip.classList.remove('active'); return; }
+    fileStrip.classList.add('active');
+    for (const a of attachments) fileStrip.appendChild(a.chipEl);
+  }
+
+  // ── Drag and drop ─────────────────────────────────────────────────────────
+  let dragDepth = 0;
+
+  document.addEventListener('dragenter', e => {
+    if (sessionEnded || isStreaming) return;
+    e.preventDefault();
+    if (++dragDepth === 1) dragOverlay.classList.add('active');
+  });
+
+  document.addEventListener('dragleave', e => {
+    e.preventDefault();
+    if (--dragDepth <= 0) { dragDepth = 0; dragOverlay.classList.remove('active'); }
+  });
+
+  document.addEventListener('dragover',  e => e.preventDefault());
+
+  document.addEventListener('drop', e => {
+    e.preventDefault();
+    dragDepth = 0;
+    dragOverlay.classList.remove('active');
+    if (sessionEnded || isStreaming) return;
+    if (e.dataTransfer?.files?.length) addFiles(e.dataTransfer.files);
+  });
+
+  // ── Textarea auto-resize ──────────────────────────────────────────────────
+  function resizeInput() {
+    msgInput.style.height = 'auto';
+    msgInput.style.height = Math.min(msgInput.scrollHeight, 180) + 'px';
+  }
+
+  // ── Toast ─────────────────────────────────────────────────────────────────
+  let toastTimer = null;
+  function showToast(msg, duration = 3200) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toast.classList.remove('show'), duration);
+  }
+
+  // ── Event wiring ──────────────────────────────────────────────────────────
+  btnSend.addEventListener('click', sendMessage);
+
+  msgInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+  });
+
+  msgInput.addEventListener('input', resizeInput);
+
+  btnAttach.addEventListener('click', () => {
+    if (!sessionEnded) fileInput.click();
+  });
+
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files?.length) { addFiles(fileInput.files); fileInput.value = ''; }
+  });
+
+  btnEndSession.addEventListener('click', endSession);
+  btnTranscript.addEventListener('click', openTranscript);
+  btnNewSession.addEventListener('click', newSession);
+
+  btnCloseTx.addEventListener('click', closeTranscript);
+  btnCloseTx2.addEventListener('click', closeTranscript);
+  btnCopyTx.addEventListener('click', copyTranscript);
+  modalTranscript.addEventListener('click', e => {
+    if (e.target === modalTranscript) closeTranscript();
+  });
+
+  // Feedback button delegation
+  messagesEl.addEventListener('click', e => {
+    const btn = e.target.closest('.fb-btn');
+    if (!btn) return;
+    const { mid, cat, val } = btn.dataset;
+    // Mark within the group
+    btn.closest('.fb-group').querySelectorAll('.fb-btn').forEach(b => b.classList.remove('chosen'));
+    btn.classList.add('chosen');
+    submitFeedback(mid, cat, val);
+  });
+
+  // ── Init ──────────────────────────────────────────────────────────────────
+  showEmpty();
+  fetchConfig();
+  msgInput.focus();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **`apps/web/public/index.html`** — single-file chat UI (no framework, no build step)
  - SSE streaming via `fetch` + `ReadableStream` for `POST /api/chat`
  - Markdown rendering (marked) + LaTeX math (KaTeX auto-render) applied after each message
  - File attachments: JPEG/PNG/GIF/WebP/PDF, click or drag-and-drop, max 5 files / 10 MB each with preview strip
  - Session end detection via `[END_SESSION_AVAILABLE]` sentinel — shows inline "wrap up" banner
  - 10-minute client inactivity timer auto-calls `DELETE /api/sessions/:id` (sends transcript email)
  - Per-message thumbs up/down feedback (accuracy, helpfulness, tone) shown after session ends
  - Transcript modal fetching `GET /api/transcript/:id` with copy-to-clipboard
  - New session button clears state and ends the prior session first if it had messages
  - Model indicator badge populated from `GET /api/config`
- **`apps/web/package.json`** — workspace metadata (`@ai-tutor/web`), no dependencies, no build
- **`apps/web/README.md`** — feature overview and usage docs
- **`apps/api/src/index.ts`** — added `express.static()` pointing at `apps/web/public/` so `npm run api` serves the frontend at `http://localhost:3000`

## Test plan

- [ ] `npm run build` from monorepo root compiles without errors
- [ ] `npm run api` starts the server and `http://localhost:3000` loads the chat UI
- [ ] Sending a message streams the tutor response token-by-token
- [ ] Markdown (lists, code blocks, tables) and LaTeX (`$...$`, `$$...$$`) render correctly in tutor replies
- [ ] Attaching an image or PDF via the paperclip button shows a preview chip; the file is included in the request
- [ ] Drag-and-dropping a file onto the chat area adds it to the preview strip
- [ ] Attaching more than 5 files or a file over 10 MB shows an error toast
- [ ] `[END_SESSION_AVAILABLE]` in a tutor reply shows the "End session" banner (sentinel stripped from display)
- [ ] Clicking "End session" calls `DELETE /api/sessions/:id`, disables input, and shows per-message feedback thumbs
- [ ] "Transcript" opens the modal and displays the conversation; "Copy to clipboard" works
- [ ] "New session" resets the UI and generates a fresh session UUID
- [ ] Model badge in the header reflects the value from `GET /api/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)