### PR TITLE
Phase 3: Documentation and deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ node_modules/
 
 # Compiled output
 dist/
+*.tsbuildinfo
 
-# Environment variables (contains API key and secrets)
+# Environment variables (contains API keys and secrets)
 .env
 .env.local
+.env.*
 
 # macOS
 .DS_Store
@@ -27,19 +29,5 @@ transcripts/
 # npm debug logs
 npm-debug.log*
 
-# TypeScript build info
-*.tsbuildinfo
-
-# iOS / Xcode
-*.xcworkspace/
-*.xcodeproj/
-DerivedData/
-build/
-Pods/
-*.pbxuser
-*.mode1v3
-*.mode2v3
-*.perspectivev3
-xcuserdata/
-
+# Claude Code
 .claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,317 @@
+# CLAUDE.md
+
+Agent context for AI contributors.  Read this before modifying any file.
+
+---
+
+## Project origin
+
+Built by a parent who wanted a better homework helper for his 9th grader — and found that building a good AI tutor is mostly about building a good feedback loop.  The core asset is a parameterized tutor prompt built on Khan Academy/Khanmigo research and Socratic tutoring literature, tested with real student interactions over five iterations.
+
+The toolkit started as a single prompt file and grew into a full monorepo: a CLI, a web app, and an API server, all sharing the same tutor logic and session model.
+
+---
+
+## Architecture decisions
+
+### Monorepo (npm workspaces)
+
+All packages and apps live in one repo and share a single `node_modules/`.  Build artifacts go to each package's `dist/` directory.  The workspace root does not have runtime code — only tooling scripts.
+
+### Plain HTML frontend — no build step
+
+`apps/web/public/index.html` is a single self-contained file.  Libraries (KaTeX, marked) are loaded from CDN.  There is no bundler, no transpilation, no framework.  The API server serves this file as a static asset.  Changes to the frontend are edit-and-refresh; no build command required.
+
+### Separate API server
+
+The Express server in `apps/api/` is the only process that runs in production.  It:
+- Serves the static frontend from `apps/web/public/`
+- Handles all API routes under `/api/`
+- Holds the in-memory session store
+- Connects to Supabase and Resend
+
+### SSE streaming
+
+Chat responses stream token-by-token over Server-Sent Events.  The client opens a `fetch()` connection and reads the response body as a stream.  The API uses `text/event-stream` with `no-cache` and `keep-alive` headers.  Each event is a JSON object on a `data:` line.
+
+Event types:
+- `{ type: "text_delta", text: "..." }` — one per token
+- `{ type: "message_stop" }` — signals end of response
+- `{ type: "error", message: "..." }` — on failure
+
+### In-memory session store + database
+
+Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — sending an email transcript before removal.
+
+### Extended thinking
+
+Enabled by default.  The Anthropic SDK is called with `thinking: { type: "enabled", budget_tokens: 10000 }` and `max_tokens: 16000`.  Thinking blocks are stored in the session (so the model can reference its own prior reasoning) but are never sent to the client or stored in transcript emails.
+
+---
+
+## Package boundaries and dependency rules
+
+```
+packages/core    ← @anthropic-ai/sdk
+packages/db      ← @supabase/supabase-js
+packages/email   ← resend
+
+apps/api         ← packages/core, packages/db, packages/email, express, cors, multer, geoip-lite
+apps/cli         ← packages/core
+apps/web         ← (no npm deps — CDN only)
+```
+
+Rules:
+- `packages/` must not import from `apps/`
+- `packages/core` must not import from `packages/db` or `packages/email`
+- `apps/cli` must not import from `packages/db` or `packages/email`
+- `apps/web` has no npm dependencies at all — it is served as static HTML
+- Cross-package imports use the workspace package name (e.g., `@ai-tutor/core`), not relative paths
+
+---
+
+## Database schema reference
+
+Managed via `supabase/migrations/001_initial_schema.sql`.  No RLS.  All queries run server-side with the service role key.
+
+### sessions
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| id | uuid | gen_random_uuid() | PK |
+| started_at | timestamptz | now() | |
+| last_activity_at | timestamptz | now() | Indexed |
+| client_ip | text | null | |
+| client_geo | jsonb | null | From geoip-lite |
+| client_user_agent | text | null | |
+| email_sent | boolean | false | Prevents duplicate emails |
+
+### messages
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| session_id | uuid | FK → sessions(id) ON DELETE CASCADE |
+| role | text | CHECK IN ('user', 'assistant') |
+| content | text | Plain text of the message |
+| thinking | text | Serialized thinking blocks (null if extended thinking off) |
+| created_at | timestamptz | Indexed with session_id |
+
+### feedback
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| session_id | uuid | FK → sessions(id) ON DELETE CASCADE |
+| rating | integer | CHECK 1–5, nullable |
+| comment | text | Nullable |
+| created_at | timestamptz | |
+
+---
+
+## API endpoint reference
+
+Base URL: `http://localhost:3000` (or the deployed origin).
+
+### POST /api/chat
+
+Stream a tutor response.
+
+**Request**: `multipart/form-data`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| sessionId | string (UUID) | yes | Client-generated; create with `crypto.randomUUID()` |
+| message | string | yes | Student's message text |
+| files[] | File | no | Max 5 files, 10 MB each; JPEG/PNG/GIF/WebP/PDF |
+
+**Response**: `text/event-stream`
+
+```
+data: {"type":"text_delta","text":"Let's look at..."}
+
+data: {"type":"text_delta","text":" that equation."}
+
+data: {"type":"message_stop"}
+```
+
+On error: `data: {"type":"error","message":"..."}` followed by connection close.
+
+Side effects: Creates or updates session in DB; persists user and assistant messages after stream completes.
+
+---
+
+### GET /api/config
+
+Get non-secret runtime config.
+
+**Response**: `application/json`
+
+```json
+{ "model": "claude-sonnet-4-6", "extendedThinking": true }
+```
+
+---
+
+### GET /api/sessions/:sessionId
+
+Get session metadata.
+
+**Response**: `application/json`
+
+```json
+{
+  "id": "uuid",
+  "started_at": "2024-01-01T00:00:00Z",
+  "last_activity_at": "2024-01-01T00:10:00Z",
+  "client_ip": "1.2.3.4",
+  "client_geo": { "city": "...", "country": "..." },
+  "client_user_agent": "Mozilla/...",
+  "email_sent": false
+}
+```
+
+Returns `404` if not found.
+
+---
+
+### DELETE /api/sessions/:sessionId
+
+End a session.  Sends transcript email if transcript exists and email not yet sent.  Deletes from DB (cascades to messages and feedback).
+
+**Response**: `application/json`
+
+```json
+{ "ok": true }
+```
+
+---
+
+### GET /api/transcript/:sessionId
+
+Get conversation transcript.  Prefers in-memory session; falls back to DB.
+
+**Response**: `application/json`
+
+```json
+{
+  "transcript": [
+    { "role": "Student", "text": "I got v = 10 m/s" },
+    { "role": "Tutor", "text": "Walk me through how you set that up." }
+  ]
+}
+```
+
+---
+
+### POST /api/feedback
+
+Submit session feedback.
+
+**Request**: `application/json`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| sessionId | string (UUID) | yes | |
+| rating | integer | no | 1–5 |
+| comment | string | no | |
+
+**Response**: `application/json`
+
+```json
+{ "ok": true, "id": "uuid" }
+```
+
+---
+
+## Config/secrets management
+
+All configuration comes from environment variables.  No `.env` files are committed.  No secrets are read by client-side code.
+
+| Variable | Required | Default | Used by | Purpose |
+|----------|----------|---------|---------|---------|
+| ANTHROPIC_API_KEY | **yes** | — | core, api, cli | Anthropic API authentication |
+| SUPABASE_URL | no | — | db, api | Supabase project URL |
+| SUPABASE_SERVICE_ROLE_KEY | no | — | db, api | Supabase service role (bypasses RLS) |
+| RESEND_API_KEY | no | — | email, api | Resend API key (email skipped if absent) |
+| PARENT_EMAIL | no | — | api | Recipient for transcript/feedback emails |
+| EMAIL_FROM | no | tutor@tutor.schmim.com | email, api | Sender address |
+| CORS_ORIGIN | no | * | api | Allowed CORS origin |
+| MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
+| EXTENDED_THINKING | no | true | core | Set "false" to disable |
+| SYSTEM_PROMPT_PATH | no | templates/tutor-prompt.md | core | Path from repo root |
+| PORT | no | 3000 | api | HTTP listen port |
+
+If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the API server starts but all DB operations silently fail.  If `RESEND_API_KEY` or `PARENT_EMAIL` is absent, emails are silently skipped.
+
+---
+
+## Frontend approach
+
+`apps/web/public/index.html` is the entire frontend — HTML, CSS, and JavaScript in one file.  No bundler.  No framework.  No compilation.
+
+CDN libraries loaded at runtime:
+- **KaTeX** — renders LaTeX math (`$...$`, `$$...$$`)
+- **marked** — renders Markdown in tutor responses
+
+The API server serves this file from the root path (`/`).  Any path not matching `/api/*` returns `index.html`.
+
+Do not add a build step to this package.  Do not introduce a framework.  If complexity grows to the point where a framework is warranted, that is an architectural decision requiring explicit discussion — not a refactor to do inline.
+
+---
+
+## Consistency rules for contributors
+
+1. **TypeScript everywhere** in `packages/` and `apps/api/` and `apps/cli/`.  Strict mode.  No `any` without a comment explaining why.
+2. **No `.env` files committed.**  Export env vars in your shell or use a secrets manager for deployment.
+3. **No RLS** on Supabase tables — all queries are server-side with the service role key.  Do not add RLS without updating `packages/db/src/client.ts` to match.
+4. **No new npm dependencies in `apps/web/`.**  It is intentionally dependency-free.  Use CDN if you must add a library.
+5. **Build before testing API changes.**  Run `npm run build` from the root, then `npm run api`.
+6. **Never expose secrets through `/api/config`.**  That route is intentionally public.
+7. **Do not modify** `templates/`, `examples/`, `tests/`, `docs/methodology.md`, `docs/model-selection.md`, or `docs/lessons-learned.md` without explicit instruction.  These are source-of-truth documents.
+8. **Transcript emails must be idempotent.**  The `email_sent` flag and `markEmailSent()` method exist precisely to prevent duplicate emails during the inactivity sweep and explicit session deletion.
+9. **SSE errors must close the connection.**  If you add a new error path in a streaming route, send the error event and then call `res.end()`.
+10. **In-memory session IDs are client-generated UUIDs.**  Never generate them server-side.  The client owns the session ID lifecycle.
+
+---
+
+## File-level reference table
+
+| Path | Purpose |
+|------|---------|
+| `package.json` | Workspace root; defines `npm run build`, `npm run api`, `npm run cli`, `npm run dev` |
+| `tsconfig.base.json` | Shared TypeScript compiler options (strict, ES2022, composite) |
+| `supabase/migrations/001_initial_schema.sql` | Initial DB schema (sessions, messages, feedback) |
+| `templates/tutor-prompt.md` | Parameterized tutor prompt (source of truth) |
+| `templates/evaluation-checklist.md` | Scoring rubric for test evaluation |
+| `examples/physics-geometry-9th-grade.md` | Real production prompt (reference) |
+| `tests/README.md` | Test harness usage guide |
+| `tests/*.md` | Character briefs for simulating student sessions |
+| `docs/methodology.md` | How to build a tutor from scratch |
+| `docs/model-selection.md` | Model and extended thinking analysis |
+| `docs/lessons-learned.md` | Key findings from five iterations |
+| `docs/deployment.md` | Render, AWS, and local deployment instructions |
+| `packages/core/src/config.ts` | `loadConfig()` — reads and validates all env vars |
+| `packages/core/src/prompt-loader.ts` | `loadSystemPrompt()` — loads prompt file from repo root |
+| `packages/core/src/tutor-client.ts` | `createTutorClient()` — Anthropic SDK wrapper (streaming + blocking) |
+| `packages/core/src/session.ts` | `Session` class — message history, transcript, file attachments |
+| `packages/db/src/client.ts` | `createSupabaseClient()` — Supabase initialization |
+| `packages/db/src/sessions.ts` | Session CRUD (create, get, update, delete) |
+| `packages/db/src/messages.ts` | Message CRUD (create, list by session, delete by session) |
+| `packages/db/src/feedback.ts` | Feedback CRUD (create, list by session) |
+| `packages/email/src/transcript.ts` | `sendTranscript()` — session summary email via Resend |
+| `packages/email/src/feedback.ts` | `sendFeedback()` — feedback notification email via Resend |
+| `apps/api/src/index.ts` | Express server entry — routes, middleware, inactivity sweep |
+| `apps/api/src/routes/chat.ts` | `POST /api/chat` — streaming chat with file upload |
+| `apps/api/src/routes/sessions.ts` | `GET/DELETE /api/sessions/:id` |
+| `apps/api/src/routes/transcript.ts` | `GET /api/transcript/:id` |
+| `apps/api/src/routes/feedback.ts` | `POST /api/feedback` |
+| `apps/api/src/routes/config.ts` | `GET /api/config` |
+| `apps/api/src/lib/session-store.ts` | In-memory session cache (`Map<id, Session>`) |
+| `apps/api/src/lib/stream.ts` | SSE helpers (`initSSE`, `sendEvent`, `sendHeartbeat`) |
+| `apps/api/src/middleware/cors.ts` | CORS middleware (origin from `CORS_ORIGIN` env var) |
+| `apps/api/src/middleware/errors.ts` | Global Express error handler |
+| `apps/web/public/index.html` | Entire frontend — HTML, CSS, JS in one file |
+| `apps/cli/src/index.ts` | Terminal REPL — readline loop, `sendMessage()`, transcript export |
+| `Dockerfile` | Multi-stage build: deps → build → production runtime |
+| `render.yaml` | Render.com deployment config |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# Stage 1: Install all workspace dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Copy workspace manifests first for layer caching
+COPY package.json package-lock.json ./
+COPY packages/core/package.json ./packages/core/
+COPY packages/db/package.json ./packages/db/
+COPY packages/email/package.json ./packages/email/
+COPY apps/api/package.json ./apps/api/
+COPY apps/cli/package.json ./apps/cli/
+COPY apps/web/package.json ./apps/web/
+
+RUN npm ci --ignore-scripts
+
+
+# Stage 2: Build TypeScript for all packages and apps/api
+FROM deps AS build
+WORKDIR /app
+
+# Copy source files
+COPY tsconfig.base.json ./
+COPY packages/ ./packages/
+COPY apps/api/ ./apps/api/
+COPY apps/cli/ ./apps/cli/
+COPY apps/web/ ./apps/web/
+COPY templates/ ./templates/
+
+# Build all TypeScript (composite project references handle order)
+RUN npm run build
+
+
+# Stage 3: Production image
+FROM node:20-alpine AS production
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace manifests for production install
+COPY package.json package-lock.json ./
+COPY packages/core/package.json ./packages/core/
+COPY packages/db/package.json ./packages/db/
+COPY packages/email/package.json ./packages/email/
+COPY apps/api/package.json ./apps/api/
+COPY apps/cli/package.json ./apps/cli/
+COPY apps/web/package.json ./apps/web/
+
+# Install production dependencies only
+RUN npm ci --omit=dev --ignore-scripts
+
+# Copy compiled JavaScript from build stage
+COPY --from=build /app/packages/core/dist ./packages/core/dist
+COPY --from=build /app/packages/db/dist ./packages/db/dist
+COPY --from=build /app/packages/email/dist ./packages/email/dist
+COPY --from=build /app/apps/api/dist ./apps/api/dist
+
+# Copy static frontend (no compilation needed)
+COPY --from=build /app/apps/web/public ./apps/web/public
+
+# Copy tutor prompt template (loaded at runtime)
+COPY --from=build /app/templates ./templates
+
+# The API server is the only process
+EXPOSE ${PORT:-3000}
+CMD ["node", "apps/api/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ This repo contains three things:
 
 2. **A test harness** using Claude's Chrome extension to simulate student interactions and evaluate tutor behavior — without needing an actual student in the loop.
 
-3. **Working tutor apps** — a CLI and a web interface, powered by the Anthropic SDK with extended thinking enabled by default.  Run `npm run serve` from the repo root and hand your student a browser.
+3. **Working tutor apps** — a CLI and a web interface, powered by the Anthropic SDK with extended thinking enabled by default.  Run `npm run api` from the repo root and hand your student a browser.
 
 ## The core insight
 
 **Examples drive model behavior more than rules.**  We went through five prompt versions.  The biggest improvements came not from adding principles or "never do this" lists, but from showing the model annotated examples of good and bad judgment.  When a stated principle conflicted with a demonstrated example, the model followed the example every time.
+
+---
 
 ## Quick start
 
@@ -26,14 +28,16 @@ This repo contains three things:
 2. Paste the contents of [`templates/tutor-prompt.md`](templates/tutor-prompt.md) into the custom instructions.  Customize the variables at the top.
 3. Set the model to **Sonnet 4.6 with extended thinking**.
 
-### Option B: Web app (local)
+### Option B: Web app
 
 ```bash
 npm install
-cp apps/web/.env.example apps/web/.env
-# Edit apps/web/.env — set ANTHROPIC_API_KEY (required)
-# Set RESEND_API_KEY and PARENT_EMAIL to enable session email summaries
-npm run serve
+
+# Export required env vars (see Environment variables below)
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Start the API server (also serves the web frontend)
+npm run api
 ```
 
 Open `http://localhost:3000`.  Your student gets a chat interface.  Your API key stays server-side.
@@ -42,118 +46,265 @@ Open `http://localhost:3000`.  Your student gets a chat interface.  Your API key
 
 ```bash
 npm install
-cp apps/cli/.env.example apps/cli/.env
-# Edit apps/cli/.env and add your Anthropic API key
+export ANTHROPIC_API_KEY=sk-ant-...
 npm run cli
 ```
 
-### Testing
+Type your student's messages at the prompt.  Type `export` to print the transcript.  Type `quit` to exit.
 
-Use the character briefs in [`tests/`](tests/) to simulate student sessions via the Claude Chrome extension, or just paste them manually into conversations.  Each test includes a scenario, a character brief, and an evaluation checklist.
+### Option D: API only
 
-### Iterating
+The API server exposes REST endpoints under `/api/`.  See [apps/api/README.md](apps/api/README.md) for the full endpoint reference.
 
-When something breaks, diagnose the transcript, trace the failure to a specific example or principle in the prompt, and make a targeted edit.  Swap examples — don't add rules.
+---
 
-## Repo structure
+## Third-party setup
+
+### Supabase (Postgres database)
+
+Supabase is used as a managed Postgres database.  The toolkit uses it for three tables: `sessions`, `messages`, and `feedback`.  No Edge Functions, no Realtime, no Storage.
+
+If you skip Supabase setup, the API server still runs and the web/CLI interfaces still work — sessions just won't be persisted between server restarts and no transcript history will be available.
+
+**Step 1: Create a Supabase project**
+
+1. Go to [supabase.com](https://supabase.com) and sign in (or create an account).
+2. Click **New project**.
+3. Give it a name (e.g., `ai-tutor`), choose a region close to you, and set a database password.
+4. Wait for the project to initialize (about 1 minute).
+
+**Step 2: Get your credentials**
+
+1. In your Supabase project dashboard, go to **Settings → API**.
+2. Copy the **Project URL** — this is your `SUPABASE_URL`.
+3. Under **Project API keys**, copy the **service_role** key (the secret one, not `anon`) — this is your `SUPABASE_SERVICE_ROLE_KEY`.
+
+Keep the service role key secret.  It bypasses row-level security and has full database access.
+
+**Step 3: Run the migration**
+
+Open **SQL Editor** in your Supabase dashboard, paste the contents of `supabase/migrations/001_initial_schema.sql`, and click **Run**.
+
+Alternatively, if you have the [Supabase CLI](https://supabase.com/docs/guides/cli) installed:
+
+```bash
+supabase login
+supabase link --project-ref <your-project-ref>
+supabase db push
+```
+
+**Step 4: Set environment variables**
+
+```bash
+export SUPABASE_URL=https://your-project-ref.supabase.co
+export SUPABASE_SERVICE_ROLE_KEY=eyJ...
+```
+
+---
+
+### Resend (outbound email)
+
+Resend sends two types of emails: session transcript summaries (to the parent) and feedback notifications.  If you skip this setup, the app works fine — emails are just silently skipped.
+
+**Step 1: Create a Resend account**
+
+Go to [resend.com](https://resend.com) and sign up.
+
+**Step 2: Add and verify your sending domain**
+
+You need to send from a domain you own.  Resend cannot send from Gmail/Yahoo/etc.
+
+1. In Resend, go to **Domains → Add Domain**.
+2. Enter your domain (e.g., `tutor.yourdomain.com`).
+3. Resend will show you DNS records to add:
+   - An SPF `TXT` record
+   - A DKIM `TXT` record
+   - Optionally a DMARC `TXT` record
+4. Add these records in your DNS provider (Cloudflare, Route 53, Namecheap, etc.).
+5. DNS propagation takes 5 minutes to 48 hours.  Click **Verify** in Resend when you're ready.
+
+**Step 3: Generate an API key**
+
+1. In Resend, go to **API Keys → Create API Key**.
+2. Give it a name (e.g., `ai-tutor-production`).
+3. Copy the key — you won't see it again.
+
+**Step 4: Set environment variables**
+
+```bash
+export RESEND_API_KEY=re_...
+export PARENT_EMAIL=you@yourdomain.com   # where transcripts are sent
+export EMAIL_FROM=tutor@tutor.yourdomain.com  # must match verified domain
+```
+
+---
+
+## Monorepo structure
 
 ```
 ai-tutor-toolkit/
-├── README.md                         ← You are here
-├── LICENSE                           ← MIT
-├── CLAUDE.md                         ← Agent context (for AI contributors)
-├── .gitignore
-├── package.json                      ← npm workspaces root
+├── package.json                          ← Workspace root (npm workspaces)
+├── tsconfig.base.json                    ← Shared TypeScript config
+├── Dockerfile                            ← Multi-stage production build
+├── render.yaml                           ← Render.com deployment config
+├── CLAUDE.md                             ← Agent context (for AI contributors)
+│
+├── packages/                             ← Shared libraries
+│   ├── core/                             ← @ai-tutor/core — tutor logic, Anthropic SDK wrapper
+│   ├── db/                               ← @ai-tutor/db — Supabase client and CRUD
+│   └── email/                            ← @ai-tutor/email — Resend email templates
+│
+├── apps/                                 ← Applications
+│   ├── api/                              ← @ai-tutor/api — Express server + API routes
+│   ├── web/                              ← @ai-tutor/web — Static single-file SPA
+│   └── cli/                              ← @ai-tutor/cli — Terminal REPL
+│
+├── supabase/
+│   └── migrations/
+│       └── 001_initial_schema.sql        ← DB schema (sessions, messages, feedback)
+│
 ├── templates/
-│   ├── tutor-prompt.md               ← Parameterized prompt template
-│   └── evaluation-checklist.md       ← Reusable scoring rubric
+│   ├── tutor-prompt.md                   ← Parameterized tutor prompt (customize this)
+│   └── evaluation-checklist.md           ← Scoring rubric for test evaluation
+│
 ├── examples/
-│   └── physics-geometry-9th-grade.md ← The actual prompt we built
+│   └── physics-geometry-9th-grade.md     ← Real production prompt
+│
 ├── tests/
-│   ├── README.md                     ← How to run tests
-│   ├── kinematics.md                 ← Wrong equation, basic error
-│   ├── projectile-motion.md          ← Multi-step, buried error
-│   ├── friction.md                   ← Frustrated/defeated student
-│   ├── similar-triangles.md          ← Geometry, conceptual error
-│   └── pendulum.md                   ← Overconfident student
-├── docs/
-│   ├── methodology.md                ← How to build a tutor from scratch
-│   ├── model-selection.md            ← Sonnet vs Opus, extended thinking
-│   └── lessons-learned.md            ← What we learned from Khan, etc.
-└── apps/
-    ├── core/                         ← Shared tutor logic (SDK, sessions, config)
-    │   ├── README.md
-    │   ├── package.json
-    │   ├── index.js
-    │   ├── config.js
-    │   ├── prompt-loader.js
-    │   ├── tutor-client.js
-    │   └── session.js
-    ├── cli/                          ← Terminal tutor (npm run cli)
-    │   ├── README.md
-    │   ├── package.json
-    │   ├── index.js
-    │   └── .env.example
-    ├── web/                          ← Web tutor (npm run serve)
-    │   ├── README.md
-    │   ├── package.json
-    │   ├── server.js
-    │   ├── email.js                  ← Session summary email (Resend)
-    │   ├── .env.example
-    │   └── public/
-    │       └── index.html
-    ├── web-parent/                   ← Parent config UI (planned)
-    │   └── README.md
-    ├── web-review/                   ← Session review tool (planned)
-    │   └── README.md
-    └── ios/                          ← iOS app (planned)
-        └── README.md
+│   ├── README.md                         ← Test harness usage
+│   ├── kinematics.md                     ← Wrong equation, confused student
+│   ├── projectile-motion.md              ← Buried vector error, puzzled student
+│   ├── friction.md                       ← Frustrated/defeated student
+│   ├── similar-triangles.md              ← Geometry, conceptual error
+│   └── pendulum.md                       ← Overconfident student
+│
+└── docs/
+    ├── methodology.md                    ← How to build a tutor from scratch
+    ├── model-selection.md                ← Sonnet vs Opus, extended thinking analysis
+    ├── lessons-learned.md                ← Key findings from five iterations
+    └── deployment.md                     ← Render, AWS, and local deployment instructions
 ```
 
-## Development
+---
 
-This is an npm workspaces monorepo.  All commands run from the repository root.
+## Technology stack
+
+| Layer | Technology | Notes |
+|-------|-----------|-------|
+| AI | Claude (Anthropic SDK) | Sonnet 4.6, extended thinking enabled |
+| API server | Express | TypeScript, SSE streaming |
+| Frontend | Plain HTML/CSS/JS | No framework, no build step |
+| Math rendering | KaTeX (CDN) | LaTeX in tutor responses |
+| Markdown | marked (CDN) | Markdown in tutor responses |
+| Database | Supabase (Postgres) | Sessions, messages, feedback |
+| Email | Resend | Transcript and feedback emails |
+| File uploads | multer | Images and PDFs up to 10 MB each |
+| Geolocation | geoip-lite | Client IP to city/country (local lookup) |
+| Language | TypeScript | Node 20+, strict mode |
+| Build | tsc --build | Composite projects, incremental |
+| Package management | npm workspaces | Monorepo, single node_modules |
+| Containerization | Docker | Multi-stage build |
+| Deployment | Render (primary) | Also documented for AWS ECS Fargate |
+
+---
+
+## Environment variables reference
+
+| Variable | Required | Default | Used by | Description |
+|----------|----------|---------|---------|-------------|
+| `ANTHROPIC_API_KEY` | **yes** | — | api, cli | Your Anthropic API key. Get it at [console.anthropic.com](https://console.anthropic.com). |
+| `SUPABASE_URL` | no | — | api | Your Supabase project URL. **Settings → API → Project URL**. |
+| `SUPABASE_SERVICE_ROLE_KEY` | no | — | api | Supabase service role key. **Settings → API → service_role**. Keep secret. |
+| `RESEND_API_KEY` | no | — | api | Resend API key. **API Keys → Create API Key** in Resend dashboard. |
+| `PARENT_EMAIL` | no | — | api | Email address where transcripts and feedback notifications are sent. |
+| `EMAIL_FROM` | no | `tutor@tutor.schmim.com` | api | Sender address. Must match a verified Resend domain. |
+| `CORS_ORIGIN` | no | `*` | api | Allowed CORS origin (e.g., `https://yourapp.com`). |
+| `MODEL` | no | `claude-sonnet-4-6` | core | Claude model ID. |
+| `EXTENDED_THINKING` | no | `true` | core | Set to `false` to disable extended thinking (faster, lower cost, weaker soft skills). |
+| `SYSTEM_PROMPT_PATH` | no | `templates/tutor-prompt.md` | core | Path to the system prompt file, relative to the repo root. |
+| `PORT` | no | `3000` | api | HTTP listen port. |
+
+---
+
+## Deployment
+
+### Local development
 
 ```bash
-npm install          # Install all workspace dependencies
-npm run serve        # Start the web tutor
-npm run cli          # Start the CLI tutor
+# Install all workspace dependencies
+npm install
+
+# Export environment variables (no .env files)
+export ANTHROPIC_API_KEY=sk-ant-...
+export SUPABASE_URL=https://...supabase.co
+export SUPABASE_SERVICE_ROLE_KEY=eyJ...
+export RESEND_API_KEY=re_...
+export PARENT_EMAIL=you@example.com
+
+# Build all TypeScript packages
+npm run build
+
+# Start API server (serves web frontend at http://localhost:3000)
+npm run api
+
+# Or start in watch mode (rebuilds on changes)
+npm run dev
 ```
 
-You can also run from individual app directories:
+### Render.com
 
-```bash
-cd apps/web && npm run serve
-cd apps/cli && npm start
-```
+See [docs/deployment.md](docs/deployment.md) for step-by-step Render deployment instructions.
 
-Each app has its own `.env.example`.  Copy it to `.env` and set your `ANTHROPIC_API_KEY`.  The `SYSTEM_PROMPT_PATH` defaults to `templates/tutor-prompt.md` and resolves from the repo root.
+Quick version:
+1. Push this repo to GitHub.
+2. Create a new **Web Service** on Render, connect your repo.
+3. Set **Runtime** to **Docker**.
+4. Add all required environment variables in Render's dashboard.
+5. Deploy.
 
-## Roadmap
+### AWS ECS Fargate
 
-### Phase 1: CLI tutor ✅
+See [docs/deployment.md](docs/deployment.md) for the full AWS deployment guide, including ECS task definition, ALB setup, and secrets in SSM Parameter Store.
 
-Command-line interface with extended thinking, transcript export, and configurable system prompt.
+---
 
-### Phase 2: Web UI ✅
+## Testing
 
-Express server with a single-page chat interface, file uploads, transcript export, session management, and end-of-session email summaries sent to the parent via Resend.
+Use the character briefs in [`tests/`](tests/) to simulate student sessions.
 
-### Phase 3: Parent configuration
+### Using the Claude Chrome extension (recommended)
 
-A setup page where a parent can choose subject, grade level, tone, and student description — then preview the generated system prompt.  See [`apps/web-parent/`](apps/web-parent/).
+1. Install the Claude Chrome extension.
+2. Configure a shortcut pointing to your Claude Project.
+3. Set the shortcut's instructions to the content of a test file (e.g., `tests/kinematics.md`).
+4. Run it.  The extension plays the student role and captures the transcript.
+5. Evaluate with the checklist in `templates/evaluation-checklist.md`.
 
-### Phase 4: Session review
+### Manual testing
 
-Transcript review with automated evaluation checks and the ability to flag specific exchanges.  See [`apps/web-review/`](apps/web-review/).
+1. Open your Claude Project or the web app.
+2. Play the student role yourself, following the character brief.
+3. Evaluate responses against the checklist.
 
-### Phase 5: Multi-student support
+### Test scenarios
 
-Multiple student profiles, each with their own tutor configuration and session history.  This is a feature added to existing apps, not a standalone application.
+| File | Error type | Student state | Tests |
+|------|-----------|--------------|-------|
+| `kinematics.md` | Wrong equation | Confused | Basic opening sequence, error diagnosis |
+| `projectile-motion.md` | Buried vector error | Puzzled | Step-by-step confirmation, finding hidden error |
+| `friction.md` | Forgot a force | Frustrated | Emotional adaptation, not lecturing |
+| `similar-triangles.md` | Wrong side correspondence | Confused | Geometry handling, conceptual vs arithmetic |
+| `pendulum.md` | Unit conversion miss | Overconfident | Respectful pushback, not caving |
 
-### Future: iOS app
+---
 
-A native mobile tutor interface.  See [`apps/ios/`](apps/ios/).
+## Methodology docs
+
+- [docs/methodology.md](docs/methodology.md) — Eight-phase process for building a tutor from scratch
+- [docs/model-selection.md](docs/model-selection.md) — Sonnet vs Opus, extended thinking analysis
+- [docs/lessons-learned.md](docs/lessons-learned.md) — Key findings from five real iterations
+
+---
 
 ## Key findings
 
@@ -163,8 +314,35 @@ These emerged from five iterations and eight test runs across four distinct scen
 - **The model follows examples over stated rules.**  If your example shows "walk me through your steps" but your principle says "ask why," the model will ask "walk me through your steps."  Always align your examples with your principles.
 - **Sonnet with extended thinking is the sweet spot for tutoring.**  Opus is overkill.  Sonnet without extended thinking breaks on soft skills (stacks multiple questions, skips tone calibration).  Extended thinking gives the model a scratchpad to check its own behavior before responding.
 - **The opening sequence matters more than anything else.**  See the problem → understand where the student is → then help.  If the tutor skips step one, everything downstream is guesswork.
-- **A browser-based test harness works surprisingly well.**  Character briefs in the Chrome extension produced reliable, evaluable transcripts with zero setup friction.  The API approach is more robust but wasn't necessary for this stage.
+- **A browser-based test harness works surprisingly well.**  Character briefs in the Chrome extension produced reliable, evaluable transcripts with zero setup friction.
 - **The student's emotional state is a real variable.**  A frustrated student, an overconfident student, and a confused student all need different approaches.  The prompt can't branch for each case — but it can demonstrate good judgment through examples that cover the range.
+
+---
+
+## Roadmap
+
+### Phase 1: CLI tutor ✅
+Command-line interface with extended thinking, transcript export, and configurable system prompt.
+
+### Phase 2: Web UI ✅
+Express server with a single-page chat interface, file uploads, transcript export, session management, and end-of-session email summaries sent to the parent via Resend.
+
+### Phase 3: Documentation and deployment ✅
+CLAUDE.md, package READMEs, deployment files (Dockerfile, render.yaml, docs/deployment.md).
+
+### Phase 4: Parent configuration
+A setup page where a parent can choose subject, grade level, tone, and student description — then preview the generated system prompt.
+
+### Phase 5: Session review
+Transcript review with automated evaluation checks and the ability to flag specific exchanges.
+
+### Phase 6: Multi-student support
+Multiple student profiles, each with their own tutor configuration and session history.
+
+### Future: iOS app
+A native mobile tutor interface.
+
+---
 
 ## Prior art and references
 
@@ -172,6 +350,8 @@ These emerged from five iterations and eight test runs across four distinct scen
 - [Khan Academy: 7-Step Approach to Prompt Engineering](https://blog.khanacademy.org/khan-academys-7-step-approach-to-prompt-engineering-for-khanmigo/)
 - [The Socratic Prompt: How to Make a Language Model Stop Guessing and Start Thinking](https://towardsai.net/p/machine-learning/the-socratic-prompt-how-to-make-a-language-model-stop-guessing-and-start-thinking)
 - [AI Socratic Tutors: Teaching The World To Think](https://aicompetence.org/ai-socratic-tutors/)
+
+---
 
 ## Contributing
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,207 @@
+# @ai-tutor/api
+
+Express API server — serves the web frontend, handles chat streaming, session management, transcript retrieval, and feedback collection.
+
+## Overview
+
+This is the only process that runs in production.  It:
+
+- Serves `apps/web/public/index.html` (and static assets) at `/`
+- Exposes REST/SSE endpoints under `/api/`
+- Holds the in-memory session store
+- Connects to Supabase (Postgres) for persistence
+- Sends emails via Resend when sessions end or feedback is submitted
+- Runs an inactivity sweep every 60 seconds to reap idle sessions
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@ai-tutor/core` | Tutor logic, Anthropic SDK wrapper, session management |
+| `@ai-tutor/db` | Supabase CRUD operations |
+| `@ai-tutor/email` | Transcript and feedback emails |
+| `express` | HTTP server |
+| `cors` | CORS middleware |
+| `multer` | Multipart file uploads |
+| `geoip-lite` | IP → city/country lookup (local database) |
+
+## API reference
+
+### POST /api/chat
+
+Stream a tutor response.
+
+**Request:** `multipart/form-data`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `sessionId` | string (UUID) | yes | Client-generated; use `crypto.randomUUID()` |
+| `message` | string | yes | Student's message text |
+| `files[]` | File | no | Max 5; max 10 MB each; JPEG/PNG/GIF/WebP/PDF |
+
+**Response:** `text/event-stream`
+
+```
+data: {"type":"text_delta","text":"Let's look at..."}
+
+data: {"type":"text_delta","text":" that equation."}
+
+data: {"type":"message_stop"}
+```
+
+On error: `data: {"type":"error","message":"..."}` then connection closes.
+
+**Side effects:**
+- On first message: captures client IP, geolocation, user-agent; creates session in DB
+- After streaming: persists user and assistant messages to DB; updates `last_activity_at`
+
+---
+
+### GET /api/config
+
+Get non-secret runtime config.
+
+**Response:**
+
+```json
+{ "model": "claude-sonnet-4-6", "extendedThinking": true }
+```
+
+---
+
+### GET /api/sessions/:sessionId
+
+Get session metadata from DB.
+
+**Response:**
+
+```json
+{
+  "id": "uuid",
+  "started_at": "2024-01-01T00:00:00Z",
+  "last_activity_at": "2024-01-01T00:10:00Z",
+  "client_ip": "1.2.3.4",
+  "client_geo": { "city": "...", "country": "..." },
+  "client_user_agent": "Mozilla/5.0...",
+  "email_sent": false
+}
+```
+
+Returns `404` if not found.
+
+---
+
+### DELETE /api/sessions/:sessionId
+
+End a session.
+
+**Behavior:**
+1. If session is in memory, transcript exists, and email not yet sent → send transcript email
+2. Remove from in-memory store
+3. Delete from DB (cascades to messages and feedback)
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### GET /api/transcript/:sessionId
+
+Get conversation transcript.
+
+Prefers in-memory session (most recent); falls back to DB if session was removed.
+
+**Response:**
+
+```json
+{
+  "transcript": [
+    { "role": "Student", "text": "I got v = 10 m/s" },
+    { "role": "Tutor", "text": "Walk me through how you set that up." }
+  ]
+}
+```
+
+---
+
+### POST /api/feedback
+
+Submit session feedback.
+
+**Request:** `application/json`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `sessionId` | string (UUID) | yes | |
+| `rating` | integer | no | 1–5 |
+| `comment` | string | no | |
+
+**Response:**
+
+```json
+{ "ok": true, "id": "uuid" }
+```
+
+**Side effects:** Inserts into `feedback` table; sends feedback email (fire-and-forget).
+
+---
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | **yes** | — | Anthropic API key |
+| `SUPABASE_URL` | no | — | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | no | — | Supabase service role key |
+| `RESEND_API_KEY` | no | — | Resend API key |
+| `PARENT_EMAIL` | no | — | Email recipient |
+| `EMAIL_FROM` | no | `tutor@tutor.schmim.com` | Sender address |
+| `CORS_ORIGIN` | no | `*` | Allowed CORS origin |
+| `MODEL` | no | `claude-sonnet-4-6` | Claude model ID |
+| `EXTENDED_THINKING` | no | `true` | Set `"false"` to disable |
+| `SYSTEM_PROMPT_PATH` | no | `templates/tutor-prompt.md` | Path from repo root |
+| `PORT` | no | `3000` | HTTP listen port |
+
+## Setup
+
+```bash
+# From the repo root
+npm install
+npm run build
+
+# Export env vars
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Start the server
+npm run api
+```
+
+Or in watch mode:
+
+```bash
+npm run dev
+```
+
+The server listens on `http://localhost:3000` by default.  The web frontend is served at `/`.
+
+## Source structure
+
+```
+apps/api/src/
+├── index.ts                ← Server entry, middleware, inactivity sweep
+├── routes/
+│   ├── chat.ts             ← POST /api/chat
+│   ├── config.ts           ← GET /api/config
+│   ├── sessions.ts         ← GET/DELETE /api/sessions/:id
+│   ├── transcript.ts       ← GET /api/transcript/:id
+│   └── feedback.ts         ← POST /api/feedback
+├── middleware/
+│   ├── cors.ts             ← CORS (origin from CORS_ORIGIN env var)
+│   └── errors.ts           ← Global error handler
+└── lib/
+    ├── session-store.ts    ← In-memory Map<sessionId, Session>
+    └── stream.ts           ← SSE helpers (initSSE, sendEvent, sendHeartbeat)
+```

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,64 @@
+# @ai-tutor/cli
+
+Terminal REPL for the AI Tutor.  Simple readline-based interface for local testing and development.
+
+## Overview
+
+The CLI provides a minimal interactive session with the tutor.  It uses the blocking `sendMessage()` API (not streaming) and prints the full response after each turn.  It is primarily useful for quick iteration on the system prompt without spinning up a browser.
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@ai-tutor/core` | Tutor logic, Anthropic SDK wrapper, session management |
+
+No other npm dependencies.
+
+## Usage
+
+```bash
+# From the repo root
+export ANTHROPIC_API_KEY=sk-ant-...
+npm run cli
+```
+
+At the prompt:
+
+| Input | Action |
+|-------|--------|
+| Any text | Send message to tutor; print full response |
+| `export` | Print the full session transcript to stdout |
+| `quit` | Exit |
+
+The model ID and extended thinking status are printed at startup.
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | **yes** | — | Anthropic API key |
+| `MODEL` | no | `claude-sonnet-4-6` | Claude model ID |
+| `EXTENDED_THINKING` | no | `true` | Set `"false"` to disable |
+| `SYSTEM_PROMPT_PATH` | no | `templates/tutor-prompt.md` | Path from repo root |
+
+## Setup
+
+```bash
+npm install        # from repo root
+npm run build      # compile TypeScript
+npm run cli        # start REPL
+```
+
+## Source structure
+
+```
+apps/cli/src/
+└── index.ts      ← readline REPL loop
+```
+
+## Notes
+
+- Does not connect to Supabase or Resend — sessions are not persisted.
+- Does not support file attachments.
+- Uses `sendMessage()` (blocking), not `streamMessage()` — the full response appears at once.
+- For streaming output and file uploads, use the web interface (`npm run api`).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,12 +2,16 @@
 
 Static web frontend for the AI Tutor.  No framework, no build step — a single HTML file served directly by the API server.
 
+## Overview
+
+`apps/web/public/index.html` is the entire frontend.  It is served as a static file by `apps/api`.  No compilation required — edit the file and refresh the browser.
+
 ## Structure
 
 ```
 apps/web/
 ├── public/
-│   └── index.html   ← All HTML, CSS, and JS in one file
+│   └── index.html   ← All HTML, CSS, and JavaScript in one file (~1,200 lines)
 ├── package.json
 └── README.md
 ```
@@ -20,25 +24,50 @@ Start the API server — it serves this frontend automatically:
 npm run api          # from monorepo root
 ```
 
-Then open <http://localhost:3000>.
+Then open `http://localhost:3000`.
 
 ## CDN dependencies
 
-Loaded via `<script>` and `<link>` tags in `index.html`:
+Loaded via `<script>` and `<link>` tags in `index.html` — no npm install needed:
 
 | Library | Purpose |
 |---------|---------|
-| [KaTeX](https://katex.org/) | Render LaTeX math in tutor responses |
+| [KaTeX](https://katex.org/) | Render LaTeX math expressions in tutor responses |
 | [marked](https://marked.js.org/) | Render Markdown in tutor responses |
 
 ## Features
 
-- **Streaming chat** — responses stream token-by-token via SSE
-- **Markdown + math** — marked + KaTeX auto-render after each message
-- **File attachments** — images and PDFs via click or drag-and-drop
-- **Transcript viewer** — modal with copy-to-clipboard
-- **Session end detection** — sentinel-based with inline wrap-up banner
-- **Inactivity timeout** — auto-emails transcript after 10 minutes of idle
-- **Per-message feedback** — thumbs up/down shown after session ends
-- **New session** — one-click reset with automatic prior session cleanup
-- **Model indicator** — shows current model and extended thinking status
+| Feature | Description |
+|---------|-------------|
+| Streaming chat | Responses stream token-by-token via SSE (`/api/chat`) |
+| Markdown + math | marked + KaTeX auto-render after each message |
+| File attachments | Images and PDFs via click or drag-and-drop (up to 5 files, 10 MB each) |
+| Transcript viewer | Modal with copy-to-clipboard |
+| Session end detection | Sentinel-based: tutor includes `[END_SESSION_AVAILABLE]` to trigger wrap-up banner |
+| Inactivity timeout | Auto-ends session after 10 minutes idle; triggers transcript email |
+| Per-message feedback | Thumbs up/down shown after session ends |
+| New session | One-click reset with automatic prior session cleanup (`DELETE /api/sessions/:id`) |
+| Model indicator | Shows current model and extended thinking status (from `/api/config`) |
+
+## API calls made by the frontend
+
+| Endpoint | When |
+|----------|------|
+| `GET /api/config` | On page load |
+| `POST /api/chat` | On each message send |
+| `GET /api/transcript/:sessionId` | When transcript modal is opened |
+| `POST /api/feedback` | When thumbs up/down is clicked |
+| `DELETE /api/sessions/:sessionId` | On inactivity timeout or new session button |
+
+## Design notes
+
+- Warm beige/brown color scheme; serif headings, sans-serif body, monospace code blocks
+- Two-column layout on desktop; single column on mobile
+- Student messages: light blue bubbles; tutor messages: white bubbles
+- Session ID is a client-generated UUID (`crypto.randomUUID()`), stored in memory (not localStorage)
+
+## Contributing
+
+Do not add a build step or a framework to this package.  The single-file constraint is intentional — it keeps the frontend auditable, deployable without tooling, and easy to hand to a non-developer.
+
+If the file grows significantly, split CSS and JS into separate files in `public/` before reaching for a framework.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,290 @@
+# Deployment Guide
+
+This document covers three deployment targets:
+
+1. [Render.com](#rendercom) — simplest, recommended for most users
+2. [AWS ECS Fargate](#aws-ecs-fargate) — for teams already on AWS
+3. [Local development](#local-development)
+
+All deployments use the same Docker image.  No `.env` files are committed.  All secrets come from the deployment platform's secret store.
+
+---
+
+## Render.com
+
+### Prerequisites
+
+- A [Render](https://render.com) account
+- This repo pushed to a GitHub repository you control
+- A Supabase project with the migration applied (see root README)
+- A Resend account with a verified sending domain (see root README)
+
+### Step 1: Create a Web Service
+
+1. In Render, click **New → Web Service**.
+2. Connect your GitHub repository.
+3. Give the service a name (e.g., `ai-tutor`).
+
+### Step 2: Configure the build
+
+1. Under **Runtime**, select **Docker**.
+2. Leave **Dockerfile path** as `./Dockerfile`.
+3. Leave **Docker build context** as `.` (repo root).
+
+### Step 3: Set environment variables
+
+In the **Environment** section, add the following key/value pairs.  Do not use a `.env` file.
+
+| Key | Value | Required |
+|-----|-------|----------|
+| `ANTHROPIC_API_KEY` | Your Anthropic API key | **yes** |
+| `SUPABASE_URL` | Your Supabase project URL | no (disables persistence) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Your Supabase service role key | no (disables persistence) |
+| `RESEND_API_KEY` | Your Resend API key | no (disables email) |
+| `PARENT_EMAIL` | Email address to receive transcripts | no (disables email) |
+| `EMAIL_FROM` | Sender address (verified Resend domain) | no |
+| `CORS_ORIGIN` | Your app URL (e.g., `https://ai-tutor.onrender.com`) | no (defaults to `*`) |
+| `PORT` | `3000` | no (Render sets this automatically) |
+
+Mark `ANTHROPIC_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `RESEND_API_KEY` as **Secret** in the Render UI.
+
+### Step 4: Set the health check path
+
+Under **Advanced**, set **Health Check Path** to `/api/config`.
+
+### Step 5: Deploy
+
+Click **Create Web Service**.  Render will:
+1. Pull your repo
+2. Build the Docker image (2–5 minutes on first build)
+3. Start the container
+4. Route traffic once the health check passes
+
+Subsequent pushes to your main branch trigger automatic rebuilds if **Auto-Deploy** is enabled.
+
+### Using render.yaml
+
+Instead of manual configuration, you can use the `render.yaml` in the repo root:
+
+1. In Render, click **New → Blueprint**.
+2. Connect your repository.
+3. Render will detect `render.yaml` and pre-fill the service configuration.
+4. You still need to set secret env vars manually (Render will prompt for `sync: false` vars).
+
+---
+
+## AWS ECS Fargate
+
+This setup uses:
+- **ECR** — container registry
+- **ECS Fargate** — serverless container runtime
+- **ALB** — Application Load Balancer (HTTPS termination)
+- **SSM Parameter Store** — secrets management
+- **Supabase** — remains external (not on AWS)
+
+### Prerequisites
+
+- AWS account with permissions for ECR, ECS, IAM, ALB, SSM
+- AWS CLI configured (`aws configure`)
+- Docker installed locally
+
+### Step 1: Push the image to ECR
+
+```bash
+# Create the ECR repository (one time)
+aws ecr create-repository --repository-name ai-tutor --region us-east-1
+
+# Authenticate Docker to ECR
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin \
+    <account-id>.dkr.ecr.us-east-1.amazonaws.com
+
+# Build and push
+docker build -t ai-tutor .
+docker tag ai-tutor:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/ai-tutor:latest
+docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/ai-tutor:latest
+```
+
+### Step 2: Store secrets in SSM Parameter Store
+
+```bash
+aws ssm put-parameter \
+  --name "/ai-tutor/ANTHROPIC_API_KEY" \
+  --value "sk-ant-..." \
+  --type SecureString
+
+aws ssm put-parameter \
+  --name "/ai-tutor/SUPABASE_SERVICE_ROLE_KEY" \
+  --value "eyJ..." \
+  --type SecureString
+
+aws ssm put-parameter \
+  --name "/ai-tutor/RESEND_API_KEY" \
+  --value "re_..." \
+  --type SecureString
+```
+
+Store non-secret values as `String`:
+
+```bash
+aws ssm put-parameter --name "/ai-tutor/SUPABASE_URL" --value "https://..." --type String
+aws ssm put-parameter --name "/ai-tutor/PARENT_EMAIL" --value "you@..." --type String
+aws ssm put-parameter --name "/ai-tutor/EMAIL_FROM" --value "tutor@..." --type String
+```
+
+### Step 3: Create an ECS task definition
+
+Create `task-definition.json`:
+
+```json
+{
+  "family": "ai-tutor",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::<account-id>:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "ai-tutor",
+      "image": "<account-id>.dkr.ecr.us-east-1.amazonaws.com/ai-tutor:latest",
+      "portMappings": [{ "containerPort": 3000, "protocol": "tcp" }],
+      "environment": [
+        { "name": "PORT", "value": "3000" },
+        { "name": "MODEL", "value": "claude-sonnet-4-6" },
+        { "name": "EXTENDED_THINKING", "value": "true" }
+      ],
+      "secrets": [
+        { "name": "ANTHROPIC_API_KEY", "valueFrom": "/ai-tutor/ANTHROPIC_API_KEY" },
+        { "name": "SUPABASE_URL", "valueFrom": "/ai-tutor/SUPABASE_URL" },
+        { "name": "SUPABASE_SERVICE_ROLE_KEY", "valueFrom": "/ai-tutor/SUPABASE_SERVICE_ROLE_KEY" },
+        { "name": "RESEND_API_KEY", "valueFrom": "/ai-tutor/RESEND_API_KEY" },
+        { "name": "PARENT_EMAIL", "valueFrom": "/ai-tutor/PARENT_EMAIL" },
+        { "name": "EMAIL_FROM", "valueFrom": "/ai-tutor/EMAIL_FROM" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ai-tutor",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+Register it:
+
+```bash
+aws ecs register-task-definition --cli-input-json file://task-definition.json
+```
+
+### Step 4: Create an ECS cluster and service
+
+```bash
+# Create cluster
+aws ecs create-cluster --cluster-name ai-tutor
+
+# Create service (attach to your VPC/subnets/security groups and ALB target group)
+aws ecs create-service \
+  --cluster ai-tutor \
+  --service-name ai-tutor \
+  --task-definition ai-tutor \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxx],securityGroups=[sg-xxx],assignPublicIp=ENABLED}" \
+  --load-balancers "targetGroupArn=arn:aws:elasticloadbalancing:...,containerName=ai-tutor,containerPort=3000"
+```
+
+### Step 5: ALB setup
+
+1. Create an Application Load Balancer with an HTTPS listener (ACM certificate).
+2. Create a target group: IP type, port 3000, health check path `/api/config`.
+3. Register the ECS service with the target group (done via `--load-balancers` above).
+
+### Step 6: Set CORS_ORIGIN
+
+Once you have your ALB DNS name or custom domain:
+
+```bash
+aws ssm put-parameter \
+  --name "/ai-tutor/CORS_ORIGIN" \
+  --value "https://your-domain.com" \
+  --type String
+```
+
+Update the task definition to include this parameter and redeploy.
+
+### Updating the image
+
+```bash
+docker build -t ai-tutor .
+docker tag ai-tutor:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/ai-tutor:latest
+docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/ai-tutor:latest
+
+aws ecs update-service --cluster ai-tutor --service ai-tutor --force-new-deployment
+```
+
+---
+
+## Local development
+
+### Prerequisites
+
+- Node.js 20+
+- npm 10+
+
+### Setup
+
+```bash
+# Install all workspace dependencies
+npm install
+
+# Build all TypeScript packages
+npm run build
+```
+
+### Environment variables
+
+Do not create `.env` files.  Export variables in your shell session:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional — app works without these
+export SUPABASE_URL=https://your-project-ref.supabase.co
+export SUPABASE_SERVICE_ROLE_KEY=eyJ...
+export RESEND_API_KEY=re_...
+export PARENT_EMAIL=you@example.com
+export EMAIL_FROM=tutor@yourdomain.com
+```
+
+To persist across terminal sessions, add the exports to your `~/.zshrc` or `~/.bashrc`.
+
+### Running the web interface
+
+```bash
+npm run api
+# Open http://localhost:3000
+```
+
+### Running in watch mode
+
+```bash
+npm run dev
+# Rebuilds and restarts on source changes
+```
+
+### Running the CLI
+
+```bash
+npm run cli
+```
+
+### Running tests
+
+The test harness uses character briefs in `tests/` with the Claude Chrome extension or manual interaction.  See [tests/README.md](../tests/README.md) for instructions.
+
+There are no automated unit or integration tests in this repo (yet).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,137 @@
+# @ai-tutor/core
+
+Shared tutor logic — Anthropic SDK wrapper, configuration, session management, and prompt loading.  Used by `apps/api` and `apps/cli`.
+
+## Overview
+
+This package abstracts everything that touches the Anthropic API: loading config from environment variables, reading the system prompt file, managing message history (including thinking blocks), and streaming or blocking responses.
+
+## Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@anthropic-ai/sdk` | ^0.39.0 | Anthropic API client |
+
+## API reference
+
+### `loadConfig()`
+
+```typescript
+import { loadConfig } from "@ai-tutor/core";
+const config = loadConfig();
+```
+
+Reads environment variables and returns a typed config object.  Throws if `ANTHROPIC_API_KEY` is not set.
+
+**Returns:**
+
+```typescript
+{
+  model: string;            // MODEL env var, default "claude-sonnet-4-6"
+  extendedThinking: boolean; // EXTENDED_THINKING env var, default true
+  systemPromptPath: string;  // SYSTEM_PROMPT_PATH env var, default "templates/tutor-prompt.md"
+  port: number;             // PORT env var, default 3000
+}
+```
+
+---
+
+### `loadSystemPrompt(path: string): Promise<string>`
+
+```typescript
+import { loadSystemPrompt } from "@ai-tutor/core";
+const prompt = await loadSystemPrompt(config.systemPromptPath);
+```
+
+Loads a prompt file from the repo root.  Strips everything above the `## Begin prompt` marker (documentation/comments above that line are ignored).  Resolves the repo root by walking up the directory tree looking for a `package.json` with `"workspaces"`.
+
+---
+
+### `createTutorClient(config, systemPrompt)`
+
+```typescript
+import { createTutorClient } from "@ai-tutor/core";
+const tutorClient = createTutorClient(config, systemPrompt);
+```
+
+Returns an object with two methods:
+
+#### `sendMessage(session, userContent, transcriptText?): Promise<string>`
+
+Blocking version.  Sends a message and waits for the full response.  Adds both the user message and assistant response to the session.  Returns the response text.
+
+Used by the CLI (where streaming is unnecessary).
+
+#### `streamMessage(session, userContent, transcriptText?): AsyncGenerator<string>`
+
+Streaming version.  Yields text deltas one by one.  Thinking tokens are buffered internally and not yielded.  Adds the full user message and assistant response to the session after streaming completes.
+
+Used by the API server for SSE responses.
+
+**Parameters:**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `session` | `Session` | Current session (message history appended in place) |
+| `userContent` | `string \| ContentBlock[]` | Student's message; can include image/PDF content blocks |
+| `transcriptText` | `string?` | Plain-text version for transcript (if different from userContent) |
+
+---
+
+### `Session`
+
+```typescript
+import { Session } from "@ai-tutor/core";
+const session = new Session();
+```
+
+Holds all state for one tutoring conversation.
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `messages` | `MessageParam[]` | Full Anthropic message history (includes thinking blocks) |
+| `transcript` | `TranscriptEntry[]` | Plain-text `{ role, text }` pairs |
+| `files` | `FileEntry[]` | Uploaded file buffers |
+| `startedAt` | `Date` | Session creation time |
+| `lastActivityAt` | `Date` | Last message time |
+| `clientInfo` | `ClientInfo \| null` | IP, geolocation, user agent |
+| `emailSent` | `boolean` | Whether transcript email has been sent |
+
+**Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `addUserMessage(content, transcriptText?)` | Appends user message to history |
+| `addAssistantResponse(contentBlocks)` | Extracts text, appends to history with thinking blocks |
+| `addFile(filename, mimetype, buffer)` | Stores an uploaded file |
+| `touchActivity()` | Updates `lastActivityAt` |
+| `setClientInfo(info)` | Stores IP/geo/user-agent |
+| `markEmailSent()` | Sets `emailSent = true` |
+| `getSessionSummary()` | Returns `{ transcript, files, clientInfo, startedAt, lastActivityAt, durationMs }` |
+| `reset()` | Clears message history and transcript; keeps clientInfo |
+
+---
+
+## Configuration
+
+All configuration is via environment variables.  See the root README for the full table.
+
+| Variable | Required | Default |
+|----------|----------|---------|
+| `ANTHROPIC_API_KEY` | **yes** | — |
+| `MODEL` | no | `claude-sonnet-4-6` |
+| `EXTENDED_THINKING` | no | `true` |
+| `SYSTEM_PROMPT_PATH` | no | `templates/tutor-prompt.md` |
+| `PORT` | no | `3000` |
+
+## Setup
+
+```bash
+# From the repo root
+npm install
+npm run build
+```
+
+This package is not run directly — it is imported by `apps/api` and `apps/cli`.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,207 @@
+# @ai-tutor/db
+
+Supabase client and CRUD operations for sessions, messages, and feedback.  Used by `apps/api`.
+
+## Overview
+
+This package wraps `@supabase/supabase-js` and provides typed CRUD functions for the three database tables.  All queries run server-side using the service role key, which bypasses row-level security.  There is no RLS on any table.
+
+Supabase is used as a managed Postgres database only — no Edge Functions, no Realtime, no Storage.
+
+## Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@supabase/supabase-js` | ^2.43.0 | Supabase client |
+
+## API reference
+
+### `createSupabaseClient()`
+
+```typescript
+import { createSupabaseClient } from "@ai-tutor/db";
+const db = createSupabaseClient();
+```
+
+Reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from environment.  Returns a Supabase client configured with the service role key (no session persistence, no auto-refresh token).
+
+Throws if either env var is missing.
+
+---
+
+### Sessions
+
+```typescript
+import { createSession, getSession, updateSession, deleteSession } from "@ai-tutor/db";
+```
+
+#### `createSession(client, insert): Promise<DbSession>`
+
+Inserts a new session row.  Returns the created row.
+
+```typescript
+const session = await createSession(db, {
+  id: "uuid",
+  client_ip: "1.2.3.4",
+  client_geo: { city: "...", country: "..." },
+  client_user_agent: "Mozilla/...",
+});
+```
+
+#### `getSession(client, id): Promise<DbSession | null>`
+
+Fetches one session by ID.  Returns `null` if not found.
+
+#### `updateSession(client, id, update): Promise<DbSession>`
+
+Partial update.  Accepts any subset of `DbSessionUpdate` fields.
+
+```typescript
+await updateSession(db, sessionId, {
+  last_activity_at: new Date().toISOString(),
+  email_sent: true,
+});
+```
+
+#### `deleteSession(client, id): Promise<void>`
+
+Deletes session by ID.  Cascades to `messages` and `feedback`.
+
+---
+
+### Messages
+
+```typescript
+import { createMessage, getMessagesBySession, deleteMessagesBySession } from "@ai-tutor/db";
+```
+
+#### `createMessage(client, insert): Promise<DbMessage>`
+
+Inserts a message.
+
+```typescript
+await createMessage(db, {
+  session_id: sessionId,
+  role: "user",
+  content: "I got v = 10 m/s",
+  thinking: null,
+});
+```
+
+#### `getMessagesBySession(client, sessionId): Promise<DbMessage[]>`
+
+Returns all messages for a session, ordered by `created_at` ascending.
+
+#### `deleteMessagesBySession(client, sessionId): Promise<void>`
+
+Deletes all messages for a session (rarely needed directly — `deleteSession` cascades).
+
+---
+
+### Feedback
+
+```typescript
+import { createFeedback, getFeedbackBySession } from "@ai-tutor/db";
+```
+
+#### `createFeedback(client, insert): Promise<DbFeedback>`
+
+Inserts a feedback row.
+
+```typescript
+const fb = await createFeedback(db, {
+  session_id: sessionId,
+  rating: 4,
+  comment: "Very helpful!",
+});
+```
+
+#### `getFeedbackBySession(client, sessionId): Promise<DbFeedback[]>`
+
+Returns all feedback for a session, ordered by `created_at` ascending.
+
+---
+
+## Types
+
+```typescript
+import type { DbSession, DbMessage, DbFeedback } from "@ai-tutor/db";
+```
+
+| Type | Description |
+|------|-------------|
+| `DbSession` | Full session row (all columns) |
+| `DbSessionInsert` | Insert shape (auto-generated fields optional) |
+| `DbSessionUpdate` | Partial update shape |
+| `DbMessage` | Full message row |
+| `DbMessageInsert` | Insert shape |
+| `DbFeedback` | Full feedback row |
+| `DbFeedbackInsert` | Insert shape |
+
+---
+
+## Database schema
+
+Managed by `supabase/migrations/001_initial_schema.sql`.
+
+### sessions
+
+```sql
+CREATE TABLE sessions (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  started_at         timestamptz DEFAULT now(),
+  last_activity_at   timestamptz DEFAULT now(),
+  client_ip          text,
+  client_geo         jsonb,
+  client_user_agent  text,
+  email_sent         boolean DEFAULT false
+);
+```
+
+### messages
+
+```sql
+CREATE TABLE messages (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id  uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  role        text NOT NULL CHECK (role IN ('user', 'assistant')),
+  content     text NOT NULL,
+  thinking    text,
+  created_at  timestamptz DEFAULT now()
+);
+```
+
+### feedback
+
+```sql
+CREATE TABLE feedback (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id  uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  rating      integer CHECK (rating BETWEEN 1 AND 5),
+  comment     text,
+  created_at  timestamptz DEFAULT now()
+);
+```
+
+---
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SUPABASE_URL` | **yes** | Supabase project URL (**Settings → API → Project URL**) |
+| `SUPABASE_SERVICE_ROLE_KEY` | **yes** | Service role key (**Settings → API → service_role**) |
+
+## Setup
+
+Run the migration against your Supabase project before starting the API server:
+
+```bash
+# Via Supabase SQL Editor (paste supabase/migrations/001_initial_schema.sql)
+# Or via Supabase CLI:
+supabase login
+supabase link --project-ref <your-project-ref>
+supabase db push
+```
+
+This package is not run directly — it is imported by `apps/api`.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,0 +1,126 @@
+# @ai-tutor/email
+
+Resend email templates for session transcripts and feedback notifications.  Used by `apps/api`.
+
+## Overview
+
+This package sends two types of emails:
+
+1. **Transcript email** — sent to the parent when a tutoring session ends, containing the full conversation, session metadata, and any uploaded files as attachments.
+2. **Feedback email** — sent to the parent when a student submits feedback (rating + comment).
+
+Both functions fail silently: if the API key or recipient is missing, they log a warning and return without throwing.
+
+## Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `resend` | ^3.2.0 | Resend email API client |
+
+## API reference
+
+### `sendTranscript(config, payload): Promise<void>`
+
+```typescript
+import { sendTranscript } from "@ai-tutor/email";
+
+await sendTranscript(
+  {
+    apiKey: process.env.RESEND_API_KEY,
+    to: process.env.PARENT_EMAIL,
+    from: process.env.EMAIL_FROM ?? "tutor@tutor.schmim.com",
+  },
+  {
+    transcript: session.transcript,
+    files: session.files,
+    clientInfo: session.clientInfo,
+    startedAt: session.startedAt,
+    lastActivityAt: session.lastActivityAt,
+    durationMs: Date.now() - session.startedAt.getTime(),
+  }
+);
+```
+
+**Config:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `apiKey` | `string \| undefined` | no | Resend API key. If absent, email is skipped. |
+| `to` | `string \| undefined` | no | Recipient address. If absent, email is skipped. |
+| `from` | `string` | yes | Sender address (must match verified Resend domain). |
+
+**Payload:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transcript` | `TranscriptEntry[]` | `{ role: "Student" \| "Tutor", text: string }[]` |
+| `files` | `FileEntry[]` | Uploaded files (sent as attachments, max ~40 MB total) |
+| `clientInfo` | `ClientInfo \| null` | IP, geolocation, user agent |
+| `startedAt` | `Date` | Session start time |
+| `lastActivityAt` | `Date` | Session last activity time |
+| `durationMs` | `number` | Session duration in milliseconds |
+
+---
+
+### `sendFeedback(config, entry): Promise<void>`
+
+```typescript
+import { sendFeedback } from "@ai-tutor/email";
+
+await sendFeedback(
+  {
+    apiKey: process.env.RESEND_API_KEY,
+    to: process.env.PARENT_EMAIL,
+    from: process.env.EMAIL_FROM ?? "tutor@tutor.schmim.com",
+  },
+  {
+    sessionId,
+    rating: 4,
+    comment: "Very helpful!",
+    submittedAt: new Date().toISOString(),
+  }
+);
+```
+
+**Entry:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionId` | `string` | Session UUID |
+| `rating` | `number \| null` | 1–5 star rating |
+| `comment` | `string \| null` | Written comment |
+| `submittedAt` | `string` | ISO timestamp |
+
+---
+
+## Types
+
+```typescript
+import type { TranscriptEmailConfig, TranscriptEmailPayload } from "@ai-tutor/email";
+import type { FeedbackEmailConfig, FeedbackEntry } from "@ai-tutor/email";
+```
+
+Shared types (used internally and exported for consumers):
+
+```typescript
+// From shared-types.ts
+type TranscriptEntry = { role: "Student" | "Tutor"; text: string };
+type FileEntry = { filename: string; mimetype: string; buffer: Buffer };
+type ClientInfo = { ip?: string; geo?: Record<string, unknown>; userAgent?: string };
+```
+
+---
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RESEND_API_KEY` | no | Resend API key. Email is silently skipped if missing. |
+| `PARENT_EMAIL` | no | Recipient for transcripts and feedback. Skipped if missing. |
+| `EMAIL_FROM` | no | Sender address. Must match a verified Resend domain. |
+
+## Setup
+
+See the Resend setup section in the root README for domain verification and API key generation.
+
+This package is not run directly — it is imported by `apps/api`.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+services:
+  - type: web
+    name: ai-tutor
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    # All env vars are set in the Render dashboard — no .env files
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: RESEND_API_KEY
+        sync: false
+      - key: PARENT_EMAIL
+        sync: false
+      - key: EMAIL_FROM
+        sync: false
+      - key: CORS_ORIGIN
+        sync: false
+      - key: MODEL
+        value: claude-sonnet-4-6
+      - key: EXTENDED_THINKING
+        value: "true"
+      - key: PORT
+        value: "3000"
+    healthCheckPath: /api/config
+    autoDeploy: true


### PR DESCRIPTION
## Summary

Added comprehensive documentation, deployment configuration, and development guides.

### Changes

- **CLAUDE.md**: Complete agent context for AI contributors covering architecture, package boundaries, API reference, config/secrets, and 10 consistency rules
- **Dockerfile**: Multi-stage build (deps → build → production) for containerized deployment
- **render.yaml**: Render.com deployment config with automatic builds and environment setup
- **README.md**: Expanded with third-party setup (Supabase, Resend), environment variables reference, deployment instructions, and test matrix
- **Package READMEs**: Added for `@ai-tutor/api`, `@ai-tutor/cli`, `@ai-tutor/web`, `@ai-tutor/core`, `@ai-tutor/db`, `@ai-tutor/email`
- **docs/deployment.md**: Step-by-step guides for Render.com and AWS ECS Fargate deployment
- **.gitignore**: Cleaned up iOS/Xcode entries, consolidated env var patterns

### Documentation structure

- **CLAUDE.md** (317 lines): Architecture decisions, package boundaries, database schema, API endpoints, config management, frontend approach, consistency rules, file-level reference table
- **docs/deployment.md** (290 lines): Render, AWS ECS Fargate, and local development instructions
- **README.md** (350 lines): Quick start, third-party setup, monorepo structure, tech stack, environment variables, testing guide, methodology docs
- **Package READMEs** (550+ lines total): Overview, dependencies, API reference, configuration, setup, and source structure for each package and app

### Result

First-time users can now follow clear onboarding paths. Contributors have explicit rules and architectural context. Deployments are documented for Render and AWS with ready-to-use config files.