### PR TITLE
Update email reports: add token tracking, session ID, and restructure feedback table

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -64,6 +64,8 @@ setInterval(() => {
           startedAt: summary.startedAt,
           lastActivityAt: summary.lastActivityAt,
           durationMs: summary.durationMs,
+          sessionId,
+          tokenUsage: summary.tokenUsage,
         });
         session.markEmailSent();
       }

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -55,6 +55,8 @@ export function createSessionsRouter(
           startedAt: summary.startedAt,
           lastActivityAt: summary.lastActivityAt,
           durationMs: summary.durationMs,
+          sessionId,
+          tokenUsage: summary.tokenUsage,
         });
         session.markEmailSent();
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export type {
   FileMetadata,
   ClientInfo,
   SessionSummary,
+  TokenUsage,
 } from "./session.js";
 
 export { createTutorClient } from "./tutor-client.js";

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -30,6 +30,11 @@ export interface ClientInfo {
   userAgent?: string;
 }
 
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 export interface SessionSummary {
   transcript: TranscriptEntry[];
   filesMetadata: FileMetadata[];
@@ -37,6 +42,7 @@ export interface SessionSummary {
   startedAt: Date;
   lastActivityAt: Date;
   durationMs: number;
+  tokenUsage: TokenUsage;
 }
 
 /**
@@ -67,6 +73,7 @@ export class Session {
   lastActivityAt: Date = new Date();
   clientInfo: ClientInfo = {};
   emailSent = false;
+  tokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
 
   /**
    * Record a user message.
@@ -121,6 +128,12 @@ export class Session {
     this.clientInfo = info;
   }
 
+  /** Accumulate token usage from an API response. */
+  addTokenUsage(input: number, output: number): void {
+    this.tokenUsage.inputTokens += input;
+    this.tokenUsage.outputTokens += output;
+  }
+
   /** Prevent double-send of the session email. */
   markEmailSent(): void {
     this.emailSent = true;
@@ -139,6 +152,7 @@ export class Session {
       startedAt: this.startedAt,
       lastActivityAt: this.lastActivityAt,
       durationMs: this.lastActivityAt.getTime() - this.startedAt.getTime(),
+      tokenUsage: { ...this.tokenUsage },
     };
   }
 
@@ -150,5 +164,6 @@ export class Session {
     this.startedAt = new Date();
     this.lastActivityAt = new Date();
     this.emailSent = false;
+    this.tokenUsage = { inputTokens: 0, outputTokens: 0 };
   }
 }

--- a/packages/core/src/tutor-client.ts
+++ b/packages/core/src/tutor-client.ts
@@ -61,6 +61,7 @@ export function createTutorClient(config: Config, systemPrompt: string) {
       stream: false,
     } as Anthropic.MessageCreateParamsNonStreaming);
 
+    session.addTokenUsage(response.usage.input_tokens, response.usage.output_tokens);
     return session.addAssistantResponse(response.content);
   }
 
@@ -100,6 +101,7 @@ export function createTutorClient(config: Config, systemPrompt: string) {
 
     // Stream is exhausted — finalMessage() is already resolved.
     const finalMessage = await stream.finalMessage();
+    session.addTokenUsage(finalMessage.usage.input_tokens, finalMessage.usage.output_tokens);
     session.addAssistantResponse(finalMessage.content);
   }
 

--- a/packages/email/src/feedback.ts
+++ b/packages/email/src/feedback.ts
@@ -44,38 +44,69 @@ export interface BatchFeedbackItem {
   sentiment: string | null; // "up" | "down" | null (not selected)
 }
 
+function sentimentBadge(sentiment: string | null): string {
+  if (sentiment === "up") {
+    return '<span style="display:inline-block;width:22px;height:22px;border-radius:50%;background:#16a34a;color:#fff;text-align:center;line-height:22px;font-size:13px;font-weight:bold;">+</span>';
+  }
+  if (sentiment === "down") {
+    return '<span style="display:inline-block;width:22px;height:22px;border-radius:50%;background:#dc2626;color:#fff;text-align:center;line-height:22px;font-size:13px;font-weight:bold;">&minus;</span>';
+  }
+  return '<span style="display:inline-block;width:22px;height:22px;border-radius:50%;background:#d4d4d4;color:#fff;text-align:center;line-height:22px;font-size:13px;">&#x2013;</span>';
+}
+
 function buildBatchHtml(sessionId: string, items: BatchFeedbackItem[], submittedAt: Date): string {
-  const rows = items
+  // Group items by message so categories become columns
+  const grouped = new Map<string, { accuracy: string | null; usefulness: string | null; tone: string | null }>();
+  for (const item of items) {
+    if (!grouped.has(item.msgText)) {
+      grouped.set(item.msgText, { accuracy: null, usefulness: null, tone: null });
+    }
+    const entry = grouped.get(item.msgText)!;
+    if (item.category === "accuracy") entry.accuracy = item.sentiment;
+    if (item.category === "usefulness") entry.usefulness = item.sentiment;
+    if (item.category === "tone") entry.tone = item.sentiment;
+  }
+
+  const rows = [...grouped.entries()]
     .map(
-      item => `
+      ([msgText, cats]) => `
     <tr>
-      <td style="padding:5px 10px;border:1px solid #ddd;font-size:0.85em;">${item.msgText}</td>
-      <td style="padding:5px 10px;border:1px solid #ddd;">${item.category}</td>
-      <td style="padding:5px 10px;border:1px solid #ddd;">${item.sentiment === "up" ? "👍" : item.sentiment === "down" ? "👎" : "—"}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;font-size:0.85em;">${msgText}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;text-align:center;">${sentimentBadge(cats.accuracy)}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;text-align:center;">${sentimentBadge(cats.usefulness)}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;text-align:center;">${sentimentBadge(cats.tone)}</td>
     </tr>`
     )
     .join("");
 
+  const messageCount = grouped.size;
+
   return `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><title>Tutor Session Feedback</title></head>
-<body style="font-family:sans-serif;max-width:640px;margin:0 auto;padding:24px;color:#222;">
+<body style="font-family:sans-serif;max-width:700px;margin:0 auto;padding:24px;color:#222;">
   <h1 style="font-size:1.4rem;border-bottom:2px solid #4f46e5;padding-bottom:8px;">Session Feedback</h1>
   <table style="width:100%;border-collapse:collapse;margin-bottom:20px;">
     <tr><td style="padding:6px 0;color:#555;width:160px;">Session ID</td><td style="font-size:0.85em;">${sessionId}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Submitted</td><td>${submittedAt.toLocaleString()}</td></tr>
-    <tr><td style="padding:6px 0;color:#555;">Ratings</td><td>${items.length}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Messages rated</td><td>${messageCount}</td></tr>
   </table>
   <table style="width:100%;border-collapse:collapse;">
     <thead>
       <tr style="background:#f4f4f4;">
-        <th style="padding:6px 10px;border:1px solid #ddd;text-align:left;">Message</th>
-        <th style="padding:6px 10px;border:1px solid #ddd;text-align:left;">Category</th>
-        <th style="padding:6px 10px;border:1px solid #ddd;text-align:left;">Rating</th>
+        <th style="padding:8px 10px;border:1px solid #ddd;text-align:left;">Message</th>
+        <th style="padding:8px 10px;border:1px solid #ddd;text-align:center;width:90px;">Accuracy</th>
+        <th style="padding:8px 10px;border:1px solid #ddd;text-align:center;width:90px;">Usefulness</th>
+        <th style="padding:8px 10px;border:1px solid #ddd;text-align:center;width:90px;">Tone</th>
       </tr>
     </thead>
     <tbody>${rows}</tbody>
   </table>
+  <p style="font-size:0.8em;color:#888;margin-top:16px;">
+    <span style="display:inline-block;width:14px;height:14px;border-radius:50%;background:#16a34a;vertical-align:middle;"></span> Positive &nbsp;
+    <span style="display:inline-block;width:14px;height:14px;border-radius:50%;background:#dc2626;vertical-align:middle;"></span> Negative &nbsp;
+    <span style="display:inline-block;width:14px;height:14px;border-radius:50%;background:#d4d4d4;vertical-align:middle;"></span> Not rated
+  </p>
 </body>
 </html>`;
 }

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -17,6 +17,8 @@ export interface TranscriptEmailPayload {
   startedAt: Date;
   lastActivityAt: Date;
   durationMs: number;
+  sessionId?: string;
+  tokenUsage?: { inputTokens: number; outputTokens: number };
 }
 
 /** Maximum total attachment size Resend accepts (40 MB in bytes). */
@@ -42,8 +44,13 @@ function formatDate(date: Date): string {
   });
 }
 
+function formatTokens(usage: { inputTokens: number; outputTokens: number }): string {
+  const total = usage.inputTokens + usage.outputTokens;
+  return `${usage.inputTokens.toLocaleString()} in / ${usage.outputTokens.toLocaleString()} out (${total.toLocaleString()} total)`;
+}
+
 function buildHtml(payload: TranscriptEmailPayload): string {
-  const { transcript, files, clientInfo, startedAt, durationMs } = payload;
+  const { transcript, files, clientInfo, startedAt, durationMs, sessionId, tokenUsage } = payload;
 
   const exchangeCount = Math.floor(transcript.length / 2);
 
@@ -74,9 +81,11 @@ function buildHtml(payload: TranscriptEmailPayload): string {
 <body style="font-family:sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#222;">
   <h1 style="font-size:1.4rem;border-bottom:2px solid #4f46e5;padding-bottom:8px;">Tutor Session Summary</h1>
   <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
-    <tr><td style="padding:6px 0;color:#555;width:160px;">Started</td><td>${formatDate(startedAt)}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;width:160px;">Session ID</td><td style="font-size:0.85em;">${sessionId ?? "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Started</td><td>${formatDate(startedAt)}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Duration</td><td>${formatDuration(durationMs)}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Exchanges</td><td>${exchangeCount}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Tokens</td><td>${tokenUsage ? formatTokens(tokenUsage) : "N/A"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">IP</td><td>${clientInfo.ip ?? "unknown"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Location</td><td>${clientInfo.geo ? JSON.stringify(clientInfo.geo) : "unknown"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">User agent</td><td style="font-size:0.85em;">${clientInfo.userAgent ?? "unknown"}</td></tr>


### PR DESCRIPTION
- Track cumulative token usage (input/output) on Session class, accumulated
  from Anthropic API responses in both streaming and blocking paths
- Add session ID and token count to transcript email header table
- Restructure batch feedback email: categories (accuracy, usefulness, tone) are
  now columns with messages as rows, replacing the flat one-row-per-category layout
- Replace thumbs up/down emoji with colored circle badges (green +, red −, gray –)
  with a legend below the table

https://claude.ai/code/session_01CwmUDK62UTb8tYp7xVT2N4