### PR TITLE
Update docs for token tracking, session ID in emails, and feedback table restructuring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ Event types:
 
 Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — sending an email transcript and marking the session ended in the DB.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.
 
+Token usage (input and output tokens) is accumulated per session after each API call and included in transcript emails alongside the session ID.
+
 ### Extended thinking
 
 Enabled by default.  The Anthropic SDK is called with `thinking: { type: "enabled", budget_tokens: 10000 }` and `max_tokens: 16000`.  Thinking blocks are stored in the session (so the model can reference its own prior reasoning) but are never sent to the client or stored in transcript emails.
@@ -319,13 +321,13 @@ Do not add a build step to this package.  Do not introduce a framework.  If comp
 | `packages/core/src/config.ts` | `loadConfig()` — reads and validates all env vars |
 | `packages/core/src/prompt-loader.ts` | `loadSystemPrompt()` — loads prompt file from repo root |
 | `packages/core/src/tutor-client.ts` | `createTutorClient()` — Anthropic SDK wrapper (streaming + blocking) |
-| `packages/core/src/session.ts` | `Session` class — message history, transcript, file attachments |
+| `packages/core/src/session.ts` | `Session` class — message history, transcript, file attachments, token usage tracking (`TokenUsage` interface) |
 | `packages/db/src/client.ts` | `createSupabaseClient()` — Supabase initialization |
 | `packages/db/src/sessions.ts` | Session CRUD (create, get, update, markSessionEnded, delete) |
 | `packages/db/src/messages.ts` | Message CRUD (create, list by session, delete by session) |
 | `packages/db/src/feedback.ts` | Feedback CRUD (create, createBatch, list by session) |
-| `packages/email/src/transcript.ts` | `sendTranscript()` — session summary email via Resend |
-| `packages/email/src/feedback.ts` | `sendFeedback()` — feedback notification email via Resend |
+| `packages/email/src/transcript.ts` | `sendTranscript()` — session summary email via Resend; includes session ID and token usage |
+| `packages/email/src/feedback.ts` | `sendFeedback()` — feedback notification email via Resend; batch table uses category columns (Accuracy, Usefulness, Tone) with sentiment badges |
 | `apps/api/src/index.ts` | Express server entry — routes, middleware, inactivity sweep |
 | `apps/api/src/routes/chat.ts` | `POST /api/chat` — streaming chat with file upload |
 | `apps/api/src/routes/sessions.ts` | `GET/DELETE /api/sessions/:id` |

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ ai-tutor-toolkit/
 ├── CLAUDE.md                             ← Agent context (for AI contributors)
 │
 ├── packages/                             ← Shared libraries
-│   ├── core/                             ← @ai-tutor/core — tutor logic, Anthropic SDK wrapper
+│   ├── core/                             ← @ai-tutor/core — tutor logic, Anthropic SDK wrapper, token usage tracking
 │   ├── db/                               ← @ai-tutor/db — Supabase client and CRUD
 │   └── email/                            ← @ai-tutor/email — Resend email templates
 │
@@ -335,7 +335,7 @@ These emerged from five iterations and eight test runs across four distinct scen
 Command-line interface with extended thinking, transcript export, and configurable system prompt.
 
 ### Phase 2: Web UI ✅
-Express server with a single-page chat interface, file uploads, transcript export, session management, end-of-session email summaries sent to the parent via Resend, and a full-page feedback review overlay that collects per-response ratings (Accuracy, Helpful, Tone) at session end.  Session data is retained in the database for analysis.
+Express server with a single-page chat interface, file uploads, transcript export, session management, end-of-session email summaries (with session ID and token usage) sent to the parent via Resend, and a full-page feedback review overlay that collects per-response ratings (Accuracy, Helpful, Tone) at session end.  Session data is retained in the database for analysis.
 
 ### Phase 3: Documentation and deployment ✅
 CLAUDE.md, package READMEs, deployment files (Dockerfile, render.yaml, docs/deployment.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -252,6 +252,8 @@ Apply all migrations in order via the Supabase dashboard SQL editor or CLI:
 
 1. `supabase/migrations/001_initial_schema.sql` — creates sessions, messages, feedback tables
 2. `supabase/migrations/002_soft_session_end.sql` — adds `ended_at` column for data retention
+3. `supabase/migrations/003_feedback_message_id.sql` — adds `message_id` FK to feedback; links ratings to messages
+4. `supabase/migrations/004_feedback_category.sql` — adds `category` column; one row per category per message
 
 ### Environment variables
 


### PR DESCRIPTION
- CLAUDE.md: add token usage tracking to architecture section and update
  file-level reference table entries for session.ts, transcript.ts, feedback.ts
- README.md: mention token usage tracking in monorepo structure and roadmap
- docs/deployment.md: add missing migrations 003 and 004

https://claude.ai/code/session_01VVn6X66z2Jrzd26STNZDPJ