### PR TITLE
Code fixes from repository audit (2026-03-17)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,6 +31,10 @@ const emailConfig = {
   from: process.env.EMAIL_FROM ?? "tutor@tutor.schmim.com",
 };
 
+// Inactivity sweep — reap sessions idle for more than 10 minutes.
+// Also served via GET /api/config so the frontend uses the same value.
+const INACTIVITY_MS = 10 * 60 * 1000;
+
 const app = express();
 
 app.use(corsMiddleware);
@@ -45,13 +49,10 @@ app.use("/api/chat", createChatRouter(tutorClient, db));
 app.use("/api/sessions", createSessionsRouter(db, emailConfig));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db, emailConfig));
-app.use("/api/config", createConfigRouter(config));
+app.use("/api/config", createConfigRouter(config, INACTIVITY_MS));
 app.use("/api/disclaimer", createDisclaimerRouter(db));
 
 app.use(errorHandler);
-
-// Inactivity sweep — reap sessions idle for more than 10 minutes.
-const INACTIVITY_MS = 10 * 60 * 1000;
 
 setInterval(() => {
   const now = Date.now();

--- a/apps/api/src/lib/geo.ts
+++ b/apps/api/src/lib/geo.ts
@@ -1,0 +1,21 @@
+import geoip from "geoip-lite";
+import type { Request } from "express";
+import type { ClientInfo } from "@ai-tutor/core";
+
+/**
+ * Extract client IP, geo location, and user agent from an Express request.
+ * Reads IP from x-forwarded-for (first entry if comma-separated) or the
+ * raw socket address.  Runs a geoip lookup and returns a ClientInfo object.
+ */
+export function extractClientInfo(req: Request): ClientInfo {
+  const ip =
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ??
+    req.socket.remoteAddress ??
+    "";
+  const geo = geoip.lookup(ip);
+  return {
+    ip,
+    geo: geo ? (geo as unknown as Record<string, unknown>) : null,
+    userAgent: req.headers["user-agent"],
+  };
+}

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -1,0 +1,3 @@
+/** Matches a standard UUID (version-agnostic, case-insensitive). */
+export const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/apps/api/src/middleware/errors.ts
+++ b/apps/api/src/middleware/errors.ts
@@ -12,10 +12,11 @@ export const errorHandler: ErrorRequestHandler = (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _next: NextFunction
 ): void => {
-  console.error("[api] Unhandled error:", err);
+  if (err instanceof Error) {
+    console.error("[api] Unhandled error:", err.message, err.stack);
+  } else {
+    console.error("[api] Unhandled error:", err);
+  }
 
-  const message =
-    err instanceof Error ? err.message : "An unexpected error occurred.";
-
-  res.status(500).json({ error: message });
+  res.status(500).json({ error: "An unexpected error occurred." });
 };

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -1,6 +1,5 @@
 import { Router } from "express";
 import multer from "multer";
-import geoip from "geoip-lite";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { TutorClient, TokenUsage } from "@ai-tutor/core";
 import {
@@ -12,6 +11,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getOrCreateSession } from "../lib/session-store.js";
 import { initSSE, sendEvent } from "../lib/stream.js";
+import { extractClientInfo } from "../lib/geo.js";
 
 /** Accepted MIME types for file uploads. */
 const ALLOWED_MIME_TYPES = new Set([
@@ -93,7 +93,7 @@ export function createChatRouter(
    *
    * Response: SSE stream
    *   { type: "text_delta", text: "..." }   — one per token
-   *   { type: "message_stop", message_id: "..." }  — final event
+   *   { type: "message_stop", messageId: "...", tokenUsage: { inputTokens: N, outputTokens: N } }  — final event
    *   { type: "error", message: "..." }     — on failure
    */
   router.post(
@@ -116,22 +116,13 @@ export function createChatRouter(
 
         // Capture client info on the first message of the session.
         if (session.transcript.length === 0) {
-          const ip =
-            (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ??
-            req.socket.remoteAddress ??
-            "";
-          const geo = geoip.lookup(ip);
-          session.setClientInfo({
-            ip,
-            geo: geo ? (geo as unknown as Record<string, unknown>) : null,
-            userAgent: req.headers["user-agent"],
-          });
+          session.setClientInfo(extractClientInfo(req));
 
           // Upsert the session row in the database.
           try {
             await createSession(db, {
               id: sessionId,
-              client_ip: session.clientInfo.ip ?? null,
+              client_ip: session.clientInfo.ip || null,
               client_geo: session.clientInfo.geo ?? null,
               client_user_agent: session.clientInfo.userAgent ?? null,
               email_sent: false,

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,14 +1,14 @@
 import { Router } from "express";
 import type { Config } from "@ai-tutor/core";
 
-export function createConfigRouter(config: Config): Router {
+export function createConfigRouter(config: Config, inactivityMs: number): Router {
   const router = Router();
 
   /**
    * GET /api/config
    *
    * Returns non-secret configuration the frontend needs to render correctly
-   * (model name, whether extended thinking is active).
+   * (model name, whether extended thinking is active, inactivity timeout).
    *
    * Never includes API keys or service-role credentials.
    */
@@ -16,6 +16,7 @@ export function createConfigRouter(config: Config): Router {
     res.json({
       model: config.model,
       extendedThinking: config.extendedThinking,
+      inactivityMs,
     });
   });
 

--- a/apps/api/src/routes/disclaimer.ts
+++ b/apps/api/src/routes/disclaimer.ts
@@ -1,10 +1,8 @@
 import { Router } from "express";
-import geoip from "geoip-lite";
 import { createDisclaimerAcceptance } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { extractClientInfo } from "../lib/geo.js";
+import { UUID_RE } from "../lib/validation.js";
 
 export function createDisclaimerRouter(db: SupabaseClient): Router {
   const router = Router();
@@ -22,11 +20,7 @@ export function createDisclaimerRouter(db: SupabaseClient): Router {
     try {
       const { sessionId } = req.body as { sessionId?: unknown };
 
-      const ip =
-        (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ??
-        req.socket.remoteAddress ??
-        "";
-      const geo = geoip.lookup(ip);
+      const clientInfo = extractClientInfo(req);
 
       const validSessionId =
         typeof sessionId === "string" && UUID_RE.test(sessionId)
@@ -35,9 +29,9 @@ export function createDisclaimerRouter(db: SupabaseClient): Router {
 
       try {
         await createDisclaimerAcceptance(db, {
-          client_ip: ip || null,
-          client_geo: geo ? (geo as unknown as Record<string, unknown>) : null,
-          client_user_agent: (req.headers["user-agent"] as string) ?? null,
+          client_ip: clientInfo.ip || null,
+          client_geo: clientInfo.geo ?? null,
+          client_user_agent: clientInfo.userAgent ?? null,
           // session_id left null — backfilled by linkDisclaimerAcceptance() after
           // the first /api/chat call creates the session row.
           session_id: null,

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -4,6 +4,7 @@ import { sendFeedback, sendFeedbackBatch } from "@ai-tutor/email";
 import type { BatchFeedbackItem } from "@ai-tutor/email";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { EmailConfig } from "./sessions.js";
+import { UUID_RE } from "../lib/validation.js";
 
 export function createFeedbackRouter(
   db: SupabaseClient,
@@ -87,8 +88,6 @@ export function createFeedbackRouter(
         res.status(400).json({ error: "items must be a non-empty array." });
         return;
       }
-
-      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
       const inserts = (items as Array<{ msgId?: unknown; msgText?: unknown; category?: unknown; sentiment?: unknown; rating?: unknown }>)
         .filter(item => typeof item === "object" && item !== null)

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -39,7 +39,8 @@ export function createSessionsRouter(
    * DELETE /api/sessions/:sessionId
    *
    * Ends a session: sends the transcript email (if not already sent), removes
-   * the in-memory session, and deletes the database row.
+   * the in-memory session, and marks the session as ended in the database
+   * (sets ended_at); session data is retained for analysis.
    */
   router.delete("/:sessionId", async (req, res, next) => {
     try {

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,5 +1,7 @@
 # @ai-tutor/ios
 
+> **Status: Placeholder.**  No Swift code exists yet.  This directory reserves the `apps/ios` slot in the monorepo.  See the project roadmap in the root README for timeline.
+
 Native iOS client for the AI Tutor.  Swift/SwiftUI app that connects to the existing API server — no AI logic runs on device.
 
 ## Overview

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -1008,11 +1008,10 @@
   let endAvailable      = false;
   let sessionEnded      = false;
   let inactivityTimer   = null;
-  let appConfig         = { model: '', extendedThinking: false };
+  let appConfig         = { model: '', extendedThinking: false, inactivityMs: 600000 };
   let msgCounter        = 0;
   let fbRatings         = new Map(); // Map<msgId, Map<category, 'up'|'down'>>
 
-  const INACTIVITY_MS  = 10 * 60 * 1000;
   const END_SENTINEL   = '[END_SESSION_AVAILABLE]';
   const MAX_FILES      = 5;
   const MAX_FILE_BYTES = 10 * 1024 * 1024;
@@ -1288,7 +1287,7 @@
   function resetInactivityTimer() {
     if (inactivityTimer) clearTimeout(inactivityTimer);
     if (sessionEnded) return;
-    inactivityTimer = setTimeout(onInactivityTimeout, INACTIVITY_MS);
+    inactivityTimer = setTimeout(onInactivityTimeout, appConfig.inactivityMs);
   }
 
   async function onInactivityTimeout() {

--- a/examples/physics-geometry-9th-grade.md
+++ b/examples/physics-geometry-9th-grade.md
@@ -32,6 +32,8 @@ You are a tutor for a 9th-grade student working through physics and geometry hom
 
 6. **Give feedback at each step, not just the end.**  When she's walking through her process, confirm or redirect at each step.  Don't listen to the whole chain silently and then deliver a diagnosis.  A quick "right" or "that step's solid" after each correct move keeps her confident and tells her exactly where things went wrong when you do redirect.  Vary your language — "that's it," "solid," "right, and that's the hard part" — and don't praise effort when the answer is wrong.
 
+7. **Signal when she's done.**  When the student has arrived at the correct answer through her own reasoning and you've confirmed it, append `[END_SESSION_AVAILABLE]` at the very end of your final confirmation message — after your response text, on its own line.  This is a machine-readable signal, not something to explain to the student.  Only emit it when the problem is fully and correctly resolved, not when she's partially there or when you're suggesting she check her work.
+
 ## What good judgment looks like
 
 **She submitted a wrong answer:**

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -32,7 +32,7 @@ Throws if either env var is missing.
 ### Sessions
 
 ```typescript
-import { createSession, getSession, updateSession, deleteSession } from "@ai-tutor/db";
+import { createSession, getSession, updateSession, markSessionEnded } from "@ai-tutor/db";
 ```
 
 #### `createSession(client, insert): Promise<DbSession>`
@@ -63,16 +63,16 @@ await updateSession(db, sessionId, {
 });
 ```
 
-#### `deleteSession(client, id): Promise<void>`
+#### `markSessionEnded(client, id): Promise<void>`
 
-Deletes session by ID.  Cascades to `messages` and `feedback`.
+Sets `ended_at` to now.  Session data (messages, feedback) is retained for analysis.
 
 ---
 
 ### Messages
 
 ```typescript
-import { createMessage, getMessagesBySession, deleteMessagesBySession } from "@ai-tutor/db";
+import { createMessage, getMessagesBySession } from "@ai-tutor/db";
 ```
 
 #### `createMessage(client, insert): Promise<DbMessage>`
@@ -91,10 +91,6 @@ await createMessage(db, {
 #### `getMessagesBySession(client, sessionId): Promise<DbMessage[]>`
 
 Returns all messages for a session, ordered by `created_at` ascending.
-
-#### `deleteMessagesBySession(client, sessionId): Promise<void>`
-
-Deletes all messages for a session (rarely needed directly — `deleteSession` cascades).
 
 ---
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,10 @@
 export { createSupabaseClient } from "./client.js";
 
-export { createSession, getSession, updateSession, markSessionEnded, deleteSession } from "./sessions.js";
+export { createSession, getSession, updateSession, markSessionEnded } from "./sessions.js";
 
 export {
   createMessage,
   getMessagesBySession,
-  deleteMessagesBySession,
 } from "./messages.js";
 
 export { createFeedback, createFeedbackBatch, getFeedbackBySession } from "./feedback.js";

--- a/packages/db/src/messages.ts
+++ b/packages/db/src/messages.ts
@@ -42,16 +42,3 @@ export async function getMessagesBySession(
   if (error) throw new Error(`getMessagesBySession: ${error.message}`);
   return data ?? [];
 }
-
-/** Delete all messages for a session (used when resetting a session). */
-export async function deleteMessagesBySession(
-  client: SupabaseClient,
-  sessionId: string
-): Promise<void> {
-  const { error } = await client
-    .from("messages")
-    .delete()
-    .eq("session_id", sessionId);
-
-  if (error) throw new Error(`deleteMessagesBySession: ${error.message}`);
-}

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -70,12 +70,3 @@ export async function markSessionEnded(
     .eq("id", id);
   if (error) throw new Error(`markSessionEnded: ${error.message}`);
 }
-
-/** Hard-delete a session and all its cascade-dependent rows. For admin use only. */
-export async function deleteSession(
-  client: SupabaseClient,
-  id: string
-): Promise<void> {
-  const { error } = await client.from("sessions").delete().eq("id", id);
-  if (error) throw new Error(`deleteSession: ${error.message}`);
-}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Database row types — manually maintained to match supabase/migrations/001_initial_schema.sql.
+ * Database row types — manually maintained to match the full migration set in supabase/migrations/.
  *
  * Do not add auth-related tables here.  RLS policies are not applied in this
  * project; the service-role key is used for all server-side queries.

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -49,6 +49,12 @@ function formatTokens(usage: { inputTokens: number; outputTokens: number }): str
   return `${usage.inputTokens.toLocaleString()} in / ${usage.outputTokens.toLocaleString()} out (${total.toLocaleString()} total)`;
 }
 
+function formatGeo(geo: Record<string, unknown> | null | undefined): string {
+  if (!geo) return "unknown";
+  const parts = [geo.city, geo.region, geo.country].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : "unknown";
+}
+
 function buildHtml(payload: TranscriptEmailPayload): string {
   const { transcript, files, clientInfo, startedAt, durationMs, sessionId, tokenUsage } = payload;
 
@@ -87,7 +93,7 @@ function buildHtml(payload: TranscriptEmailPayload): string {
     <tr><td style="padding:6px 0;color:#555;">Exchanges</td><td>${exchangeCount}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Tokens</td><td>${tokenUsage ? formatTokens(tokenUsage) : "N/A"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">IP</td><td>${clientInfo.ip ?? "unknown"}</td></tr>
-    <tr><td style="padding:6px 0;color:#555;">Location</td><td>${clientInfo.geo ? JSON.stringify(clientInfo.geo) : "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Location</td><td>${formatGeo(clientInfo.geo)}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">User agent</td><td style="font-size:0.85em;">${clientInfo.userAgent ?? "unknown"}</td></tr>
   </table>
   <h2 style="font-size:1.1rem;">Uploaded files</h2>

--- a/templates/tutor-prompt.md
+++ b/templates/tutor-prompt.md
@@ -45,6 +45,8 @@ You are a tutor for a {GRADE_LEVEL} student working through {SUBJECTS} homework.
 
 6. **Give feedback at each step, not just the end.**  When she's walking through her process, confirm or redirect at each step.  Don't listen to the whole chain silently and then deliver a diagnosis.  A quick "right" or "that step's solid" after each correct move keeps her confident and tells her exactly where things went wrong when you do redirect.  Vary your language — "that's it," "solid," "right, and that's the hard part" — and don't praise effort when the answer is wrong.
 
+7. **Signal when she's done.**  When the student has arrived at the correct answer through her own reasoning and you've confirmed it, append `[END_SESSION_AVAILABLE]` at the very end of your final confirmation message — after your response text, on its own line.  This is a machine-readable signal, not something to explain to the student.  Only emit it when the problem is fully and correctly resolved, not when she's partially there or when you're suggesting she check her work.
+
 ## What good judgment looks like
 
 **She submitted a wrong answer:**


### PR DESCRIPTION
## Summary

- Fix 3 stale inline comments (`sessions.ts`, `chat.ts`, `db/types.ts`)
- Remove 2 dead exports: `deleteSession()` and `deleteMessagesBySession()`
- Error handler returns generic 5xx message; logs real error server-side only
- Extract shared IP/geo helper to `apps/api/src/lib/geo.ts`
- Extract shared UUID regex to `apps/api/src/lib/validation.ts`
- Fix transcript email geo display: `JSON.stringify` → `"City, Region, Country"` format
- Centralize `INACTIVITY_MS`: server owns the value, frontend reads it from `/api/config`
- Activate `END_SENTINEL`: add principle 7 to tutor prompt and example file so the model emits `[END_SESSION_AVAILABLE]` when a problem is fully resolved
- Add placeholder status note to `apps/ios/README.md`

## Test plan

- [ ] `npm run build` passes from repo root (verified locally)
- [ ] `GET /api/config` returns `{ model, extendedThinking, inactivityMs: 600000 }`
- [ ] Transcript email shows geo as `"New York, NY, US"` not raw JSON
- [ ] 5xx errors return `{ error: "An unexpected error occurred." }` (real message in server log)
- [ ] `@ai-tutor/db` no longer exports `deleteSession` or `deleteMessagesBySession`

🤖 Generated with [Claude Code](https://claude.ai/code)