### PR TITLE
Move gallery pane to right side and add hover-to-zoom on images

### DIFF
--- a/apps/web/public/gallery.css
+++ b/apps/web/public/gallery.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   background: var(--surface);
-  border-right: 1px solid var(--border);
+  border-left: 1px solid var(--border);
   transition: width 0.25s ease;
 }
 
@@ -46,13 +46,30 @@
   gap: 10px;
 }
 
-.gallery-focused img {
+/* ── Zoom wrapper (wraps focused image for hover-to-zoom) ──────────────── */
+.gallery-zoom-wrap {
+  position: relative;
   max-width: 100%;
   max-height: calc(100% - 32px);
-  object-fit: contain;
+  overflow: hidden;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
+  cursor: zoom-in;
+}
+
+.gallery-zoom-wrap img {
   display: block;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.gallery-zoom-wrap.zooming img {
+  opacity: 0;
+}
+
+.gallery-zoom-wrap.zooming {
+  background-repeat: no-repeat;
 }
 
 .gallery-pdf-placeholder {
@@ -200,14 +217,14 @@
 @media (max-width: 768px) {
   .gallery-pane {
     position: fixed;
-    left: 0;
+    right: 0;
     top: 0;
     height: 100%;
     width: 300px !important;
     z-index: 50;
-    transform: translateX(-100%);
+    transform: translateX(100%);
     transition: transform 0.25s ease;
-    border-right: 1px solid var(--border-bright);
+    border-left: 1px solid var(--border-bright);
     box-shadow: var(--shadow-md);
   }
 

--- a/apps/web/public/gallery.js
+++ b/apps/web/public/gallery.js
@@ -4,6 +4,9 @@
 //                  focusUpload, addToGallery, resetGallery
 
 (function () {
+  var ZOOM_SCALE = 250; // background-size percentage for hover zoom
+  var supportsHover = window.matchMedia('(hover: hover)').matches;
+
   let galleryOpen = false;
 
   // DOM refs — resolved after DOMContentLoaded
@@ -47,10 +50,35 @@
     if (!entry) return;
 
     if (entry.mimeType.startsWith('image/') && entry.blobUrl) {
+      const wrap = document.createElement('div');
+      wrap.className = 'gallery-zoom-wrap';
+
       const img = document.createElement('img');
       img.src = entry.blobUrl;
       img.alt = entry.name;
-      galleryFocused.appendChild(img);
+      wrap.appendChild(img);
+
+      if (supportsHover) {
+        wrap.addEventListener('mouseenter', function () {
+          wrap.style.backgroundImage = 'url(' + entry.blobUrl + ')';
+          wrap.style.backgroundSize = ZOOM_SCALE + '%';
+          wrap.classList.add('zooming');
+        });
+        wrap.addEventListener('mousemove', function (e) {
+          var rect = wrap.getBoundingClientRect();
+          var x = ((e.clientX - rect.left) / rect.width) * 100;
+          var y = ((e.clientY - rect.top) / rect.height) * 100;
+          wrap.style.backgroundPosition = x + '% ' + y + '%';
+        });
+        wrap.addEventListener('mouseleave', function () {
+          wrap.classList.remove('zooming');
+          wrap.style.backgroundImage = '';
+          wrap.style.backgroundSize = '';
+          wrap.style.backgroundPosition = '';
+        });
+      }
+
+      galleryFocused.appendChild(wrap);
 
       const label = document.createElement('div');
       label.className = 'gallery-filename';

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -57,19 +57,6 @@
   <!-- ── Main ───────────────────────────────────────────────────────────── -->
   <main>
 
-    <!-- Gallery pane -->
-    <aside id="gallery-pane" class="gallery-pane">
-      <div class="gallery-header">
-        <h2 class="gallery-title">Uploads</h2>
-        <button class="btn btn-icon btn-sm" id="btn-gallery-close" title="Close gallery">✕</button>
-      </div>
-      <div class="gallery-focused" id="gallery-focused">
-        <div class="gallery-empty-state">No uploads yet</div>
-      </div>
-      <div class="gallery-thumbs" id="gallery-thumbs"></div>
-    </aside>
-    <div class="gallery-backdrop" id="gallery-backdrop"></div>
-
     <div class="chat-column">
     <div id="chat-container">
       <div id="chat-area">
@@ -132,6 +119,20 @@
       </div>
     </div>
     </div><!-- /.chat-column -->
+
+    <div class="gallery-backdrop" id="gallery-backdrop"></div>
+
+    <!-- Gallery pane -->
+    <aside id="gallery-pane" class="gallery-pane">
+      <div class="gallery-header">
+        <h2 class="gallery-title">Uploads</h2>
+        <button class="btn btn-icon btn-sm" id="btn-gallery-close" title="Close gallery">✕</button>
+      </div>
+      <div class="gallery-focused" id="gallery-focused">
+        <div class="gallery-empty-state">No uploads yet</div>
+      </div>
+      <div class="gallery-thumbs" id="gallery-thumbs"></div>
+    </aside>
   </main>
 
   <!-- ── Transcript modal ────────────────────────────────────────────────── -->


### PR DESCRIPTION
Gallery panel now opens on the right of the chat column instead of the left. Focused images support a hover-to-zoom effect (2.5x magnification) that tracks cursor position — gated by `(hover: hover)` media query so touch devices are unaffected. Mobile drawer slides from the right edge.

https://claude.ai/code/session_014uAyQBgNo85V2LGXr6Winf