### PR TITLE
Add iOS Safari web app standalone mode and viewport stability fix

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -857,3 +857,51 @@
     disclaimerOverlay.classList.remove('active');
   }
   msgInput.focus();
+
+  // ── iOS viewport stability ────────────────────────────────────────────────
+  // Uses the visualViewport API to set a reliable --vh custom property that
+  // tracks the actual usable viewport height (accounts for iOS keyboard and
+  // dynamic toolbar). Also resets scroll position to prevent layout drift.
+  (function () {
+    if (!window.visualViewport) return;
+
+    function onViewportResize() {
+      document.documentElement.style.setProperty(
+        '--vh', window.visualViewport.height + 'px'
+      );
+      window.scrollTo(0, 0);
+    }
+
+    window.visualViewport.addEventListener('resize', onViewportResize);
+    onViewportResize();
+  })();
+
+  // ── iOS Add-to-Home-Screen prompt ─────────────────────────────────────────
+  (function () {
+    var isIOS = /iP(hone|od)/.test(navigator.userAgent) ||
+      (navigator.userAgent.includes('Macintosh') && navigator.maxTouchPoints > 1);
+    var isStandalone = window.navigator.standalone === true ||
+      window.matchMedia('(display-mode: standalone)').matches;
+
+    if (!isIOS || isStandalone || localStorage.getItem('a2hs-dismissed')) return;
+
+    var banner = document.getElementById('a2hs-banner');
+    var btnClose = document.getElementById('btn-a2hs-close');
+    if (!banner || !btnClose) return;
+
+    function tryShow() {
+      var accessWall = document.getElementById('disclaimer-overlay');
+      if (accessWall && accessWall.classList.contains('active')) {
+        setTimeout(tryShow, 1000);
+        return;
+      }
+      banner.style.display = '';
+    }
+
+    setTimeout(tryShow, 2000);
+
+    btnClose.addEventListener('click', function () {
+      banner.style.display = 'none';
+      localStorage.setItem('a2hs-dismissed', '1');
+    });
+  })();

--- a/apps/web/public/gallery.js
+++ b/apps/web/public/gallery.js
@@ -48,6 +48,9 @@
     galleryBackdrop.classList.remove('active');
     if (galleryResizer) galleryResizer.classList.remove('active');
     galleryOpen = false;
+    // Reset scroll position to prevent iOS Safari layout drift after
+    // the fixed-position backdrop is removed.
+    window.scrollTo(0, 0);
   };
 
   window.isGalleryOpen = function () {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -2,8 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Axiom AI Tutor</title>
+
+  <!-- PWA / iOS standalone -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="Axiom">
+  <meta name="theme-color" content="#0f1117">
+  <link rel="manifest" href="/manifest.json">
 
   <!-- KaTeX -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous">
@@ -191,6 +198,22 @@
       <div class="disclaimer-foot">
         <button class="btn btn-primary btn-sm" id="btn-disclaimer-ok">Get started</button>
       </div>
+    </div>
+  </div>
+
+  <!-- ── Add to Home Screen banner (iOS) ─────────────────────────────────── -->
+  <div id="a2hs-banner" style="display:none">
+    <div class="a2hs-content">
+      <p class="a2hs-text">
+        Install this app: tap
+        <svg class="a2hs-share-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+          <path d="M4 12v7a2 2 0 002 2h12a2 2 0 002-2v-7"/>
+          <polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/>
+        </svg>
+        then <strong>Add to Home Screen</strong>
+      </p>
+      <button class="btn btn-sm" id="btn-a2hs-close">Got it</button>
     </div>
   </div>
 

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Axiom AI Tutor",
+  "short_name": "Axiom",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f1117",
+  "theme_color": "#0f1117",
+  "icons": []
+}

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -49,7 +49,7 @@
     body {
       display: flex;
       flex-direction: column;
-      height: 100dvh;
+      height: var(--vh, 100dvh);
       overflow: hidden;
     }
 
@@ -730,6 +730,57 @@
       white-space: nowrap;
     }
     #toast.show { opacity: 1; }
+
+    /* ── Add-to-Home-Screen banner (iOS) ──────────────────────────────────── */
+    #a2hs-banner {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 90;
+      background: var(--surface-alt);
+      border-top: 1px solid var(--border-bright);
+      padding: 12px 16px;
+      animation: a2hs-slide-up 0.3s ease-out;
+    }
+    .a2hs-content {
+      max-width: 600px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .a2hs-text {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex-wrap: wrap;
+      margin: 0;
+    }
+    .a2hs-text strong { color: var(--text); }
+    .a2hs-share-icon {
+      vertical-align: middle;
+      color: var(--accent);
+      flex-shrink: 0;
+    }
+    @keyframes a2hs-slide-up {
+      from { transform: translateY(100%); }
+      to   { transform: translateY(0); }
+    }
+
+    /* ── Standalone mode (launched from home screen) ──────────────────────── */
+    @media (display-mode: standalone) {
+      body {
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: env(safe-area-inset-bottom);
+        padding-left: env(safe-area-inset-left);
+        padding-right: env(safe-area-inset-right);
+      }
+    }
 
     /* ── Responsive ────────────────────────────────────────────────────────── */
     @media (max-width: 600px) {


### PR DESCRIPTION
- Add web app manifest and apple-mobile-web-app meta tags for standalone mode
- Add A2HS banner prompting iOS Safari users to add site to home screen
- Fix iOS Safari viewport instability using visualViewport API (--vh custom property)
- Add scroll reset in closeGallery() to prevent layout drift on iOS
- Add safe-area inset padding for standalone mode (notch/dynamic island)
- Add viewport-fit=cover to viewport meta tag

https://claude.ai/code/session_01QVvx6uidfJS8Dbm8fJJwLK