### PR TITLE
Fix code review findings: remove sentinel instruction, clean stale comments

### DIFF
--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Database row types — manually maintained to match the full migration set in supabase/migrations/.
+ * Database row types — manually maintained to match supabase/migrations/000_schema.sql.
  *
  * Do not add auth-related tables here.  RLS policies are not applied in this
  * project; the service-role key is used for all server-side queries.
@@ -18,9 +18,9 @@ export interface DbSession {
   total_input_tokens: number;
   /** Cumulative output tokens across all turns in this session. */
   total_output_tokens: number;
-  /** Claude model ID used for this session (e.g. "claude-sonnet-4-6"). Added in migration 012. */
+  /** Claude model ID used for this session (e.g. "claude-sonnet-4-6"). Set on first message. */
   model: string | null;
-  /** Tutor prompt name used for this session (e.g. "tutor-prompt-v7"). Added in migration 012. */
+  /** Tutor prompt filename stem used for this session (e.g. "tutor-prompt-v7"). Set on first message. */
   prompt_name: string | null;
 }
 
@@ -33,9 +33,9 @@ export interface DbMessage {
   content: string;
   /** Serialized thinking blocks for analysis.  Null when extended thinking is off. */
   thinking: string | null;
-  /** Input tokens consumed by this API call.  Null for user messages and legacy rows. */
+  /** Input tokens consumed by this API call.  Null for user messages. */
   input_tokens: number | null;
-  /** Output tokens produced by this API call.  Null for user messages and legacy rows. */
+  /** Output tokens produced by this API call.  Null for user messages. */
   output_tokens: number | null;
   created_at: string;
 }
@@ -124,7 +124,7 @@ export interface DbDisclaimerAcceptance {
   /** The client-generated session UUID stored at acceptance time (no FK).
    *  Used to backfill session_id after the sessions row is created. */
   client_session_id: string | null;
-  /** Email submitted through the access-wall overlay.  Added in migration 011. */
+  /** Email submitted through the access-wall overlay. */
   email: string | null;
 }
 

--- a/templates/tutor-prompt-v6.md
+++ b/templates/tutor-prompt-v6.md
@@ -47,8 +47,6 @@ You are a tutor for a {GRADE_LEVEL} student working through {SUBJECTS} homework.
 
 7. **Reference her uploads by name.**  When you're discussing a specific image or document she uploaded, use the marker `[IMG:filename]` inline in your response — where `filename` matches the name shown in the `[Uploaded files: ...]` line.  This tells the interface to highlight that file so you're both looking at the same thing.  Use it naturally, at the point in your response where the reference is relevant — not at the beginning or end as a formality.  If she uploaded multiple files, reference only the one you're currently discussing.
 
-8. **Signal when she's done.**  When the student has arrived at the correct answer through her own reasoning and you've confirmed it, append `[END_SESSION_AVAILABLE]` at the very end of your final confirmation message — after your response text, on its own line.  This is a machine-readable signal, not something to explain to the student.  Only emit it when the problem is fully and correctly resolved, not when she's partially there or when you're suggesting she check her work.
-
 ## What good judgment looks like
 
 **She submitted a wrong answer:**

--- a/templates/tutor-prompt-v7.md
+++ b/templates/tutor-prompt-v7.md
@@ -127,11 +127,6 @@ Don't let "right" become a reflex.
 
 **Reference uploaded images by filename** using the format `[IMG:filename]`.
 
-**Signal when the problem is fully resolved** by appending `[END_SESSION_AVAILABLE]` on
-its own line at the very end of your message.  Only emit this when the problem is fully and
-correctly resolved.  If the student declares they're done and moves on, follow them — don't
-hold the signal hostage to your own verification.
-
 -----
 
 ## What good judgment looks like


### PR DESCRIPTION
## Summary

Follow-up to #36 — addresses two issues found during code review.

- **Remove `[END_SESSION_AVAILABLE]` sentinel instruction** from tutor-prompt-v7.md (line 130-133) and tutor-prompt-v6.md (line 50). PR #36 removed the frontend code that stripped this sentinel, but left the prompt instruction — meaning the model would emit `[END_SESSION_AVAILABLE]` as visible text in student chat messages. Session end is handled by the header button and inactivity timeout.
- **Fix stale JSDoc comments** in packages/db/src/types.ts: update file-level comment to reference `000_schema.sql`, remove "Added in migration 012/011" notes from fields whose migrations were deleted, remove "and legacy rows" phrasing that was cleaned up in CLAUDE.md but missed here.

## Test plan

- [x] `npm run build` passes
- [x] Grep confirms no `END_SESSION_AVAILABLE` references remain in active code (only in historical audit report and protected example file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)