### PR TITLE
Add global system instructions, fix sentinel for non-problem sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,14 @@ Event types:
 - `{ type: "message_stop", messageId: "<uuid or null>", tokenUsage: { inputTokens: N, outputTokens: N } }` — signals end of response; `messageId` is the DB UUID of the persisted assistant message, or `null` if DB persistence failed
 - `{ type: "error", message: "..." }` — on failure
 
+### End-of-session sentinel
+
+The model appends `[END_SESSION_AVAILABLE]` on its own line when a conversation reaches a natural end.  The instruction lives in `templates/system-instructions.md` (appended to every prompt at load time), not in individual tutor prompts.  The frontend (`apps/web/public/app.js`) detects the sentinel during SSE streaming, strips it before display, and shows a green banner (`#end-banner`) suggesting the student end the session.  The `endAvailable` flag prevents re-triggering.
+
+### Global system instructions
+
+`templates/system-instructions.md` contains protocol-level instructions appended to every tutor prompt by `loadSystemPrompt()`.  These are system/frontend contracts (sentinel token, image-ref format) — not tutoring methodology.  Tutor prompts should not duplicate these instructions.
+
 ### In-memory session store + database
 
 Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — running an automated evaluation, recording a `source: 'timeout'` feedback row if none exists, sending an email transcript (including evaluation and feedback), and marking the session ended in the DB.  When a session is explicitly ended via `DELETE /api/sessions/:id`, the same evaluation + feedback fetch happens before the transcript email is sent.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.
@@ -411,6 +419,7 @@ These apply to every Claude Code session in this repo.
 | `supabase/migrations/000_schema.sql` | Consolidated database schema (sessions, messages, session_feedback, session_evaluations, disclaimer_acceptances) |
 | `templates/tutor-prompt-v7.md` | Production tutor prompt — current version; loaded at runtime via `SYSTEM_PROMPT_PATH` |
 | `templates/tutor-prompt-v6.md` | Tutor prompt v6 — retained as rollback target |
+| `templates/system-instructions.md` | Global system instructions appended to every tutor prompt at load time (sentinel token, image-ref format) |
 | `templates/evaluation-checklist.md` | Manual scoring rubric for test evaluation (v6-era; automated evaluation now uses `packages/core/src/evaluation-prompt.md`) |
 | `examples/physics-geometry-9th-grade-v6.md` | Physics & geometry example prompt v6 — retained as rollback reference |
 | `tests/README.md` | Test harness usage guide |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -40,7 +40,7 @@ const promptMap = new Map<string, string>();
 for (const file of fs.readdirSync(templatesDir)) {
   if (file.startsWith("tutor-prompt-") && file.endsWith(".md")) {
     const name = file.replace(/\.md$/, "");
-    promptMap.set(name, fs.readFileSync(path.join(templatesDir, file), "utf-8"));
+    promptMap.set(name, loadSystemPrompt(path.join(templatesDir, file)));
   }
 }
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -52,6 +52,7 @@ Loaded via `<script>` and `<link>` tags in `index.html` — no npm install neede
 | Tutor image references | When the tutor response contains `[IMG:filename.ext]`, it renders as a clickable pill that opens the gallery focused on that file |
 | Transcript viewer | Modal with copy-to-clipboard |
 | Inactivity timeout | Auto-ends session after 10 minutes idle; triggers transcript email |
+| End-session banner | When the tutor resolves a problem or finishes a question, a green banner suggests ending the session; driven by `[END_SESSION_AVAILABLE]` sentinel in `templates/system-instructions.md` |
 | Session feedback | Session-level outcome, experience, and comment collected at session end. |
 | New session | One-click reset with automatic prior session cleanup (`DELETE /api/sessions/:id`) |
 | Model indicator | Shows current model and extended thinking status (from `/api/config`) |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,7 +43,7 @@ import { loadSystemPrompt } from "@ai-tutor/core";
 const prompt = loadSystemPrompt(config.systemPromptPath);
 ```
 
-Loads a prompt file from the repo root (synchronous).  Strips everything above the `## Begin prompt` marker (documentation/comments above that line are ignored).  Resolves the repo root by walking up the directory tree looking for a `package.json` with `"workspaces"`.  Exits the process if the file cannot be read.
+Loads a prompt file from the repo root (synchronous).  Strips everything above the `## Begin prompt` marker (documentation/comments above that line are ignored).  Appends global system instructions from `templates/system-instructions.md` if the file exists.  Resolves the repo root by walking up the directory tree looking for a `package.json` with `"workspaces"`.  Exits the process if the file cannot be read.
 
 ---
 

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { loadSystemPrompt } from "./prompt-loader.js";
+import { loadPromptFile } from "./prompt-loader.js";
 
 /** Load the evaluation prompt from the co-located .md file (single source of truth). */
-const EVALUATION_PROMPT = loadSystemPrompt("packages/core/src/evaluation-prompt.md");
+const EVALUATION_PROMPT = loadPromptFile("packages/core/src/evaluation-prompt.md");
 
 export interface EvaluationResult {
   model: string;

--- a/packages/core/src/prompt-loader.ts
+++ b/packages/core/src/prompt-loader.ts
@@ -33,14 +33,28 @@ function findRepoRoot(): string {
 
 const repoRoot = findRepoRoot();
 
+const SYSTEM_INSTRUCTIONS_PATH = resolve(repoRoot, "templates/system-instructions.md");
+
+/** Cached system instructions content, loaded once at module init. */
+let systemInstructionsCache: string | null = null;
+try {
+  systemInstructionsCache = readFileSync(SYSTEM_INSTRUCTIONS_PATH, "utf-8");
+} catch {
+  console.warn(
+    "Warning: templates/system-instructions.md not found — global system instructions will not be appended."
+  );
+}
+
 /**
- * Load a system prompt from a file.  If the file contains a "## Begin prompt"
- * marker, everything above it is stripped — that section holds template
- * variable documentation, not prompt content.
+ * Load a prompt file, stripping template documentation.  If the file contains
+ * a "## Begin prompt" marker, everything above it is stripped.
+ *
+ * Does NOT append global system instructions — use `loadSystemPrompt()` for
+ * tutor prompts that need them.
  *
  * Paths resolve relative to the repository root unless absolute.
  */
-export function loadSystemPrompt(filePath: string): string {
+export function loadPromptFile(filePath: string): string {
   const resolved = isAbsolute(filePath)
     ? filePath
     : resolve(repoRoot, filePath);
@@ -49,7 +63,7 @@ export function loadSystemPrompt(filePath: string): string {
   try {
     content = readFileSync(resolved, "utf-8");
   } catch {
-    console.error(`Could not read system prompt from ${resolved}`);
+    console.error(`Could not read prompt from ${resolved}`);
     console.error(
       "Set SYSTEM_PROMPT_PATH to the path of your prompt file, relative to the repo root."
     );
@@ -60,6 +74,22 @@ export function loadSystemPrompt(filePath: string): string {
   const beginIndex = content.indexOf(beginMarker);
   if (beginIndex !== -1) {
     content = content.substring(beginIndex + beginMarker.length).trim();
+  }
+
+  return content;
+}
+
+/**
+ * Load a tutor system prompt with global system instructions appended.
+ *
+ * Calls `loadPromptFile()` then appends protocol-level instructions from
+ * `templates/system-instructions.md` (sentinel token, image-ref format).
+ */
+export function loadSystemPrompt(filePath: string): string {
+  let content = loadPromptFile(filePath);
+
+  if (systemInstructionsCache) {
+    content = content + "\n\n-----\n\n" + systemInstructionsCache;
   }
 
   return content;

--- a/reports/code-audit-2026-03-17.md
+++ b/reports/code-audit-2026-03-17.md
@@ -42,12 +42,9 @@ The ai-tutor-toolkit is a well-structured monorepo with strong type safety, cons
 
 ## Important (fix soon)
 
-### 2. `END_SENTINEL` feature is unreachable
+### 2. ~~`END_SENTINEL` feature is unreachable~~ — RESOLVED
 
-- **File:** `apps/web/public/index.html:1016`, `finalizeTutor()` at line 1159
-- **What:** The frontend defines `const END_SENTINEL = '[END_SESSION_AVAILABLE]'` and `finalizeTutor()` checks `rawText.includes(END_SENTINEL)` to show an end-of-session banner.  Neither `templates/tutor-prompt.md` nor `examples/physics-geometry-9th-grade.md` contains this string or instructs the model to emit it.  Unless the model spontaneously generates this exact string, `endAvailable` will never be set to `true` and the end-session banner (driven by `endBanner.classList.add('active')` at line 1173) will never appear.
-- **Why it matters:** The UI has a fully-implemented feature — the end-session banner — that is currently dead code because the prompt side was never connected.  A future contributor may not realize this is intentional versus a bug.
-- **Fix:** Either (a) add a final section to the tutor prompt instructing the model to append `[END_SESSION_AVAILABLE]` when a problem is fully resolved, or (b) remove the sentinel logic from the frontend if the feature is no longer planned.
+- **Resolved:** 2026-04-04.  The sentinel instruction now lives in `templates/system-instructions.md` (appended to every prompt at load time).  PR #39 restored the frontend detection; this change moved the instruction out of individual prompts into a global file and broadened the trigger to cover all session types (direct questions, conceptual clarifications, not just problem-solving).
 
 ### 3. `deleteSession` exported but never called by any app
 

--- a/templates/system-instructions.md
+++ b/templates/system-instructions.md
@@ -1,0 +1,15 @@
+# System instructions
+
+These instructions apply to every session regardless of the tutor prompt in use.
+
+**Reference uploaded images by filename** using the format `[IMG:filename]` inline in your
+response, at the point where the reference is relevant.
+
+**Signal when the conversation has reached a natural end** by appending
+`[END_SESSION_AVAILABLE]` on its own line at the very end of your message.  Emit this when:
+- A problem is fully and correctly resolved.
+- A direct question or conceptual clarification has been answered and the student has no
+  follow-up (e.g., "just curious," "that's all," "thanks").
+- The student signals they're done, even if you haven't verified their understanding.
+Don't hold the signal hostage to your own closure instinct — if the student is done, you're
+done.

--- a/templates/tutor-prompt-v7.md
+++ b/templates/tutor-prompt-v7.md
@@ -125,13 +125,6 @@ have them apply it.
 move.  Vary your language — "right," "that step's solid," "close — what happens if…"
 Don't let "right" become a reflex.
 
-**Reference uploaded images by filename** using the format `[IMG:filename]`.
-
-**Signal when the problem is fully resolved** by appending `[END_SESSION_AVAILABLE]` on
-its own line at the very end of your message.  Only emit this when the problem is fully and
-correctly resolved.  If the student declares they're done and moves on, follow them — don't
-hold the signal hostage to your own verification.
-
 -----
 
 ## What good judgment looks like


### PR DESCRIPTION
## Summary

- Create `templates/system-instructions.md` with protocol-level instructions (sentinel token, image-ref format) appended to every tutor prompt at load time
- Broaden sentinel trigger from "problem is fully resolved" to cover all session types — fixes sessions where the tutor failed to emit `[END_SESSION_AVAILABLE]` after answering a direct question
- Split `loadPromptFile()` from `loadSystemPrompt()` so the evaluation prompt does not receive tutor-facing system instructions
- Fix prompt discovery in `index.ts` to route through `loadSystemPrompt()` instead of raw `readFileSync` (system instructions were never appended in production)
- Update CLAUDE.md, packages/core/README.md, apps/web/README.md, and audit report

## Test plan

- [ ] `npm run build` passes
- [ ] Start a direct-question session (e.g. "What's 4i equal to?"), answer follow-up with "just curious" — confirm green end-session banner appears
- [ ] Repeat with v6 prompt — confirm sentinel fires via global append
- [ ] Verify evaluation prompt does NOT contain `[END_SESSION_AVAILABLE]` instruction
- [ ] Confirm CLAUDE.md documents sentinel protocol and global system instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)