### PR TITLE
Update CLAUDE.md file-level reference for prompt-loader exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,7 @@ These apply to every Claude Code session in this repo.
 | `docs/archive/` | Archived versions of superseded docs |
 | `docs/deployment.md` | Render, AWS, and local deployment instructions |
 | `packages/core/src/config.ts` | `loadConfig()` — reads and validates all env vars |
-| `packages/core/src/prompt-loader.ts` | `loadSystemPrompt()` — loads prompt file from repo root |
+| `packages/core/src/prompt-loader.ts` | `loadPromptFile()` — loads and strips a prompt file; `loadSystemPrompt()` — wraps `loadPromptFile()` and appends global system instructions |
 | `packages/core/src/tutor-client.ts` | `createTutorClient()` — Anthropic SDK wrapper (streaming + blocking) |
 | `packages/core/src/session.ts` | `Session` class — message history, transcript, file attachments, token usage tracking (`TokenUsage` interface) |
 | `packages/core/src/evaluate-transcript.ts` | Automated transcript evaluation against twelve tutoring dimensions (v7) |


### PR DESCRIPTION
## Summary

- Document both `loadPromptFile()` and `loadSystemPrompt()` in CLAUDE.md's file-level reference table
- Code review finding from PR #41 — the new `loadPromptFile()` export was not reflected in the table

## Test plan

- [ ] Verify CLAUDE.md file-level reference table entry for `packages/core/src/prompt-loader.ts` lists both functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)