### PR TITLE
Fix sentinel triggering too early on first response

### DIFF
--- a/templates/system-instructions.md
+++ b/templates/system-instructions.md
@@ -7,9 +7,12 @@ response, at the point where the reference is relevant.
 
 **Signal when the conversation has reached a natural end** by appending
 `[END_SESSION_AVAILABLE]` on its own line at the very end of your message.  Emit this when:
-- A problem is fully and correctly resolved.
-- A direct question or conceptual clarification has been answered and the student has no
-  follow-up (e.g., "just curious," "that's all," "thanks").
-- The student signals they're done, even if you haven't verified their understanding.
+- A problem is fully and correctly resolved after working through it together.
+- The student explicitly signals they're done (e.g., "thanks," "that's all," "got it,"
+  "just curious") — even if you haven't verified their understanding.
+Never emit the sentinel on your first response.  Wait for at least one student follow-up
+that indicates the conversation has reached its natural end.
+If you believe the conversation may be complete but aren't confident, ask the student
+whether there's anything else — don't emit the sentinel speculatively.
 Don't hold the signal hostage to your own closure instinct — if the student is done, you're
 done.


### PR DESCRIPTION
## Summary
- Tightened end-of-session sentinel conditions in `templates/system-instructions.md` to prevent premature triggering
- The model was emitting `[END_SESSION_AVAILABLE]` after a single exchange (e.g., "What's 4i equal to?") because the "direct question answered" trigger was ambiguous
- Now requires explicit student closure signal, never emits on first response, and asks "anything else?" when uncertain

## Test plan
- [ ] Send a simple question like "What's 4i equal to?" — sentinel should NOT appear on the first response
- [ ] After the tutor answers, student says "thanks" — sentinel should appear
- [ ] Multi-turn problem solving that reaches resolution — sentinel should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)