### PR TITLE
Daily bug sweep: ordering, XSS, timer, CVE fixes (#51)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,6 +89,19 @@ setInterval(() => {
   const now = Date.now();
   for (const [sessionId, session] of getAllSessions()) {
     if (now - session.lastActivityAt.getTime() > INACTIVITY_MS) {
+      // Remove from memory first to prevent the next sweep tick from re-processing.
+      removeSession(sessionId);
+
+      // Shared teardown: mark ended_at in DB and log. Called both from the async
+      // eval/email path (in finally, after the evaluation row is written) and from
+      // the no-email path (immediately, since there is no evaluation to wait for).
+      const finishReap = () => {
+        void markSessionEnded(db, sessionId).catch(err =>
+          console.error(`[sweep] Could not mark session ${sessionId} as ended:`, err)
+        );
+        console.log(`[sweep] Reaped idle session ${sessionId}.`);
+      };
+
       if (!session.emailSent && session.transcript.length > 0) {
         void (async () => {
           try {
@@ -115,14 +128,15 @@ setInterval(() => {
             session.markEmailSent();
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
+          } finally {
+            // Mark ended_at only after evaluation and email have completed (or failed),
+            // so session_evaluations is always written before ended_at is set.
+            finishReap();
           }
         })();
+      } else {
+        finishReap();
       }
-      removeSession(sessionId);
-      void markSessionEnded(db, sessionId).catch(err =>
-        console.error(`[sweep] Could not mark session ${sessionId} as ended:`, err)
-      );
-      console.log(`[sweep] Reaped idle session ${sessionId}.`);
     }
   }
 }, 60 * 1000); // Check every minute.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -56,25 +56,29 @@ export function createSessionsRouter(
       const discard = req.query["discard"] === "true";
       const session = getSession(sessionId);
 
-      if (!discard && session && !session.emailSent && session.transcript.length > 0) {
-        const evalResult = await runSessionEvaluation(db, sessionId, session.transcript);
-        const feedback = await getSessionFeedback(db, sessionId).catch(err => {
-          console.error(`[sessions] Failed to fetch feedback for ${sessionId}:`, err);
-          return null;
-        });
-        const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback);
-        void sendTranscript(emailConfig, payload).then(
-          () => session.markEmailSent(),
-          err => console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err),
-        );
-      }
-
-      removeSession(sessionId);
-
       try {
-        await markSessionEnded(db, sessionId);
-      } catch (err) {
-        console.error("[sessions] Could not mark DB session as ended:", err);
+        if (!discard && session && !session.emailSent && session.transcript.length > 0) {
+          const evalResult = await runSessionEvaluation(db, sessionId, session.transcript);
+          const feedback = await getSessionFeedback(db, sessionId).catch(err => {
+            console.error(`[sessions] Failed to fetch feedback for ${sessionId}:`, err);
+            return null;
+          });
+          const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback);
+          try {
+            await sendTranscript(emailConfig, payload);
+            session.markEmailSent();
+          } catch (err) {
+            console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err);
+          }
+        }
+      } finally {
+        // Always clean up — even if eval or email throws unexpectedly.
+        removeSession(sessionId);
+        try {
+          await markSessionEnded(db, sessionId);
+        } catch (err) {
+          console.error("[sessions] Could not mark DB session as ended:", err);
+        }
       }
 
       res.json({ ok: true });

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -258,9 +258,13 @@
     // Replace [IMG:...] markers before markdown parse
     const withRefs = parseImgRefs(clean);
 
-    // Render markdown (marked is defer-loaded; should be ready by first message)
-    const html = (typeof marked !== 'undefined')
-      ? marked.parse(withRefs)
+    // Render markdown then sanitize with DOMPurify before assigning to innerHTML.
+    // DOMPurify is required — if it hasn't loaded (CDN blocked/slow), fall back to
+    // plain-text rendering rather than passing unsanitized HTML to innerHTML.
+    // ADD_ATTR: tabindex is not in DOMPurify's default allow-list; data-upload-id
+    // is allowed by default via ALLOW_DATA_ATTR but listed explicitly for clarity.
+    const html = (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined')
+      ? DOMPurify.sanitize(marked.parse(withRefs), { ADD_ATTR: ['data-upload-id', 'tabindex'] })
       : `<p>${escHtml(withRefs)}</p>`;
 
     entry.bubbleEl.innerHTML = html;
@@ -398,8 +402,8 @@
         }
       }
 
-      // Fallback: finalize if stream ended without message_stop
-      if (rawText && !tutorEntry.bubbleEl.querySelector('p, ul, ol, pre, h1, h2, h3')) {
+      // Fallback: finalize if stream ended without message_stop (handles zero-token case too)
+      if (!tutorEntry.bubbleEl.querySelector('p, ul, ol, pre, h1, h2, h3')) {
         finalizeTutor(tutorEntry, rawText);
       }
 
@@ -494,6 +498,8 @@
 
   /** Reset all session state and UI to a fresh-session starting point. */
   function resetSessionState() {
+    if (inactivityTimer) { clearTimeout(inactivityTimer); inactivityTimer = null; }
+    stopCountdownDisplay();
     sessionId       = crypto.randomUUID();
     msgList         = [];
     for (const u of sessionUploads) {
@@ -537,9 +543,6 @@
     if (msgList.length > 0 && !sessionEnded) {
       void discardSession(sessionId);
     }
-    if (inactivityTimer) clearTimeout(inactivityTimer);
-    stopCountdownDisplay();
-
     resetSessionState();
 
     // Apply the switch.
@@ -727,9 +730,6 @@
     if (msgList.length > 0 && !sessionEnded) {
       await deleteSession(sessionId);
     }
-    if (inactivityTimer) clearTimeout(inactivityTimer);
-    stopCountdownDisplay();
-
     resetSessionState();
     msgInput.focus();
   }

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -20,6 +20,8 @@
 
   <!-- marked -->
   <script defer src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js" crossorigin="anonymous"></script>
+  <!-- DOMPurify: sanitizes marked output before setting innerHTML -->
+  <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.1.5/dist/purify.min.js" crossorigin="anonymous"></script>
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -930,9 +930,9 @@
       }
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/js-beautify/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -1957,9 +1957,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/peberminta": {


### PR DESCRIPTION
* Daily bug sweep: ordering, XSS, timer, CVE fixes

- apps/api/src/index.ts (HIGH): Move markSessionEnded into IIFE finally block so ended_at is stamped after session_evaluations is written, not before. Extract finishReap() helper to eliminate duplicate teardown blocks. Keep removeSession synchronous to block re-processing on the next tick.

- apps/api/src/routes/sessions.ts (MEDIUM): Await sendTranscript in the DELETE handler instead of fire-and-forget; eliminates process-exit email loss and ensures markEmailSent is called before removeSession.

- apps/web/public/app.js + index.html (HIGH): Add DOMPurify 3.1.5 via CDN and sanitize marked.parse() output before assigning to innerHTML, preventing XSS from model-generated HTML via prompt injection. Preserve data-upload-id and tabindex attrs for img-ref pills.

- apps/web/public/app.js (MEDIUM): Clear inactivityTimer and call stopCountdownDisplay inside resetSessionState so all callers are safe; remove now-redundant timer teardown from confirmSwitch and newSession.

- apps/web/public/app.js (LOW): Remove rawText guard from SSE fallback finalizeTutor call so zero-token stream terminations clear the spinner.

- package-lock.json (MEDIUM/HIGH): npm audit fix — brace-expansion 1.1.12→1.1.13, path-to-regexp 0.1.12→0.1.13, lodash 4.17.23→4.18.1.



* Address code review findings: DELETE finally-cleanup, DOMPurify fallback

- sessions.ts: Wrap eval/email block in try/finally so removeSession and markSessionEnded always run even if an unexpected exception propagates, matching the finally-based pattern already used in the inactivity sweep.

- app.js: Remove the unsanitized marked.parse() fallback path. When DOMPurify is unavailable (CDN blocked or slow), fall back to plain-text rendering instead of passing potentially-unsafe HTML to innerHTML. Also simplify the nested ternary to a single condition.



---------