### PR TITLE
Update branch references from main to stage

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,7 +99,7 @@ To confirm the server is healthy, visit `https://your-app-url.onrender.com/api/c
 
 ### Ongoing
 
-- **Auto-deploy:** By default, Render rebuilds and redeploys whenever you push to your main branch.  You can disable this under **Settings → Auto-Deploy**.
+- **Auto-deploy:** By default, Render rebuilds and redeploys whenever you push to your **stage** branch.  You can disable this under **Settings → Auto-Deploy**.
 - **Manual redeploy:** Click **Manual Deploy → Deploy latest commit** from your service's dashboard.
 - **Logs:** Click **Logs** in the left sidebar to see live server output.
 

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: web
     name: ai-tutor
     runtime: node
+    branch: stage
     buildCommand: npm install && npm run build
     startCommand: npm run api
     # All env vars are set in the Render dashboard — no .env files


### PR DESCRIPTION
## Summary
- Updated `docs/deployment.md` to reference `stage` instead of `main` as the deploy branch
- Added explicit `branch: stage` to `render.yaml` so deployment config is self-documenting
- Also updated Claude Code global config and memory files (outside repo) to reflect the new default branch

## Test plan
- [ ] Verify `render.yaml` is valid YAML (`branch: stage` under the service)
- [ ] Verify `docs/deployment.md` line 102 says "stage" not "main"
- [ ] Confirm Render dashboard branch setting matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)