### PR TITLE
Daily bug sweep: UUID validation, streaming guard, feedback dedup, email fallbacks

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -76,7 +76,7 @@ app.use(express.static(path.join(__dirname, "../../web/public")));
 
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db, promptMap, defaultPromptName, config.model));
-app.use("/api/sessions", createSessionsRouter(db, emailConfig));
+app.use("/api/sessions", createSessionsRouter(db, emailConfig, config.model, defaultPromptName));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -22,7 +22,7 @@ const ALLOWED_MIME_TYPES = new Set([
   "application/pdf",
 ]);
 
-import { ALLOWED_MODELS } from "../lib/validation.js";
+import { ALLOWED_MODELS, UUID_RE } from "../lib/validation.js";
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -120,6 +120,11 @@ export function createChatRouter(
 
         if (!sessionId || !message?.trim()) {
           res.status(400).json({ error: "sessionId and message are required." });
+          return;
+        }
+
+        if (!UUID_RE.test(sessionId)) {
+          res.status(400).json({ error: "sessionId must be a valid UUID." });
           return;
         }
 

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { UUID_RE } from "../lib/validation.js";
 
 export function createFeedbackRouter(db: SupabaseClient): Router {
   const router = Router();
@@ -32,6 +33,11 @@ export function createFeedbackRouter(db: SupabaseClient): Router {
 
       if (!sessionId) {
         res.status(400).json({ error: "sessionId is required." });
+        return;
+      }
+
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ error: "sessionId must be a valid UUID." });
         return;
       }
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 import { runSessionEvaluation, buildTranscriptEmailPayload } from "../lib/evaluation.js";
+import { UUID_RE } from "../lib/validation.js";
 
 export interface EmailConfig {
   apiKey: string | undefined;
@@ -17,7 +18,9 @@ export interface EmailConfig {
 
 export function createSessionsRouter(
   db: SupabaseClient,
-  emailConfig: EmailConfig
+  emailConfig: EmailConfig,
+  defaultModel: string,
+  defaultPromptName: string,
 ): Router {
   const router = Router();
 
@@ -29,6 +32,10 @@ export function createSessionsRouter(
   router.get("/:sessionId", async (req, res, next) => {
     try {
       const { sessionId } = req.params;
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ error: "sessionId must be a valid UUID." });
+        return;
+      }
       const row = await getDbSession(db, sessionId);
       if (!row) {
         res.status(404).json({ error: "Session not found." });
@@ -53,6 +60,10 @@ export function createSessionsRouter(
   router.delete("/:sessionId", async (req, res, next) => {
     try {
       const { sessionId } = req.params;
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ error: "sessionId must be a valid UUID." });
+        return;
+      }
       const discard = req.query["discard"] === "true";
       const session = getSession(sessionId);
 
@@ -63,7 +74,7 @@ export function createSessionsRouter(
             console.error(`[sessions] Failed to fetch feedback for ${sessionId}:`, err);
             return null;
           });
-          const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback);
+          const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback, defaultModel, defaultPromptName);
           try {
             await sendTranscript(emailConfig, payload);
             session.markEmailSent();

--- a/apps/api/src/routes/transcript.ts
+++ b/apps/api/src/routes/transcript.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { getMessagesBySession } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession } from "../lib/session-store.js";
+import { UUID_RE } from "../lib/validation.js";
 
 export function createTranscriptRouter(db: SupabaseClient): Router {
   const router = Router();
@@ -18,6 +19,10 @@ export function createTranscriptRouter(db: SupabaseClient): Router {
   router.get("/:sessionId", async (req, res, next) => {
     try {
       const { sessionId } = req.params;
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ error: "sessionId must be a valid UUID." });
+        return;
+      }
       const session = getSession(sessionId);
 
       if (session) {

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -606,7 +606,7 @@
   }
 
   async function onInactivityTimeout() {
-    if (sessionEnded || msgList.length === 0) return;
+    if (sessionEnded || msgList.length === 0 || isStreaming) return;
     sessionEnded = true;
     stopCountdownDisplay();
     endBanner.classList.remove('active');
@@ -655,6 +655,8 @@
   }
 
   async function submitFeedback(skip) {
+    btnFbSubmit.disabled = true;
+    btnFbSkip.disabled   = true;
     fbCard.classList.remove('active');
     inputRow.style.display = '';
 


### PR DESCRIPTION
## Summary

Automated daily bug sweep — 7 fixes across 6 files.

- **UUID validation on all sessionId inputs** (`chat.ts`, `feedback.ts`, `sessions.ts`, `transcript.ts`): Non-UUID strings previously passed through to Supabase, which rejected them with a Postgres type error surfaced as a 500. More critically, non-UUID sessionIds in `POST /api/chat` caused in-memory sessions to be created with all DB writes silently failing — a DoS vector allowing memory exhaustion. All four routes now return 400 immediately.
- **Inactivity timer streaming guard** (`app.js`): `onInactivityTimeout` could fire during an active SSE response (plausible with extended thinking at 10,000 budget tokens), setting `sessionEnded = true` and deleting the session mid-stream. The `finally` block then re-enabled input but all sends were silently dropped. Fixed with an `isStreaming` guard.
- **Feedback double-submit guard** (`app.js`): Rapid double-tap on the feedback overlay (common on mobile with slow networks) caused duplicate feedback POSTs, duplicate session deletions, and a second `newSession()` call that mislinked disclaimer acceptances. Fixed by disabling both buttons synchronously before the first await.
- **Email fallback model/promptName** (`sessions.ts`, `index.ts`): The DELETE handler called `buildTranscriptEmailPayload` without fallback model/promptName arguments, so sessions ended before the first message produced transcript emails showing `undefined` for model and prompt. The inactivity sweep already passed fallbacks correctly; now the DELETE path does too.

## Confirmed bugs (from plan)

| File | Lines | Severity | Root cause |
|---|---|---|---|
| `apps/api/src/routes/chat.ts` | 121-127 | HIGH | No UUID validation on sessionId — memory exhaustion and silent DB failures |
| `apps/web/public/app.js` | 608-616 | HIGH | Inactivity timer fires during active stream — broken UI state |
| `apps/api/src/routes/feedback.ts` | 33-45 | MEDIUM | No UUID validation — DB constraint error surfaces as 500 |
| `apps/api/src/routes/sessions.ts` | 29-57 | MEDIUM | Same UUID gap on GET and DELETE (found during /simplify pass) |
| `apps/api/src/routes/transcript.ts` | 18-20 | MEDIUM | Same UUID gap on GET (found during /simplify pass) |
| `apps/api/src/routes/sessions.ts` | 66 | MEDIUM | DELETE path missing fallback model/promptName in email payload |
| `apps/web/public/app.js` | 657-682 | MEDIUM | Feedback overlay has no double-submit guard |

## Open issues

No open bug-labeled issues on GitHub.

## Test plan

- [ ] `curl -X POST /api/chat -F "sessionId=not-a-uuid" -F "message=test"` → 400
- [ ] `curl -X POST /api/feedback -d '{"sessionId":"bad"}' -H 'Content-Type: application/json'` → 400
- [ ] `curl /api/sessions/not-a-uuid` → 400
- [ ] `curl /api/transcript/not-a-uuid` → 400
- [ ] Set `inactivityMs` to 5s, send a message with extended thinking — confirm timeout does not fire mid-stream
- [ ] On mobile/throttled connection, tap feedback "Skip" twice rapidly — second tap should be a no-op
- [ ] Build: `npm run build` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)