### PR TITLE
Auto-focus passcode input on access wall (#59)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1022,8 +1022,10 @@
   // Show access wall only once per browser session
   if (sessionStorage.getItem('access-granted')) {
     disclaimerOverlay.classList.remove('active');
+    msgInput.focus();
+  } else {
+    accessPasscodeInput.focus();
   }
-  msgInput.focus();
 
   // ── iOS viewport stability ────────────────────────────────────────────────
   var isIOS = /iP(hone|od)/.test(navigator.userAgent) ||


### PR DESCRIPTION
## Summary

- Auto-focus the passcode input field when the access-wall overlay is displayed on first visit, so keyboard users can start typing immediately without clicking
- When `access-granted` is already in `sessionStorage` (return visit), the chat input receives focus as before -- no behavior change

Closes #59

## Test plan

- [ ] Open the app in a fresh browser tab (or clear `sessionStorage`). Verify the passcode input is focused immediately (cursor blinking without any click)
- [ ] Type a passcode and press Enter -- verify the keydown handler fires
- [ ] Complete the full access-wall flow. On next page load, verify the main chat input receives focus
- [ ] Test on iOS Safari: verify the keyboard does not pop up uninvited (iOS ignores programmatic focus not triggered by user gesture)

Generated with [Claude Code](https://claude.com/claude-code)
