### PR TITLE
Daily bug sweep: feedback dedup, email error propagation, timer reset, button state

### DIFF
--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -41,8 +41,6 @@ export function createFeedbackRouter(db: SupabaseClient): Router {
         return;
       }
 
-      // createSessionFeedback returns null on duplicate (UNIQUE constraint on
-      // session_id) — treat as idempotent success.
       await createSessionFeedback(db, {
         session_id: sessionId,
         source: source ?? "student",

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -41,6 +41,8 @@ export function createFeedbackRouter(db: SupabaseClient): Router {
         return;
       }
 
+      // createSessionFeedback returns null on duplicate (UNIQUE constraint on
+      // session_id) — treat as idempotent success.
       await createSessionFeedback(db, {
         session_id: sessionId,
         source: source ?? "student",

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -428,6 +428,7 @@
       isStreaming = false;
       setInputDisabled(false);
       msgInput.focus();
+      resetInactivityTimer();
     }
   }
 
@@ -661,6 +662,8 @@
 
   // ── Feedback card ──────────────────────────────────────────────────────────
   function showFeedbackCard() {
+    btnFbSubmit.disabled = false;
+    btnFbSkip.disabled   = false;
     fbSelections = { outcome: null, experience: null };
     fbComment.value = '';
     fbCard.querySelectorAll('.fb-opt.chosen').forEach(el => el.classList.remove('chosen'));

--- a/packages/db/src/session-feedback.ts
+++ b/packages/db/src/session-feedback.ts
@@ -17,7 +17,7 @@ export async function createSessionFeedback(
     .single();
 
   // Postgres unique-violation: a feedback row already exists for this session.
-  if ((error as { code?: string } | null)?.code === '23505') return null;
+  if (error?.code === '23505') return null;
   return assertRow(data, error, "createSessionFeedback");
 }
 

--- a/packages/db/src/session-feedback.ts
+++ b/packages/db/src/session-feedback.ts
@@ -2,17 +2,22 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { DbSessionFeedback, DbSessionFeedbackInsert } from "./types.js";
 import { assertRow } from "./assert.js";
 
-/** Insert a session_feedback row and return it. */
+/**
+ * Insert a session_feedback row and return it.
+ * Returns null if a row already exists for this session_id (idempotent).
+ */
 export async function createSessionFeedback(
   client: SupabaseClient,
   insert: DbSessionFeedbackInsert
-): Promise<DbSessionFeedback> {
+): Promise<DbSessionFeedback | null> {
   const { data, error } = await client
     .from("session_feedback")
     .insert(insert)
     .select()
     .single();
 
+  // Postgres unique-violation: a feedback row already exists for this session.
+  if ((error as { code?: string } | null)?.code === '23505') return null;
   return assertRow(data, error, "createSessionFeedback");
 }
 

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -241,8 +241,9 @@ function buildHtml(payload: TranscriptEmailPayload): string {
 /**
  * Send the session transcript email via Resend.
  *
- * Fails silently — logs warnings but never throws.  A failed email must not
- * crash the API server or disrupt the student's session.
+ * @throws {Error} if the Resend API returns an error or the network call fails.
+ * Callers are responsible for catching and logging; callers must NOT mark the
+ * email as sent unless this function returns without throwing.
  *
  * File attachments are included unless the combined size exceeds Resend's
  * 40 MB limit, in which case attachments are skipped and the omission is
@@ -283,21 +284,23 @@ export async function sendTranscript(
     );
   }
 
+  let result;
   try {
-    const result = await resend.emails.send({
+    result = await resend.emails.send({
       from: config.from,
       to: config.to,
       subject: `Tutor session — ${formatDate(payload.startedAt)}`,
       html: buildHtml(payload),
       attachments,
     });
-
-    if (result.error) {
-      console.error("[email] Resend API error:", result.error);
-    } else {
-      console.log(`[email] Transcript sent (id: ${result.data?.id}).`);
-    }
   } catch (err) {
     console.error("[email] Unexpected error sending transcript:", err);
+    throw err;
   }
+
+  if (result.error) {
+    console.error("[email] Resend API error:", result.error);
+    throw new Error(`Resend API error: ${result.error.message}`);
+  }
+  console.log(`[email] Transcript sent (id: ${result.data?.id}).`);
 }


### PR DESCRIPTION
## Summary

Automated daily bug sweep — four bugs fixed across three files.

## Confirmed bugs fixed

### MEDIUM — `POST /api/feedback` returns 500 on duplicate submission
- **File**: `packages/db/src/session-feedback.ts`, `apps/api/src/routes/feedback.ts`
- **Root cause**: `createSessionFeedback` threw on Postgres unique-constraint violation (code `23505`) and the route passed it to `next(err)` → 500. A student double-tapping "submit" or a network retry would get an error response.
- **Fix**: `createSessionFeedback` now checks `error.code === '23505'` before calling `assertRow` and returns `null` instead of throwing. The route naturally falls through to `{ ok: true }`.

### MEDIUM — Feedback card buttons permanently disabled across sessions
- **File**: `apps/web/public/app.js` (`showFeedbackCard`, line ~663)
- **Root cause**: `submitFeedback` disables `btnFbSubmit` and `btnFbSkip` but `showFeedbackCard` never re-enables them. After a feedback submission, starting a new session and ending it would show a feedback card with both buttons already disabled.
- **Fix**: `showFeedbackCard` now resets both buttons to `disabled = false` at the top.

### LOW — Resend API error silently consumed; `markEmailSent()` fires on delivery failure
- **File**: `packages/email/src/transcript.ts`
- **Root cause**: The Resend SDK returns errors in `result.error` (not as exceptions). The previous code logged the error but resolved normally, so callers treated a failed email as a successful one.
- **Fix**: `sendTranscript` now throws on `result.error` and re-throws network exceptions. Both callers (`index.ts` sweep and `sessions.ts` DELETE handler) already wrap in `try/catch`, so `markEmailSent()` is only called on actual success. JSDoc updated to document the new throwing contract.

### LOW — Inactivity timer not restarted after slow stream completes
- **File**: `apps/web/public/app.js` (`sendMessage` finally block, line ~428)
- **Root cause**: `resetInactivityTimer()` is called when the user sends a message but not when the stream ends. If a model response took longer than `inactivityMs`, `onInactivityTimeout` would fire but return early (due to `isStreaming`), and no new timer would be scheduled afterward. Session would run indefinitely without auto-end protection.
- **Fix**: `resetInactivityTimer()` added to the `finally` block of `sendMessage` so the countdown restarts after every stream.

## False positives discarded

| Claim | Reason |
|-------|--------|
| Sweep race: session resurrected during async teardown | Node.js single-threaded; `removeSession` runs synchronously before any I/O event fires |
| Sweep vs DELETE duplicate eval+email | Same — Node.js can't interleave synchronous operations |
| Live Map iterator during mid-loop mutation | No concurrent HTTP handler can fire during the synchronous for-loop |
| `finalizeTutor` double-call | `marked.parse()` always produces `<p>` elements for non-empty text; fallback check never triggers after first call |
| `dragDepth` not reset on session restart | `dragleave` clamps to 0; `drop` explicitly resets to 0 — self-correcting |

## Verification

- `npm run build` passes (TypeScript strict, all packages)
- `npm audit` — 0 vulnerabilities
- No open GitHub issues labeled "bug"

🤖 Generated with [Claude Code](https://claude.com/claude-code)