### PR TITLE
Daily bug sweep: CDN fallback, finalizeTutor guard, inactivity reschedule, feedback TOCTOU, email_sent persistence

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,7 +24,7 @@ import { createDisclaimerRouter } from "./routes/disclaimer.js";
 import { createAccessRouter } from "./routes/access.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload } from "./lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted } from "./lib/evaluation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -119,13 +119,18 @@ setInterval(() => {
                 console.error(`[sweep] Failed to create timeout feedback for ${sessionId}:`, err);
                 return null;
               });
+              // createSessionFeedback returns null on unique-constraint violation (concurrent insert).
+              // Re-fetch to get the row that was created by the concurrent path.
+              if (!feedback) {
+                feedback = await getSessionFeedback(db, sessionId).catch(() => null);
+              }
             }
 
             const payload = buildTranscriptEmailPayload(
               session, sessionId, evalResult, feedback, config.model, defaultPromptName
             );
             await sendTranscript(emailConfig, payload);
-            session.markEmailSent();
+            await markEmailSentPersisted(session, db, sessionId, "sweep");
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
           } finally {

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -1,7 +1,7 @@
 import { evaluateTranscript } from "@ai-tutor/core";
 import type { EvaluationResult, Session } from "@ai-tutor/core";
 import type { TranscriptEmailPayload } from "@ai-tutor/email";
-import { createSessionEvaluation } from "@ai-tutor/db";
+import { createSessionEvaluation, updateSession } from "@ai-tutor/db";
 import type { DbSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -92,4 +92,21 @@ export async function runSessionEvaluation(
     console.error(`[evaluation] Failed to evaluate session ${sessionId}:`, err);
     return null;
   }
+}
+
+/**
+ * Mark the session email as sent in both in-memory state and the database.
+ * Called after sendTranscript succeeds in both the inactivity sweep and the
+ * DELETE handler — extracted here to avoid duplicating the two-step pattern.
+ */
+export async function markEmailSentPersisted(
+  session: Session,
+  db: SupabaseClient,
+  sessionId: string,
+  logPrefix: string,
+): Promise<void> {
+  session.markEmailSent();
+  await updateSession(db, sessionId, { email_sent: true }).catch(err =>
+    console.error(`[${logPrefix}] Could not persist email_sent for ${sessionId}:`, err)
+  );
 }

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -7,7 +7,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload } from "../lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 
 export interface EmailConfig {
@@ -77,7 +77,7 @@ export function createSessionsRouter(
           const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback, defaultModel, defaultPromptName);
           try {
             await sendTranscript(emailConfig, payload);
-            session.markEmailSent();
+            await markEmailSentPersisted(session, db, sessionId, "sessions");
           } catch (err) {
             console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err);
           }

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -279,7 +279,7 @@
     // is allowed by default via ALLOW_DATA_ATTR but listed explicitly for clarity.
     const html = (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined')
       ? DOMPurify.sanitize(marked.parse(withRefs), { ADD_ATTR: ['data-upload-id', 'tabindex'] })
-      : `<p>${escHtml(withRefs)}</p>`;
+      : `<p>${escHtml(clean)}</p>`;
 
     entry.bubbleEl.innerHTML = html;
     renderKaTeX(entry.bubbleEl);
@@ -367,6 +367,7 @@
 
     let rawText = '';
     let gotToken = false;
+    let finalized = false;
 
     try {
       const resp = await fetch('/api/chat', { method: 'POST', body: fd });
@@ -410,14 +411,15 @@
               tokenCounter.style.display = 'inline';
             }
             finalizeTutor(tutorEntry, rawText);
+            finalized = true;
           } else if (event.type === 'error') {
             throw new Error(event.message || 'Streaming error');
           }
         }
       }
 
-      // Fallback: finalize if stream ended without message_stop (handles zero-token case too)
-      if (!tutorEntry.bubbleEl.querySelector('p, ul, ol, pre, h1, h2, h3')) {
+      // Fallback: finalize if stream ended without message_stop
+      if (!finalized) {
         finalizeTutor(tutorEntry, rawText);
       }
 
@@ -621,7 +623,11 @@
   }
 
   async function onInactivityTimeout() {
-    if (sessionEnded || msgList.length === 0 || isStreaming) return;
+    if (sessionEnded || msgList.length === 0) return;
+    if (isStreaming) {
+      inactivityTimer = setTimeout(onInactivityTimeout, 5000);
+      return;
+    }
     sessionEnded = true;
     stopCountdownDisplay();
     endBanner.classList.remove('active');


### PR DESCRIPTION
## Summary

- **MEDIUM** `apps/web/public/app.js`: CDN fallback passed `withRefs` (already-HTML output of `parseImgRefs`) to `escHtml`, rendering escaped `<span>` tags as visible text when DOMPurify/marked fail to load. Fixed: use `clean` instead.
- **LOW** `apps/web/public/app.js`: `finalizeTutor` could be called twice when a stream ends without `message_stop` and `rawText` is empty. Added `finalized` flag; simplified fallback condition to `!finalized`.
- **LOW** `apps/web/public/app.js`: `onInactivityTimeout` silently no-oped when `isStreaming`, leaving client alive after server reaps the session. Now reschedules itself 5s out so the check fires once streaming ends.
- **MEDIUM** `apps/api/src/index.ts`: TOCTOU in inactivity sweep — if a student feedback row was inserted between `getSessionFeedback` (returned null) and `createSessionFeedback` (unique-constraint → returns null), transcript email went out with `feedback: null`. Added fallback re-fetch.
- **LOW** `apps/api/src/index.ts` + `apps/api/src/routes/sessions.ts`: `sessions.email_sent` DB column was never written to `true` after sending the transcript (only the in-memory flag was set). Added `markEmailSentPersisted` helper in `evaluation.ts` that calls both `session.markEmailSent()` and `updateSession(db, sessionId, { email_sent: true })`; both send paths use it.

## Test plan

- [ ] Build passes: `npm run build` from repo root
- [ ] CDN fallback: block CDN in devtools, send a message — no escaped HTML in bubble
- [ ] `finalizeTutor` guard: verify no double rendering on empty server response
- [ ] Inactivity timeout during stream: send a message, simulate inactivity firing during stream — session ends promptly after stream completes
- [ ] Feedback TOCTOU: trace code path — `getSessionFeedback` called after null `createSessionFeedback` result
- [ ] `email_sent` DB: verify `sessions.email_sent` is `true` after session end in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)