### PR TITLE
Daily bug sweep: feedback validation, missing timeout-feedback row, upsert evaluation, state cleanup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,8 +10,6 @@ import {
 import {
   createSupabaseClient,
   markSessionEnded,
-  createSessionFeedback,
-  getSessionFeedback,
 } from "@ai-tutor/db";
 import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/errors.js";
@@ -24,7 +22,7 @@ import { createDisclaimerRouter } from "./routes/disclaimer.js";
 import { createAccessRouter } from "./routes/access.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted } from "./lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback } from "./lib/evaluation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -105,26 +103,10 @@ setInterval(() => {
       if (!session.emailSent && session.transcript.length > 0) {
         void (async () => {
           try {
-            const evalResult = await runSessionEvaluation(db, sessionId, session.transcript);
-
-            let feedback = await getSessionFeedback(db, sessionId).catch(err => {
-              console.error(`[sweep] Failed to fetch feedback for ${sessionId}:`, err);
-              return null;
-            });
-            if (!feedback) {
-              feedback = await createSessionFeedback(db, {
-                session_id: sessionId,
-                source: "timeout",
-              }).catch(err => {
-                console.error(`[sweep] Failed to create timeout feedback for ${sessionId}:`, err);
-                return null;
-              });
-              // createSessionFeedback returns null on unique-constraint violation (concurrent insert).
-              // Re-fetch to get the row that was created by the concurrent path.
-              if (!feedback) {
-                feedback = await getSessionFeedback(db, sessionId).catch(() => null);
-              }
-            }
+            const [evalResult, feedback] = await Promise.all([
+              runSessionEvaluation(db, sessionId, session.transcript),
+              getOrCreateTimeoutFeedback(db, sessionId, "sweep"),
+            ]);
 
             const payload = buildTranscriptEmailPayload(
               session, sessionId, evalResult, feedback, config.model, defaultPromptName

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -1,7 +1,7 @@
 import { evaluateTranscript } from "@ai-tutor/core";
 import type { EvaluationResult, Session } from "@ai-tutor/core";
 import type { TranscriptEmailPayload } from "@ai-tutor/email";
-import { createSessionEvaluation, updateSession } from "@ai-tutor/db";
+import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback } from "@ai-tutor/db";
 import type { DbSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -62,6 +62,37 @@ export function buildTranscriptEmailPayload(
   };
 }
 
+/**
+ * Fetch the session_feedback row for a session, creating a source:'timeout' row
+ * if none exists.  Handles unique-constraint races by re-fetching on null return.
+ * Used by both the inactivity sweep and the explicit DELETE handler.
+ */
+export async function getOrCreateTimeoutFeedback(
+  db: SupabaseClient,
+  sessionId: string,
+  logPrefix: string,
+): Promise<DbSessionFeedback | null> {
+  let feedback = await getSessionFeedback(db, sessionId).catch(err => {
+    console.error(`[${logPrefix}] Failed to fetch feedback for ${sessionId}:`, err);
+    return null;
+  });
+  if (!feedback) {
+    feedback = await createSessionFeedback(db, {
+      session_id: sessionId,
+      source: "timeout",
+    }).catch(err => {
+      console.error(`[${logPrefix}] Failed to create timeout feedback for ${sessionId}:`, err);
+      return null;
+    });
+    // createSessionFeedback returns null on unique-constraint violation (concurrent insert).
+    // Re-fetch to get the row that was created by the concurrent path.
+    if (!feedback) {
+      feedback = await getSessionFeedback(db, sessionId).catch(() => null);
+    }
+  }
+  return feedback;
+}
+
 export async function runSessionEvaluation(
   db: SupabaseClient,
   sessionId: string,
@@ -69,7 +100,7 @@ export async function runSessionEvaluation(
 ): Promise<EvaluationResult | null> {
   try {
     const result = await evaluateTranscript(transcript);
-    await createSessionEvaluation(db, {
+    await upsertSessionEvaluation(db, {
       session_id: sessionId,
       model: result.model,
       mode_handling: result.mode_handling,

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -3,6 +3,9 @@ import { createSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { UUID_RE } from "../lib/validation.js";
 
+const VALID_OUTCOMES = new Set(["solved", "partial", "stuck"]);
+const VALID_EXPERIENCES = new Set(["positive", "neutral", "negative"]);
+
 export function createFeedbackRouter(db: SupabaseClient): Router {
   const router = Router();
 
@@ -38,6 +41,25 @@ export function createFeedbackRouter(db: SupabaseClient): Router {
 
       if (!UUID_RE.test(sessionId)) {
         res.status(400).json({ error: "sessionId must be a valid UUID." });
+        return;
+      }
+
+      // source: only 'student' is accepted from external callers; 'timeout' is server-only.
+      if (source !== undefined && source !== "student") {
+        res.status(400).json({ error: "Invalid source." });
+        return;
+      }
+
+      if (outcome !== undefined && outcome !== null && !VALID_OUTCOMES.has(outcome)) {
+        res.status(400).json({ error: "Invalid outcome." });
+        return;
+      }
+      if (experience !== undefined && experience !== null && !VALID_EXPERIENCES.has(experience)) {
+        res.status(400).json({ error: "Invalid experience." });
+        return;
+      }
+      if (typeof comment === "string" && comment.length > 2000) {
+        res.status(400).json({ error: "Comment too long (max 2000 characters)." });
         return;
       }
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2,12 +2,11 @@ import { Router } from "express";
 import {
   getSession as getDbSession,
   markSessionEnded,
-  getSessionFeedback,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted } from "../lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 
 export interface EmailConfig {
@@ -69,11 +68,10 @@ export function createSessionsRouter(
 
       try {
         if (!discard && session && !session.emailSent && session.transcript.length > 0) {
-          const evalResult = await runSessionEvaluation(db, sessionId, session.transcript);
-          const feedback = await getSessionFeedback(db, sessionId).catch(err => {
-            console.error(`[sessions] Failed to fetch feedback for ${sessionId}:`, err);
-            return null;
-          });
+          const [evalResult, feedback] = await Promise.all([
+            runSessionEvaluation(db, sessionId, session.transcript),
+            getOrCreateTimeoutFeedback(db, sessionId, "sessions"),
+          ]);
           const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback, defaultModel, defaultPromptName);
           try {
             await sendTranscript(emailConfig, payload);

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -530,6 +530,8 @@
     endAvailable    = false;
     sessionEnded    = false;
     msgCounter      = 0;
+    katexQueue      = [];
+    dragDepth       = 0;
     fbSelections    = { outcome: null, experience: null };
     tokenCounter.style.display = 'none';
     tokenCounter.textContent = '';


### PR DESCRIPTION
## Summary

- **`routes/feedback.ts` (MEDIUM):** Block `source:'timeout'` from external callers; validate `outcome`/`experience` enums (400 instead of 500 on bad values); cap `comment` at 2000 chars
- **`routes/sessions.ts` (MEDIUM):** Create a `source:'timeout'` `session_feedback` row in the DELETE handler when none exists — explicit-end sessions previously violated the one-row-per-session schema invariant
- **`lib/evaluation.ts` (LOW):** Switch `createSessionEvaluation` → `upsertSessionEvaluation` so duplicate evaluation runs don't silently discard the result
- **`app.js` (LOW):** Reset `katexQueue` and `dragDepth` in `resetSessionState` — stale queue held detached DOM nodes; stale `dragDepth` could break the drag overlay after a session reset
- **Refactor:** Extract `getOrCreateTimeoutFeedback` helper to eliminate the duplicated fetch-create-refetch pattern shared between the inactivity sweep and the DELETE handler; parallelize it with `runSessionEvaluation` using `Promise.all`

## False positives discarded

| Claim | Ruling |
|-------|--------|
| `chat.ts` partial DB write (HIGH) | Non-transactional writes by design; user gets response; acceptable trade-off |
| `chat.ts` MIME spoofing (MEDIUM) | Files forwarded to Anthropic API, not served back; fix requires new dependency |
| `app.js` CDN fallback drops `withRefs` | Correct by design — fallback uses `escHtml(clean)` to avoid unescaped HTML spans |
| `app.js` inactivity TOCTOU | Inactivity path never shows the feedback card; UI path for the race doesn't exist |
| `index.ts` Map iteration during removal | Node.js single-threaded; `removeSession` synchronous; safe per spec |
| `index.ts` removeSession-before-IIFE race | New resumed session has correct `emailSent:false`; sends own email for own transcript |
| `evaluation.ts` `markEmailSent` on detached object | Dedup guard is removeSession-first; no-op in-memory call is harmless |
| `app.js` SSE buf remainder | `sendEvent` uses `\n\n`; `buf` is empty after last event; fallback `!finalized` path handles edge case |

## Test plan

- [ ] `POST /api/feedback` with `source:"timeout"` → 400
- [ ] `POST /api/feedback` with `outcome:"invalid"` → 400
- [ ] `POST /api/feedback` with `comment` > 2000 chars → 400
- [ ] End a session via DELETE before submitting feedback; verify `session_feedback` row exists with `source='timeout'`
- [ ] Verify build passes: `npm run build`
- [ ] Verify `/simplify` was run (completed above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)