### PR TITLE
Daily bug sweep: upsert evaluation, feedback validation, SSE buf flush, AbortController, sentinel regex

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -42,6 +42,7 @@
 
   let sessionUploads = []; // { id, name, mimeType, blobUrl, messageId }
   let uploadCounter  = 0;
+  let activeAbortController = null; // aborts the in-flight /api/chat fetch when session resets
 
   // Sentinel emitted by tutor prompt when the problem is fully resolved.
   const END_SENTINEL   = '[END_SESSION_AVAILABLE]';
@@ -267,7 +268,7 @@
 
   function finalizeTutor(entry, rawText) {
     const hasSentinel = rawText.includes(END_SENTINEL);
-    const clean = rawText.replace(END_SENTINEL, '').trim();
+    const clean = rawText.replace(/\[END_SESSION_AVAILABLE\]/g, '').trim();
 
     // Replace [IMG:...] markers before markdown parse
     const withRefs = parseImgRefs(clean);
@@ -284,15 +285,13 @@
     entry.bubbleEl.innerHTML = html;
     renderKaTeX(entry.bubbleEl);
 
-    // Wire click handlers for image-reference pills
-    entry.bubbleEl.querySelectorAll('.img-ref[data-upload-id]').forEach(pill => {
+    // Wire click handlers for image-reference pills and auto-focus the last one
+    const refPills = entry.bubbleEl.querySelectorAll('.img-ref[data-upload-id]');
+    refPills.forEach(pill => {
       pill.addEventListener('click', () => {
         if (typeof focusUpload === 'function') focusUpload(pill.dataset.uploadId);
       });
     });
-
-    // Auto-focus the last referenced image
-    const refPills = entry.bubbleEl.querySelectorAll('.img-ref[data-upload-id]');
     if (refPills.length > 0) {
       const lastId = refPills[refPills.length - 1].dataset.uploadId;
       if (typeof focusUpload === 'function') focusUpload(lastId);
@@ -370,7 +369,8 @@
     let finalized = false;
 
     try {
-      const resp = await fetch('/api/chat', { method: 'POST', body: fd });
+      activeAbortController = new AbortController();
+      const resp = await fetch('/api/chat', { method: 'POST', body: fd, signal: activeAbortController.signal });
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({ error: resp.statusText }));
         throw new Error(err.error || resp.statusText);
@@ -382,10 +382,9 @@
 
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
+        buf += decoder.decode(value ?? new Uint8Array(), { stream: !done });
         const lines = buf.split('\n');
-        buf = lines.pop() ?? '';
+        buf = done ? '' : (lines.pop() ?? '');
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
@@ -401,7 +400,7 @@
             }
             rawText += event.text;
             tutorEntry.bubbleEl.textContent =
-              rawText.replace(END_SENTINEL, '').trimEnd();
+              rawText.replace(/\[END_SESSION_AVAILABLE\]/g, '').trimEnd();
             scrollBottom();
           } else if (event.type === 'message_stop') {
             if (event.messageId) tutorEntry.dbId = event.messageId;
@@ -416,6 +415,7 @@
             throw new Error(event.message || 'Streaming error');
           }
         }
+        if (done) break;
       }
 
       // Fallback: finalize if stream ended without message_stop
@@ -515,6 +515,7 @@
 
   /** Reset all session state and UI to a fresh-session starting point. */
   function resetSessionState() {
+    if (activeAbortController) { activeAbortController.abort(); activeAbortController = null; }
     if (inactivityTimer) { clearTimeout(inactivityTimer); inactivityTimer = null; }
     stopCountdownDisplay();
     sessionId       = crypto.randomUUID();


### PR DESCRIPTION
## Summary

After rebase on stage (PR #63 already fixed evaluation upsert, feedback validation, and comment cap), this PR contains only the new `app.js` fixes:

- **app.js SSE buf flush (HIGH)** — Flush the `TextDecoder` buffer on stream `done` before breaking the read loop (`{ stream: !done }`, process remaining `buf` before exit). Previously, if the final `data:` SSE line arrived without a trailing `\n`, `message_stop` stayed unprocessed, `finalized` stayed `false`, and `finalizeTutor` ran a second time via the fallback — double-wiring `.img-ref` click handlers and re-running KaTeX on already-rendered nodes.
- **app.js AbortController (HIGH)** — Add an `AbortController` per `sendMessage` call, stored as module-level `activeAbortController`; abort it in `resetSessionState()`. Previously, `confirmSwitch()` called `resetSessionState()` without aborting the in-flight fetch; the stale SSE coroutine continued reading and eventually called `finalizeTutor` → `focusUpload` → `openGallery()` on the blank new session.
- **app.js sentinel regex (MEDIUM)** — Replace `String.replace(END_SENTINEL, '')` (first-match only) with `/\[END_SESSION_AVAILABLE\]/g` in both `finalizeTutor` and the streaming `textContent` update. A model emitting the sentinel twice would leave the second occurrence visible.

## Already fixed by PR #63

- `evaluation.ts`: `upsertSessionEvaluation` (duplicate key handling)
- `feedback.ts`: enum validation, comment length cap

## False Positives Discarded

- `geo.ts` `x-forwarded-for` trust: intentional for Render single-hop proxy; no auth surface.
- `chat.ts` in-memory session before DB insert: pre-existing design.
- `index.ts` concurrent DELETE+sweep race: idempotent; `email_sent` DB flag prevents duplicate emails.

## Open Issues

No open GitHub bug issues.

## Test plan

- [ ] Build passes: `npm run build`
- [ ] Stream a response; confirm `finalizeTutor` runs exactly once per message (no duplicate `.img-ref` click handlers)
- [ ] Send a message, switch model mid-stream via config picker; confirm gallery does not open on the blank new session and no console errors
- [ ] `'[END_SESSION_AVAILABLE]x[END_SESSION_AVAILABLE]'.replace(/\[END_SESSION_AVAILABLE\]/g,'')` === `'x'` in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)