### PR TITLE
Lock prompt selector behind ALLOW_PROMPT_SELECTION (#65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | PORT | no | 3000 | api | HTTP listen port |
 | ACCESS_PASSCODE | **yes (API)** | — | api | 5-digit numeric passcode for the access wall; fails closed if unset |
 | CONTACT_EMAIL | no | wax.spirits8d@icloud.com | api | Contact email shown in access-wall overlay and returned by GET /api/config |
+| ALLOW_PROMPT_SELECTION | no | — (locked) | api | Set `"true"` to allow users to switch prompt versions via the header badge; omitting locks the picker (fail-closed). Surfaced as `promptSelectionEnabled` in `GET /api/config`. |
 
 Both `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are required for the API server.  If either is absent, the server will not start.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `PARENT_EMAIL` is absent, emails are silently skipped.
 

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -46,6 +46,7 @@ export function createConfigRouter(
       availableModels: [...ALLOWED_MODELS],
       availablePrompts: [...promptMap.keys()],
       defaultPrompt: defaultPromptName,
+      promptSelectionEnabled: process.env.ALLOW_PROMPT_SELECTION === "true",
       buildVersion: buildInfo?.commitShort ?? null,
       buildDate: buildInfo?.builtAt ?? null,
     });

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -133,8 +133,14 @@
     // Strip "tutor-prompt-" prefix for compact display (e.g. "v7").
     const label = selectedPrompt.replace(/^tutor-prompt-/, '');
     promptBadge.textContent = label;
-    promptBadge.title = selectedPrompt;
     promptBadge.style.display = '';
+    if (!appConfig.promptSelectionEnabled) {
+      promptBadge.classList.add('locked');
+      promptBadge.title = selectedPrompt;
+    } else {
+      promptBadge.classList.remove('locked');
+      promptBadge.title = selectedPrompt + ' — click to switch';
+    }
   }
 
   function updateBuildInfo() {
@@ -939,6 +945,7 @@
 
   promptBadge.addEventListener('click', e => {
     e.stopPropagation();
+    if (!appConfig.promptSelectionEnabled) return; // locked — ignore clicks
     if (activePicker === 'prompt') { closeConfigPicker(); return; }
     openConfigPicker('prompt', promptBadge);
   });

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -147,6 +147,14 @@
       border-color: var(--accent);
       color: var(--text);
     }
+    .prompt-badge.locked {
+      cursor: default;
+      opacity: 0.55;
+    }
+    .prompt-badge.locked:hover {
+      border-color: var(--border);
+      color: var(--text-muted);
+    }
     .model-badge.extended::after {
       content: ' · thinking';
       color: var(--accent);

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,6 +62,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
 | `CORS_ORIGIN` | no | Your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`) | No |
+| `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
 
 You can skip `RESEND_API_KEY`, `PARENT_EMAIL`, and `EMAIL_FROM` if you don't want email transcripts.  The app will work without them.
 
@@ -141,6 +142,10 @@ export ACCESS_PASSCODE=12345
 export RESEND_API_KEY=re_...
 export PARENT_EMAIL=you@yourdomain.com
 export EMAIL_FROM=tutor@tutor.yourdomain.com
+
+# Optional — set to "true" to allow users to switch prompt versions in the UI.
+# Omitting this variable locks the prompt picker (fail-closed).
+export ALLOW_PROMPT_SELECTION=true
 ```
 
 To avoid re-entering these every time you open a terminal, add the export lines to your `~/.zshrc` (Mac) or `~/.bashrc` (Linux).


### PR DESCRIPTION
Closes #65.

## Summary
- Adds an `ALLOW_PROMPT_SELECTION` environment variable. When unset (default), the header prompt-version badge is rendered as a static, dimmed informational label and the click handler is suppressed. Set to `"true"` to restore the interactive picker.
- Exposes the new flag as `promptSelectionEnabled: boolean` on `GET /api/config`.
- Adds a `.prompt-badge.locked` style for the dimmed, non-interactive state.
- Documents the new env var in `CLAUDE.md` and `docs/deployment.md`.

## ⚠️ Operator alert — silent behavior change on deploy
This change is **fail-closed by default**. Any existing deployment that does not set `ALLOW_PROMPT_SELECTION` will silently lose the ability to switch prompt versions via the header badge. Operators who want to keep the interactive picker must add:

```
ALLOW_PROMPT_SELECTION=true
```

to their environment (Render dashboard, shell exports, etc.) **before** deploying this change. This matches the fail-closed pattern used by `ACCESS_PASSCODE`.

## Test plan
- [ ] Start the API without `ALLOW_PROMPT_SELECTION` set; confirm `GET /api/config` returns `"promptSelectionEnabled": false`
- [ ] Visit the UI; confirm the prompt badge displays the active prompt name and has the `locked` CSS class
- [ ] Click the badge; confirm the picker does not open
- [ ] Set `ALLOW_PROMPT_SELECTION=true`, restart, confirm `GET /api/config` returns `true`
- [ ] Click the badge; confirm the picker opens and selection works
- [ ] `npm run build` passes with zero TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)