### PR TITLE
Daily bug sweep: AbortError display, gallery guards, timingSafeEqual, email-sent flag, finishReap async

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -93,10 +93,12 @@ setInterval(() => {
       // Shared teardown: mark ended_at in DB and log. Called both from the async
       // eval/email path (in finally, after the evaluation row is written) and from
       // the no-email path (immediately, since there is no evaluation to wait for).
-      const finishReap = () => {
-        void markSessionEnded(db, sessionId).catch(err =>
-          console.error(`[sweep] Could not mark session ${sessionId} as ended:`, err)
-        );
+      const finishReap = async () => {
+        try {
+          await markSessionEnded(db, sessionId);
+        } catch (err) {
+          console.error(`[sweep] Could not mark session ${sessionId} as ended:`, err);
+        }
         console.log(`[sweep] Reaped idle session ${sessionId}.`);
       };
 
@@ -113,17 +115,19 @@ setInterval(() => {
               { model: config.model, promptName: defaultPromptName, extendedThinking: config.extendedThinking }
             );
             await sendTranscript(emailConfig, payload);
-            await markEmailSentPersisted(session, db, sessionId, "sweep");
+            if (emailConfig.apiKey && emailConfig.to) {
+              await markEmailSentPersisted(session, db, sessionId, "sweep");
+            }
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
           } finally {
             // Mark ended_at only after evaluation and email have completed (or failed),
             // so session_evaluations is always written before ended_at is set.
-            finishReap();
+            await finishReap();
           }
         })();
       } else {
-        finishReap();
+        void finishReap();
       }
     }
   }

--- a/apps/api/src/routes/access.ts
+++ b/apps/api/src/routes/access.ts
@@ -24,10 +24,13 @@ export function createAccessRouter(): Router {
       return;
     }
 
-    const ok =
-      typeof passcode === "string" &&
-      passcode.length === expected.length &&
-      timingSafeEqual(Buffer.from(passcode), Buffer.from(expected));
+    if (typeof passcode !== "string") {
+      res.json({ ok: false });
+      return;
+    }
+    const submittedBuf = Buffer.from(passcode);
+    const expectedBuf  = Buffer.from(expected);
+    const ok = submittedBuf.length === expectedBuf.length && timingSafeEqual(submittedBuf, expectedBuf);
     res.json({ ok });
   });
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -77,7 +77,9 @@ export function createSessionsRouter(
             { model: defaultModel, promptName: defaultPromptName, extendedThinking: defaultExtendedThinking });
           try {
             await sendTranscript(emailConfig, payload);
-            await markEmailSentPersisted(session, db, sessionId, "sessions");
+            if (emailConfig.apiKey && emailConfig.to) {
+              await markEmailSentPersisted(session, db, sessionId, "sessions");
+            }
           } catch (err) {
             console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err);
           }

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -445,8 +445,10 @@
       }
 
     } catch (err) {
-      tutorEntry.bubbleEl.innerHTML =
-        `<span style="color:var(--danger)">Error: ${escHtml(err.message)}</span>`;
+      if (err.name !== 'AbortError') {
+        tutorEntry.bubbleEl.innerHTML =
+          `<span style="color:var(--danger)">Error: ${escHtml(err.message)}</span>`;
+      }
     } finally {
       isStreaming = false;
       setInputDisabled(false);

--- a/apps/web/public/gallery.js
+++ b/apps/web/public/gallery.js
@@ -23,6 +23,7 @@
 
   // ── Open / close ───────────────────────────────────────────────────────
   window.openGallery = function () {
+    if (!galleryPane) return;
     galleryPane.classList.add('open');
     if (isMobile()) {
       galleryBackdrop.classList.add('active');
@@ -41,6 +42,7 @@
   };
 
   window.closeGallery = function () {
+    if (!galleryPane) return;
     // Clear inline width so the CSS width:0 rule takes over and the
     // close transition animates correctly.
     galleryPane.style.width = '';
@@ -59,6 +61,7 @@
 
   // ── Focus a specific upload ───────────────────────────────────────────
   window.focusUpload = function (uploadId) {
+    if (!galleryThumbs || !galleryFocused) return;
     const entry = (typeof sessionUploads !== 'undefined' ? sessionUploads : [])
       .find(u => u.id === uploadId);
 
@@ -121,6 +124,7 @@
 
   // ── Add a new upload to the gallery ──────────────────────────────────
   window.addToGallery = function (entry) {
+    if (!galleryThumbs) return;
     const thumb = document.createElement('div');
     thumb.className = 'gallery-thumb';
     thumb.dataset.uploadId = entry.id;
@@ -147,6 +151,7 @@
 
   // ── Reset gallery (called on new session) ────────────────────────────
   window.resetGallery = function () {
+    if (!galleryThumbs || !galleryFocused) return;
     galleryThumbs.innerHTML = '';
     galleryFocused.innerHTML =
       '<div class="gallery-empty-state">No uploads yet</div>';


### PR DESCRIPTION
## Summary

Five bugs found and fixed during the daily automated sweep.

### Confirmed bugs fixed

**MEDIUM — `apps/web/public/app.js:447`** — AbortError from `activeAbortController.abort()` (called during model/session switches) was displayed as a red error bubble in the chat UI. Fixed by checking `err.name !== 'AbortError'` before writing the error HTML.

**LOW — `apps/web/public/gallery.js:25,43,61,123,149`** — All five globally exported gallery functions (`openGallery`, `closeGallery`, `focusUpload`, `addToGallery`, `resetGallery`) accessed module-level DOM refs that are only initialized in the `DOMContentLoaded` handler, with no null guard. Added early-return guards to each.

**LOW — `apps/api/src/routes/access.ts:27`** — `passcode.length === expected.length` compared string code-unit lengths before `timingSafeEqual`, which compares buffer byte lengths. Multi-byte input could cause a `RangeError` instead of `{ ok: false }`. Restructured to early-exit on non-string input, then compare buffer byte lengths.

**MEDIUM — `apps/api/src/index.ts:116` + `apps/api/src/routes/sessions.ts:80`** — `markEmailSentPersisted` was called even when `sendTranscript` silently no-oped (missing `RESEND_API_KEY` or `PARENT_EMAIL`), writing `email_sent=true` to the DB and permanently blocking future re-sends. Fixed by guarding `markEmailSentPersisted` on `emailConfig.apiKey && emailConfig.to`.

**MEDIUM — `apps/api/src/index.ts:96`** — `finishReap` used `void markSessionEnded(...)`, so a DB failure silently left `ended_at=null` on the session row. Made `finishReap` async and awaited `markSessionEnded` (consistent with the `DELETE` handler which already awaits it).

### False positives discarded

- Race condition between inactivity sweep and `DELETE /api/sessions/:id`: Node.js is single-threaded; `removeSession()` runs synchronously before any `await`, preventing re-entry.
- `session.markEmailSent()` called on already-removed session: harmless — object is in closure memory, mutation has no downstream readers.
- Concurrent sweep ticks: `setInterval` callbacks are serialized; synchronous `removeSession` prevents re-processing.

## Test plan

- [ ] Switch model mid-stream → no red error bubble appears
- [ ] End a session with `RESEND_API_KEY` unset → `email_sent` column stays `false` in DB
- [ ] POST `/api/access/verify` with non-ASCII body → returns `{ ok: false }`, no 500
- [ ] Normal session end → `ended_at` is set in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)