### PR TITLE
fix: make register flow visible and immediately usable

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -37,8 +37,8 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   /**
    * POST /api/auth/register
    *
-   * Creates a new Supabase auth user with `email_confirm: false` so the user
-   * must confirm their email before login succeeds. Uses the service-role
+   * Creates a new Supabase auth user with `email_confirm: true` so the user
+   * can log in immediately without a confirmation step. Uses the service-role
    * admin API. Returns a generic error message on failure to avoid leaking
    * which emails are registered.
    */
@@ -53,7 +53,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
       const { error } = await db.auth.admin.createUser({
         email: parsed.email,
         password: parsed.password,
-        email_confirm: false,
+        email_confirm: true,
       });
       if (error) {
         res.status(400).json({ ok: false, error: "registration_failed" });

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -14,6 +14,7 @@
   --accent: #7c6af7;
   --accent-hover: #8d7dfa;
   --danger: #ef4444;
+  --success: #22c55e;
 }
 
 * { box-sizing: border-box; }
@@ -184,7 +185,7 @@ html, body {
 
 .login-success {
   margin: 0.85rem 0 0;
-  color: #22c55e;
+  color: var(--success);
   font-size: 0.85rem;
 }
 

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -182,6 +182,12 @@ html, body {
   font-size: 0.85rem;
 }
 
+.login-success {
+  margin: 0.85rem 0 0;
+  color: #22c55e;
+  font-size: 0.85rem;
+}
+
 .login-contact-note {
   margin: 1rem 0 0;
   font-size: 0.75rem;

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -53,6 +53,7 @@
       </form>
 
       <p class="login-error" id="login-error" style="display:none"></p>
+      <p class="login-success" id="login-success" style="display:none"></p>
       <p class="login-contact-note" id="login-contact-note"></p>
 
       <!-- ── Post-login status ─────────────────────────────────────────── -->

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -12,12 +12,15 @@
 
   function $(id) { return document.getElementById(id); }
 
-  function setError(msg) {
-    var el = $('login-error');
+  function setMessage(id, msg) {
+    var el = $(id);
     if (!msg) { el.style.display = 'none'; el.textContent = ''; return; }
     el.textContent = msg;
     el.style.display = '';
   }
+
+  function setError(msg) { setMessage('login-error', msg); }
+  function setSuccess(msg) { setMessage('login-success', msg); }
 
   function setOutput(obj) {
     var el = $('login-status-output');
@@ -67,6 +70,7 @@
         panels[key].classList.toggle('active', key === target);
       });
       setError(null);
+      setSuccess(null);
     });
   });
 
@@ -99,10 +103,10 @@
         btn.disabled = false;
         if (res.status >= 200 && res.status < 300 && res.body.ok) {
           setError(null);
-          setOutput('Account created. You can now sign in.');
-          // Switch to login tab
+          // Switch to login tab first — the tab handler clears success, so set it after
           document.querySelector('.login-tab[data-tab="login"]').click();
           $('login-email').value = email;
+          setSuccess('Account created. You can now sign in.');
         } else {
           setError('Registration failed. (' + (res.body.error || 'unknown') + ')');
         }


### PR DESCRIPTION
## Summary

- **`email_confirm: true`** — registration was creating unconfirmed accounts that could never log in (Supabase confirmation email never arrived)
- **`#login-success` element + `setSuccess()`** — the success message was being written to `#login-status-output` inside the hidden `#login-status` div; users saw nothing after a successful register
- **Reorder `setSuccess` after `.click()`** — the tab-switch handler was calling `setSuccess(null)` synchronously, wiping the message before the browser painted it
- **`setMessage(id, msg)` helper** — collapsed the identical `setError`/`setSuccess` implementations into one shared function

Fixes the two bugs reported after PR #74 (issue #73).

## Test plan
- [ ] Navigate to `/login.html` → Register tab
- [ ] Fill in email + password (≥8 chars), check terms, submit
- [ ] Green "Account created. You can now sign in." message appears on the Sign In tab
- [ ] Sign in with same credentials succeeds and shows post-login status section
- [ ] `Test GET /api/auth/me` returns `{ ok: true, userId: "..." }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)