### PR TITLE
feat: registration enhancements — user info capture + email verification

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -101,10 +101,13 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   /**
    * POST /api/auth/register
    *
-   * Creates a new Supabase auth user with `email_confirm: true` so the user
-   * can log in immediately without a confirmation step. Uses the service-role
-   * admin API. Returns a generic error message on failure to avoid leaking
-   * which emails are registered.
+   * Creates a new Supabase auth user with `email_confirm: false` so Supabase
+   * sends a verification email before the account can be used to sign in
+   * (issue #76). Uses the service-role admin API. Additional profile fields
+   * (name, birthdate, grade_level, state, country) are persisted in
+   * `user_metadata`. Returns a generic error message on failure to avoid
+   * leaking which emails are registered; the one exception is the `underage`
+   * error, which is surfaced so the client can show a specific message.
    */
   router.post("/register", async (req, res) => {
     const parsed = validateCredentials(req.body);
@@ -127,7 +130,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
       const { error } = await db.auth.admin.createUser({
         email: parsed.email,
         password: parsed.password,
-        email_confirm: true,
+        email_confirm: false,
         user_metadata: {
           name: profile.name,
           birthdate: profile.birthdate,
@@ -151,8 +154,10 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    *
    * Authenticates via `anonDb.auth.signInWithPassword`. On success, returns
    * the access token, refresh token, and expiry so the client can store them
-   * in sessionStorage. On failure, returns a single opaque error so callers
-   * cannot distinguish "wrong password" from "unconfirmed email" etc.
+   * in sessionStorage. On failure, returns an opaque `invalid_credentials`
+   * error in most cases. The one exception is `email_not_confirmed`, which
+   * is passed through so the client can offer a "resend verification email"
+   * affordance (issue #76).
    */
   router.post("/login", async (req, res) => {
     const parsed = validateCredentials(req.body);
@@ -167,6 +172,11 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
         password: parsed.password,
       });
       if (error || !data?.session) {
+        const code = (error as { code?: string } | null)?.code;
+        if (code === "email_not_confirmed") {
+          res.status(401).json({ ok: false, error: "email_not_confirmed" });
+          return;
+        }
         res.status(401).json({ ok: false, error: "invalid_credentials" });
         return;
       }
@@ -179,6 +189,30 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
     } catch {
       res.status(500).json({ ok: false, error: "server_error" });
     }
+  });
+
+  /**
+   * POST /api/auth/resend-verification
+   *
+   * Re-sends the Supabase signup verification email for a given address
+   * (issue #76). Always returns `{ ok: true }` regardless of whether the
+   * email exists, to avoid account enumeration. Errors are logged
+   * server-side but never surfaced to the client.
+   */
+  router.post("/resend-verification", async (req, res) => {
+    const body = req.body as { email?: unknown } | undefined;
+    const email = body?.email;
+    if (typeof email !== "string" || !EMAIL_RE.test(email)) {
+      // Still return ok:true to avoid enumeration / probing.
+      res.json({ ok: true });
+      return;
+    }
+    try {
+      await anonDb.auth.resend({ type: "signup", email });
+    } catch {
+      // Swallow — do not surface errors to client.
+    }
+    res.json({ ok: true });
   });
 
   /**

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -25,6 +25,18 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   const requireAuth = createRequireAuth(db);
 
   const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const BIRTHDATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+  const ALLOWED_GRADES = new Set([
+    "6th",
+    "7th",
+    "8th",
+    "9th",
+    "10th",
+    "11th",
+    "12th",
+    "Other",
+  ]);
+  const MIN_AGE_YEARS = 13;
 
   function validateCredentials(body: unknown): { email: string; password: string } | string {
     if (!body || typeof body !== "object") return "invalid_request";
@@ -32,6 +44,58 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
     if (typeof email !== "string" || !EMAIL_RE.test(email)) return "invalid_email";
     if (typeof password !== "string" || password.length < 8) return "invalid_password";
     return { email, password };
+  }
+
+  interface RegistrationProfile {
+    name: string;
+    birthdate: string;
+    gradeLevel: string;
+    state: string | null;
+    country: string | null;
+  }
+
+  function validateRegistrationProfile(body: unknown): RegistrationProfile | string {
+    if (!body || typeof body !== "object") return "invalid_request";
+    const {
+      name,
+      birthdate,
+      gradeLevel,
+      state,
+      country,
+    } = body as {
+      name?: unknown;
+      birthdate?: unknown;
+      gradeLevel?: unknown;
+      state?: unknown;
+      country?: unknown;
+    };
+
+    if (typeof name !== "string" || name.trim().length === 0) return "invalid_name";
+    if (typeof birthdate !== "string" || !BIRTHDATE_RE.test(birthdate)) return "invalid_birthdate";
+    const parsed = new Date(birthdate + "T00:00:00Z");
+    if (Number.isNaN(parsed.getTime())) return "invalid_birthdate";
+    if (typeof gradeLevel !== "string" || !ALLOWED_GRADES.has(gradeLevel)) return "invalid_grade";
+
+    const stateVal = typeof state === "string" && state.trim().length > 0 ? state.trim() : null;
+    const countryVal = typeof country === "string" && country.trim().length > 0 ? country.trim() : null;
+
+    return {
+      name: name.trim(),
+      birthdate,
+      gradeLevel,
+      state: stateVal,
+      country: countryVal,
+    };
+  }
+
+  function computeAgeYears(birthdate: string, today: Date = new Date()): number {
+    const [y, m, d] = birthdate.split("-").map((n) => parseInt(n, 10));
+    let age = today.getUTCFullYear() - y;
+    const monthDiff = today.getUTCMonth() + 1 - m;
+    if (monthDiff < 0 || (monthDiff === 0 && today.getUTCDate() < d)) {
+      age -= 1;
+    }
+    return age;
   }
 
   /**
@@ -48,12 +112,29 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
       res.status(400).json({ ok: false, error: parsed });
       return;
     }
+    const profile = validateRegistrationProfile(req.body);
+    if (typeof profile === "string") {
+      res.status(400).json({ ok: false, error: profile });
+      return;
+    }
+    const age = computeAgeYears(profile.birthdate);
+    if (age < MIN_AGE_YEARS) {
+      res.status(400).json({ ok: false, error: "underage" });
+      return;
+    }
 
     try {
       const { error } = await db.auth.admin.createUser({
         email: parsed.email,
         password: parsed.password,
         email_confirm: true,
+        user_metadata: {
+          name: profile.name,
+          birthdate: profile.birthdate,
+          grade_level: profile.gradeLevel,
+          state: profile.state,
+          country: profile.country,
+        },
       });
       if (error) {
         res.status(400).json({ ok: false, error: "registration_failed" });

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -32,10 +32,15 @@
           <input type="password" id="login-password" class="login-input" autocomplete="current-password" required minlength="8">
         </label>
         <button type="submit" class="login-btn login-btn-primary" id="btn-login">Sign in</button>
+        <button type="button" class="login-btn" id="btn-resend-verification" style="display:none">Resend verification email</button>
       </form>
 
       <!-- ── Register panel ────────────────────────────────────────────── -->
       <form class="login-panel" id="register-panel" autocomplete="on">
+        <label class="login-field">
+          <span class="login-label">Full name</span>
+          <input type="text" id="register-name" class="login-input" autocomplete="name" required>
+        </label>
         <label class="login-field">
           <span class="login-label">Email</span>
           <input type="email" id="register-email" class="login-input" autocomplete="email" required>
@@ -44,6 +49,33 @@
           <span class="login-label">Password</span>
           <input type="password" id="register-password" class="login-input" autocomplete="new-password" required minlength="8">
           <span class="login-hint">At least 8 characters.</span>
+        </label>
+        <label class="login-field">
+          <span class="login-label">Birthdate</span>
+          <input type="date" id="register-birthdate" class="login-input" autocomplete="bday" required>
+          <span class="login-hint">You must be at least 13 to register.</span>
+        </label>
+        <label class="login-field">
+          <span class="login-label">Grade level</span>
+          <select id="register-grade" class="login-input" required>
+            <option value="" disabled selected>Select grade</option>
+            <option value="6th">6th</option>
+            <option value="7th">7th</option>
+            <option value="8th">8th</option>
+            <option value="9th">9th</option>
+            <option value="10th">10th</option>
+            <option value="11th">11th</option>
+            <option value="12th">12th</option>
+            <option value="Other">Other</option>
+          </select>
+        </label>
+        <label class="login-field">
+          <span class="login-label">State / Province <span class="login-hint-inline">(optional)</span></span>
+          <input type="text" id="register-state" class="login-input" autocomplete="address-level1">
+        </label>
+        <label class="login-field">
+          <span class="login-label">Country <span class="login-hint-inline">(optional)</span></span>
+          <input type="text" id="register-country" class="login-input" autocomplete="country-name">
         </label>
         <label class="login-checkbox-row">
           <input type="checkbox" id="register-terms">

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -83,32 +83,85 @@
   }).catch(function () { /* silent */ });
 
   /* ── Register ──────────────────────────────────────────────────────── */
+  function computeAgeYears(birthdate) {
+    // birthdate in YYYY-MM-DD format
+    var parts = birthdate.split('-');
+    if (parts.length !== 3) return NaN;
+    var y = parseInt(parts[0], 10);
+    var m = parseInt(parts[1], 10);
+    var d = parseInt(parts[2], 10);
+    var today = new Date();
+    var age = today.getFullYear() - y;
+    var monthDiff = (today.getMonth() + 1) - m;
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < d)) {
+      age -= 1;
+    }
+    return age;
+  }
+
+  function resetRegisterForm() {
+    $('register-name').value = '';
+    $('register-email').value = '';
+    $('register-password').value = '';
+    $('register-birthdate').value = '';
+    $('register-grade').value = '';
+    $('register-state').value = '';
+    $('register-country').value = '';
+    $('register-terms').checked = false;
+  }
+
   $('register-panel').addEventListener('submit', function (e) {
     e.preventDefault();
     setError(null);
+    var name = $('register-name').value.trim();
     var email = $('register-email').value.trim();
     var password = $('register-password').value;
+    var birthdate = $('register-birthdate').value;
+    var gradeLevel = $('register-grade').value;
+    var state = $('register-state').value.trim();
+    var country = $('register-country').value.trim();
     var terms = $('register-terms').checked;
+
+    if (!name) { setError('Please enter your full name.'); return; }
+    if (!birthdate) { setError('Please enter your birthdate.'); return; }
+    if (!gradeLevel) { setError('Please select a grade level.'); return; }
     if (!terms) { setError('Please accept the terms to continue.'); return; }
     if (password.length < 8) { setError('Password must be at least 8 characters.'); return; }
+
+    var age = computeAgeYears(birthdate);
+    if (!isFinite(age) || age < 13) {
+      setError('You must be at least 13 to register.');
+      return;
+    }
 
     var btn = $('btn-register');
     btn.disabled = true;
     fetch('/api/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: email, password: password }),
+      body: JSON.stringify({
+        email: email,
+        password: password,
+        name: name,
+        birthdate: birthdate,
+        gradeLevel: gradeLevel,
+        state: state,
+        country: country,
+      }),
     }).then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
       .then(function (res) {
         btn.disabled = false;
         if (res.status >= 200 && res.status < 300 && res.body.ok) {
           setError(null);
+          resetRegisterForm();
           // Switch to login tab first — the tab handler clears success, so set it after
           document.querySelector('.login-tab[data-tab="login"]').click();
           $('login-email').value = email;
           setSuccess('Account created. You can now sign in.');
+        } else if (res.body && res.body.error === 'underage') {
+          setError('You must be at least 13 to register.');
         } else {
-          setError('Registration failed. (' + (res.body.error || 'unknown') + ')');
+          setError('Registration failed. (' + ((res.body && res.body.error) || 'unknown') + ')');
         }
       }).catch(function (err) {
         btn.disabled = false;

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -71,6 +71,8 @@
       });
       setError(null);
       setSuccess(null);
+      var resendBtn = $('btn-resend-verification');
+      if (resendBtn) resendBtn.style.display = 'none';
     });
   });
 
@@ -154,10 +156,11 @@
         if (res.status >= 200 && res.status < 300 && res.body.ok) {
           setError(null);
           resetRegisterForm();
-          // Switch to login tab first — the tab handler clears success, so set it after
-          document.querySelector('.login-tab[data-tab="login"]').click();
+          // Stay on the register tab and prompt the user to verify their
+          // email (issue #76). Pre-fill the login email field so they can
+          // sign in once they have verified.
           $('login-email').value = email;
-          setSuccess('Account created. You can now sign in.');
+          setSuccess('Check your inbox to verify your email before logging in.');
         } else if (res.body && res.body.error === 'underage') {
           setError('You must be at least 13 to register.');
         } else {
@@ -170,9 +173,16 @@
   });
 
   /* ── Login ─────────────────────────────────────────────────────────── */
+  function setResendVisible(visible) {
+    var btn = $('btn-resend-verification');
+    if (!btn) return;
+    btn.style.display = visible ? '' : 'none';
+  }
+
   $('login-panel').addEventListener('submit', function (e) {
     e.preventDefault();
     setError(null);
+    setResendVisible(false);
     var email = $('login-email').value.trim();
     var password = $('login-password').value;
 
@@ -195,9 +205,33 @@
           saveAuth(auth);
           showStatus(auth);
           setOutput('Login successful. Tokens stored in sessionStorage.');
+        } else if (res.body && res.body.error === 'email_not_confirmed') {
+          setError('Please verify your email first.');
+          setResendVisible(true);
         } else {
           setError('Invalid email or password.');
         }
+      }).catch(function (err) {
+        btn.disabled = false;
+        setError('Network error: ' + err.message);
+      });
+  });
+
+  /* ── Resend verification email ─────────────────────────────────────── */
+  $('btn-resend-verification').addEventListener('click', function () {
+    var email = $('login-email').value.trim();
+    if (!email) { setError('Enter your email above, then click resend.'); return; }
+    var btn = $('btn-resend-verification');
+    btn.disabled = true;
+    fetch('/api/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email }),
+    }).then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
+      .then(function () {
+        btn.disabled = false;
+        setError(null);
+        setSuccess('Verification email sent.');
       }).catch(function (err) {
         btn.disabled = false;
         setError('Network error: ' + err.message);


### PR DESCRIPTION
## Summary

Two related enhancements to the parallel Supabase-backed login flow at `/login.html`.

### #77 — Capture user info at registration
- Register form now collects full name, birthdate, grade level, state, and country.
- Client-side and server-side age gate reject registrations under 13 (`underage` error code).
- Profile fields are persisted to Supabase `user_metadata` via `auth.admin.createUser`.

### #76 — Enable email verification via Supabase
- Flipped `email_confirm` to `false` so Supabase sends a signup verification email.
- After a successful register, the UI stays on the register tab and prompts the user to check their inbox.
- New `POST /api/auth/resend-verification` endpoint calls `anonDb.auth.resend({ type: 'signup', email })` and always returns `{ ok: true }` (no enumeration).
- Login route now surfaces the `email_not_confirmed` error code so the client can show a "Resend verification email" button.

## Files touched
- `apps/api/src/routes/auth.ts`
- `apps/web/public/login.html`
- `apps/web/public/login.js`

No new migrations, no new npm deps, no changes to the main app or the passcode access wall.

## Test plan
- [ ] `npm run build` succeeds from repo root (verified locally).
- [ ] Visit `/login.html`, register with a birthdate making the user < 13 → client-side error, request not sent.
- [ ] Register with a valid birthdate and all required fields → success message "Check your inbox to verify your email before logging in."
- [ ] Attempt to log in before verifying → "Please verify your email first." with a visible "Resend verification email" button.
- [ ] Click resend → "Verification email sent." (no error).
- [ ] Click the email link, then log in → success, `/api/auth/me` returns the user ID.
- [ ] Confirm the new profile fields (`name`, `birthdate`, `grade_level`, `state`, `country`) appear in the Supabase user's `user_metadata`.

Closes #77
Closes #76