### PR TITLE
fix: registration email verification and resend-verification docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,12 +392,13 @@ Returns `{ ok: false }` if the passcode is wrong or if `ACCESS_PASSCODE` is not 
 
 ---
 
-### POST /api/auth/register, POST /api/auth/login, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
+### POST /api/auth/register, POST /api/auth/login, POST /api/auth/resend-verification, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
 
 Parallel Supabase-backed individual-user login flow (issue #73). **These endpoints are only registered if `SUPABASE_ANON_KEY` is set.** They do NOT gate `/api/chat`, `/api/sessions`, `/api/transcript`, or `/api/feedback` — those still run on the existing passcode access wall. The new flow is reachable only by typing `/login.html` directly; it is a smoke-test / manual-verification surface.
 
-- `POST /api/auth/register` — body `{ email, password }`. Server-side validation (valid email, password ≥ 8). Calls `db.auth.admin.createUser({ email, password, email_confirm: false })`. Returns `{ ok: true }` on success.
-- `POST /api/auth/login` — body `{ email, password }`. Calls `anonDb.auth.signInWithPassword(...)`. Returns `{ ok: true, accessToken, refreshToken, expiresAt }` on success. On failure, always returns the same opaque `invalid_credentials` error (no distinction between wrong password and unconfirmed email).
+- `POST /api/auth/register` — body `{ email, password, name, birthdate, gradeLevel, state?, country? }`. Server-side validation (valid email, password ≥ 8, age ≥ 13, valid grade level). Calls `db.auth.admin.createUser({ email, password, email_confirm: false, user_metadata: {...} })`, then immediately sends the Supabase signup verification email via `anonDb.auth.resend({ type: "signup", email })`. Returns `{ ok: true }` on success, `{ ok: false, error: "underage" }` if age < 13, or `{ ok: false, error: "registration_failed" }` for other errors.
+- `POST /api/auth/login` — body `{ email, password }`. Calls `anonDb.auth.signInWithPassword(...)`. Returns `{ ok: true, accessToken, refreshToken, expiresAt }` on success. On failure, returns `{ ok: false, error: "email_not_confirmed" }` (HTTP 401) when the account is unconfirmed so the client can show a "Resend verification" affordance. All other failures return the opaque `{ ok: false, error: "invalid_credentials" }`.
+- `POST /api/auth/resend-verification` — body `{ email }`. Re-sends the Supabase signup confirmation email via `anonDb.auth.resend({ type: "signup", email })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). Errors logged server-side only.
 - `POST /api/auth/refresh` — body `{ refreshToken }`. Calls `anonDb.auth.refreshSession(...)`. Returns `{ ok, accessToken?, refreshToken?, expiresAt? }`.
 - `POST /api/auth/logout` — requires `Authorization: Bearer <accessToken>`. Calls `db.auth.admin.signOut(userId)` (service-role admin API). Returns `{ ok: true }`.
 - `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId }`. This is the smoke-test endpoint used by `/login.html`.
@@ -515,7 +516,7 @@ These apply to every Claude Code session in this repo.
 | `apps/api/src/routes/feedback.ts` | `POST /api/feedback` — saves one `session_feedback` row |
 | `apps/api/src/routes/disclaimer.ts` | `POST /api/disclaimer/accept` — records access-wall acceptance with IP/geo/user-agent/email |
 | `apps/api/src/routes/access.ts` | `POST /api/access/verify` — server-side passcode validation against ACCESS_PASSCODE env var |
-| `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — POST `/register`, `/login`, `/refresh`, `/logout` and GET `/me` for the parallel Supabase-auth login flow (issue #73). Registered only if `SUPABASE_ANON_KEY` is set. Does not gate the main app. |
+| `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — POST `/register`, `/login`, `/resend-verification`, `/refresh`, `/logout` and GET `/me` for the parallel Supabase-auth login flow (issue #73). Registered only if `SUPABASE_ANON_KEY` is set. Does not gate the main app. |
 | `apps/api/src/middleware/require-auth.ts` | `createRequireAuth(db)` — middleware that verifies `Authorization: Bearer <token>` via `db.auth.getUser(token)` and sets `req.userId`. Used by the `/api/auth/me` and `/api/auth/logout` routes. |
 | `apps/api/scripts/gen-build-info.js` | Generates `build-info.json` (commit SHA + timestamp) at build time; called by the API `build` script |
 | `apps/api/build-info.json` | Generated build metadata (gitignored); read at startup by the config route |

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -88,6 +88,16 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
     };
   }
 
+  // Sends (or re-sends) the Supabase signup verification email.
+  // admin.createUser with email_confirm:false does NOT dispatch an email on its
+  // own — only the public resend API does.  Errors are logged but never
+  // surfaced to the caller (anti-enumeration + always-ok contract).
+  function sendVerificationEmail(email: string, context: string): void {
+    anonDb.auth.resend({ type: "signup", email }).catch((err: unknown) => {
+      console.error(`[auth] ${context}:`, err);
+    });
+  }
+
   function computeAgeYears(birthdate: string, today: Date = new Date()): number {
     const [y, m, d] = birthdate.split("-").map((n) => parseInt(n, 10));
     let age = today.getUTCFullYear() - y;
@@ -143,6 +153,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
         res.status(400).json({ ok: false, error: "registration_failed" });
         return;
       }
+      sendVerificationEmail(parsed.email, "initial verification email failed");
       res.json({ ok: true });
     } catch {
       res.status(500).json({ ok: false, error: "server_error" });
@@ -207,11 +218,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
       res.json({ ok: true });
       return;
     }
-    try {
-      await anonDb.auth.resend({ type: "signup", email });
-    } catch {
-      // Swallow — do not surface errors to client.
-    }
+    sendVerificationEmail(email, "resend-verification failed");
     res.json({ ok: true });
   });
 


### PR DESCRIPTION
## Summary

- **HIGH** `apps/api/src/routes/auth.ts`: `admin.createUser` with `email_confirm: false` creates an unconfirmed Supabase user but never sends a verification email. Registered users saw "Check your inbox" but received nothing and could only recover by attempting login, hitting `email_not_confirmed`, and clicking Resend. Fixed by extracting a `sendVerificationEmail()` helper (fire-and-forget via `.catch`) and calling it immediately after successful `createUser`.
- **LOW** `apps/api/src/routes/auth.ts`: The `/resend-verification` endpoint was silently swallowing `anonDb.auth.resend()` errors with no server-side logging. Now uses the shared helper which logs via `console.error`.
- **LOW** `CLAUDE.md`: `POST /api/auth/resend-verification` was implemented in `1bf50ac` but missing from the API reference section. Also corrected the `/register` and `/login` descriptions which were stale.

## Plan (from Phase 4/5 sweep)

### Confirmed bugs

**Bug 1 — HIGH** `apps/api/src/routes/auth.ts:146` — `admin.createUser({ email_confirm: false })` does not dispatch a verification email; the comment at line 104-106 was wrong. Every registered user was permanently unconfirmed with no automated path to verify. Fix: call `sendVerificationEmail()` after `createUser` succeeds.

**Bug 2 — LOW** `apps/api/src/routes/auth.ts:212` — bare `catch {}` in `/resend-verification` swallowed errors without logging. Fix: use the shared helper.

**Bug 3 — LOW** `CLAUDE.md` auth section — `POST /api/auth/resend-verification` undocumented, `/register` and `/login` descriptions stale.

### False positives discarded

- `computeAgeYears` UTC edge case: internally consistent, not a bug
- AbortError dangling placeholder in `app.js`: only possible in a timing window that doesn't exist at current call sites
- Double-confirm switch race in `app.js`: overlay dismissed synchronously before any await
- Inactivity sweep ordering: session reference held in JS closure, no double-reap possible
- `session.markEmailSent()` dead write in sweep path: idempotency fully preserved by DB write

### Open issues

No open issues labeled "bug".

## Test plan

- [ ] Register a new account via `/login.html` — verify a Supabase confirmation email arrives immediately
- [ ] Attempt login before confirming — verify `email_not_confirmed` error and resend button appear
- [ ] Click resend — verify a second confirmation email arrives
- [ ] Confirm email, log in — verify smoke-test (`GET /api/auth/me`) returns `{ ok: true }`
- [ ] `npm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)