### PR TITLE
feat: link authenticated user to sessions (#81)

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -164,6 +164,26 @@ export function createChatRouter(
             session.extendedThinking = defaultExtendedThinking;
           }
 
+          // Resolve user_id from Bearer token (best-effort; never 401 on this route).
+          let userId: string | null = null;
+          try {
+            const authHeader = req.headers.authorization;
+            if (authHeader && typeof authHeader === "string") {
+              const match = authHeader.match(/^Bearer\s+(.+)$/i);
+              if (match) {
+                const token = match[1].trim();
+                if (token) {
+                  const { data, error } = await db.auth.getUser(token);
+                  if (!error && data?.user?.id) {
+                    userId = data.user.id;
+                  }
+                }
+              }
+            }
+          } catch {
+            // Swallow — user_id is optional.
+          }
+
           // Upsert the session row in the database.
           try {
             await createSession(db, {
@@ -175,6 +195,7 @@ export function createChatRouter(
               model: session.model,
               prompt_name: session.promptName,
               extended_thinking: session.extendedThinking,
+              user_id: userId,
             });
             // Backfill session_id on any disclaimer acceptance rows recorded
             // before this session row existed.

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -386,7 +386,17 @@
 
     try {
       activeAbortController = new AbortController();
-      const resp = await fetch('/api/chat', { method: 'POST', body: fd, signal: activeAbortController.signal });
+      const fetchOpts = { method: 'POST', body: fd, signal: activeAbortController.signal, headers: {} };
+      try {
+        const authRaw = sessionStorage.getItem('authSession');
+        if (authRaw) {
+          const auth = JSON.parse(authRaw);
+          if (auth && auth.accessToken) {
+            fetchOpts.headers['Authorization'] = 'Bearer ' + auth.accessToken;
+          }
+        }
+      } catch (_) { /* ignore — auth is optional */ }
+      const resp = await fetch('/api/chat', fetchOpts);
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({ error: resp.statusText }));
         throw new Error(err.error || resp.statusText);


### PR DESCRIPTION
## Summary
- When a logged-in user sends POST /api/chat, the server extracts the Bearer token from the Authorization header, verifies it via `db.auth.getUser()`, and passes the resulting `user_id` to `createSession()`. Only runs on the first message of a session.
- Token verification errors are swallowed gracefully — `user_id` defaults to null and the request continues normally. The chat route never returns 401.
- The frontend (`app.js`) now reads the `authSession` key from `sessionStorage` and sends `Authorization: Bearer <token>` on POST /api/chat if available.

## Files changed
- `apps/api/src/routes/chat.ts` — extract and verify Bearer token, pass `user_id` to `createSession()`
- `apps/web/public/app.js` — send Authorization header with chat requests

## Test plan
- [ ] Log in via `/login.html`, start a chat session, verify the `sessions` table row has `user_id` populated
- [ ] Without logging in, start a chat session via passcode wall, verify `user_id` is null
- [ ] With an expired/invalid token, verify the chat still works (user_id = null, no 401)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)