### PR TITLE
feat: email transcript copy to authenticated user (#82)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,7 +23,7 @@ import { createDisclaimerRouter } from "./routes/disclaimer.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback } from "./lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -137,6 +137,12 @@ setInterval(() => {
             if (emailConfig.apiKey && emailConfig.to) {
               await markEmailSentPersisted(session, db, sessionId, "sweep");
             }
+            // Send a student-facing copy (fire-and-forget).
+            const summary = session.getSessionSummary();
+            void sendUserTranscriptIfApplicable(
+              sessionId, summary.transcript, summary.startedAt, summary.durationMs,
+              emailConfig.from, db,
+            );
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
           } finally {

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -1,7 +1,8 @@
 import { evaluateTranscript } from "@ai-tutor/core";
 import type { EvaluationResult, Session } from "@ai-tutor/core";
 import type { TranscriptEmailPayload } from "@ai-tutor/email";
-import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback } from "@ai-tutor/db";
+import { sendUserTranscript } from "@ai-tutor/email";
+import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback, getUserEmailForSession } from "@ai-tutor/db";
 import type { DbSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -140,4 +141,31 @@ export async function markEmailSentPersisted(
   await updateSession(db, sessionId, { email_sent: true }).catch(err =>
     console.error(`[${logPrefix}] Could not persist email_sent for ${sessionId}:`, err)
   );
+}
+
+/**
+ * Send a student-facing transcript email if the session belongs to a
+ * registered user.  Fire-and-forget — never throws.
+ */
+export async function sendUserTranscriptIfApplicable(
+  sessionId: string,
+  transcript: Array<{ role: string; text: string }>,
+  startedAt: Date,
+  durationMs: number,
+  emailFrom: string,
+  db: SupabaseClient,
+): Promise<void> {
+  try {
+    const email = await getUserEmailForSession(db, sessionId);
+    if (!email) return;
+
+    const apiKey = process.env.RESEND_API_KEY;
+    await sendUserTranscript(email, { apiKey, from: emailFrom }, {
+      transcript: transcript as Array<{ role: "Student" | "Tutor"; text: string }>,
+      startedAt,
+      durationMs,
+    });
+  } catch (err) {
+    console.error(`[email] Failed to send user transcript for ${sessionId}:`, err);
+  }
 }

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -6,7 +6,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback } from "../lib/evaluation.js";
+import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 
 export interface EmailConfig {
@@ -83,6 +83,12 @@ export function createSessionsRouter(
           } catch (err) {
             console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err);
           }
+          // Send a student-facing copy (fire-and-forget).
+          const summary = session.getSessionSummary();
+          void sendUserTranscriptIfApplicable(
+            sessionId, summary.transcript, summary.startedAt, summary.durationMs,
+            emailConfig.from, db,
+          );
         }
       } finally {
         // Always clean up — even if eval or email throws unexpectedly.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,6 @@
 export { createSupabaseClient, createSupabaseAnonClient } from "./client.js";
 
-export { createSession, getSession, updateSession, markSessionEnded } from "./sessions.js";
+export { createSession, getSession, updateSession, markSessionEnded, getUserEmailForSession } from "./sessions.js";
 
 export {
   createMessage,

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -48,6 +48,27 @@ export async function updateSession(
 }
 
 /**
+ * Look up the email address of the authenticated user who owns a session.
+ * Returns null if the session has no user_id or if any lookup fails.
+ */
+export async function getUserEmailForSession(
+  client: SupabaseClient,
+  sessionId: string,
+): Promise<string | null> {
+  try {
+    const session = await getSession(client, sessionId);
+    if (!session?.user_id) return null;
+
+    const { data, error } = await client.auth.admin.getUserById(session.user_id);
+    if (error || !data?.user?.email) return null;
+
+    return data.user.email;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Mark a session as ended by setting ended_at to now.
  * Session data (messages, feedback) is retained for analysis.
  */

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,5 +1,6 @@
-export { sendTranscript } from "./transcript.js";
+export { sendTranscript, sendUserTranscript } from "./transcript.js";
 export type {
   TranscriptEmailConfig,
   TranscriptEmailPayload,
+  UserTranscriptPayload,
 } from "./transcript.js";

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -321,6 +321,14 @@ export interface UserTranscriptPayload {
  * conversation transcript.  Omits evaluation, feedback, IP/geo, token
  * counts, model info, session ID, and prompt name.
  */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 function buildUserHtml(payload: UserTranscriptPayload): string {
   const { transcript, startedAt, durationMs } = payload;
 
@@ -331,7 +339,7 @@ function buildUserHtml(payload: UserTranscriptPayload): string {
       const label = isStudent
         ? "<strong>You</strong>"
         : "<strong>Tutor</strong>";
-      return `<div style="background:${bg};padding:12px 16px;margin:8px 0;border-radius:6px;white-space:pre-wrap;">${label}<br>${entry.text}</div>`;
+      return `<div style="background:${bg};padding:12px 16px;margin:8px 0;border-radius:6px;white-space:pre-wrap;">${label}<br>${escapeHtml(entry.text)}</div>`;
     })
     .join("");
 

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -308,3 +308,90 @@ export async function sendTranscript(
   }
   console.log(`[email] Transcript sent (id: ${result.data?.id}).`);
 }
+
+/** Minimal payload for the student-facing transcript email. */
+export interface UserTranscriptPayload {
+  transcript: TranscriptEntry[];
+  startedAt: Date;
+  durationMs: number;
+}
+
+/**
+ * Build a student-friendly HTML email with only the session date and
+ * conversation transcript.  Omits evaluation, feedback, IP/geo, token
+ * counts, model info, session ID, and prompt name.
+ */
+function buildUserHtml(payload: UserTranscriptPayload): string {
+  const { transcript, startedAt, durationMs } = payload;
+
+  const transcriptHtml = transcript
+    .map((entry) => {
+      const isStudent = entry.role === "Student";
+      const bg = isStudent ? "#f0f4ff" : "#f9f9f9";
+      const label = isStudent
+        ? "<strong>You</strong>"
+        : "<strong>Tutor</strong>";
+      return `<div style="background:${bg};padding:12px 16px;margin:8px 0;border-radius:6px;white-space:pre-wrap;">${label}<br>${entry.text}</div>`;
+    })
+    .join("");
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Your Tutoring Session</title></head>
+<body style="font-family:sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#222;">
+  <h1 style="font-size:1.4rem;border-bottom:2px solid #4f46e5;padding-bottom:8px;">Your Tutoring Session</h1>
+  <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+    <tr><td style="padding:6px 0;color:#555;width:120px;">Date</td><td>${formatDate(startedAt)}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Duration</td><td>${formatDuration(durationMs)}</td></tr>
+  </table>
+  <h2 style="font-size:1.1rem;">Conversation</h2>
+  ${transcriptHtml || "<p>No messages.</p>"}
+  <p style="margin-top:32px;font-size:0.85em;color:#888;">This is an automated copy of your tutoring session for your reference.</p>
+</body>
+</html>`;
+}
+
+/**
+ * Send a student-facing transcript email.  This is a slimmed-down version
+ * of sendTranscript that omits evaluation, feedback, and admin-only fields.
+ *
+ * @param to - The student's email address.
+ * @param config - Email config (apiKey and from).  The `to` field on the
+ *   config is ignored; the explicit `to` parameter is used instead.
+ * @param payload - Minimal transcript payload.
+ */
+export async function sendUserTranscript(
+  to: string,
+  config: Pick<TranscriptEmailConfig, "apiKey" | "from">,
+  payload: UserTranscriptPayload,
+): Promise<void> {
+  if (!config.apiKey) {
+    console.warn("[email] RESEND_API_KEY not set — skipping user transcript email.");
+    return;
+  }
+  if (payload.transcript.length === 0) {
+    console.warn("[email] Transcript is empty — skipping user transcript email.");
+    return;
+  }
+
+  const resend = new Resend(config.apiKey);
+
+  let result;
+  try {
+    result = await resend.emails.send({
+      from: config.from,
+      to,
+      subject: `Your tutoring session transcript — ${formatDate(payload.startedAt)}`,
+      html: buildUserHtml(payload),
+    });
+  } catch (err) {
+    console.error("[email] Unexpected error sending user transcript:", err);
+    throw err;
+  }
+
+  if (result.error) {
+    console.error("[email] Resend API error (user transcript):", result.error);
+    throw new Error(`Resend API error: ${result.error.message}`);
+  }
+  console.log(`[email] User transcript sent to ${to} (id: ${result.data?.id}).`);
+}


### PR DESCRIPTION
## Summary
- After a session ends (explicit DELETE or inactivity sweep), the server looks up the authenticated user's email via `getUserEmailForSession()` and sends a student-friendly transcript email.
- The user email contains only the session date, duration, and conversation transcript. Evaluation results, IP/geo, token counts, model info, session ID, and prompt name are all omitted.
- The admin email (PARENT_EMAIL) is unchanged and continues to include full evaluation and feedback.
- Fire-and-forget: failures are logged but never block session teardown or propagate errors to the client.

## Files changed
- `packages/db/src/sessions.ts` — added `getUserEmailForSession()`
- `packages/db/src/index.ts` — re-exported `getUserEmailForSession`
- `packages/email/src/transcript.ts` — added `buildUserHtml()`, `sendUserTranscript()`, `UserTranscriptPayload`
- `packages/email/src/index.ts` — re-exported new functions and types
- `apps/api/src/lib/evaluation.ts` — added `sendUserTranscriptIfApplicable()`
- `apps/api/src/routes/sessions.ts` — call `sendUserTranscriptIfApplicable` in DELETE handler
- `apps/api/src/index.ts` — call `sendUserTranscriptIfApplicable` in inactivity sweep

## Test plan
- [ ] Log in via `/login.html`, complete a tutoring session, end it, verify both admin and user emails are sent
- [ ] Verify the user email contains only date/duration and conversation (no evaluation, no IP, no tokens)
- [ ] End a session without being logged in (passcode-only) — verify no user email is sent
- [ ] Verify the admin email still includes full evaluation and feedback as before

Depends on #83 (issue #81).
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)