### PR TITLE
feat: email verification hash handling in login.js

### DIFF
--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -229,6 +229,27 @@
       });
   });
 
+  /* ── Verification hash (Supabase email confirmation callback) ────────── */
+  function handleVerificationHash() {
+    var hash = window.location.hash;
+    if (!hash) return false;
+    var params = new URLSearchParams(hash.slice(1));
+    if (params.get('type') !== 'signup') return false;
+    var accessToken = params.get('access_token');
+    if (!accessToken) return false;
+    var expiresAtRaw = params.get('expires_at');
+    var expiresAt = expiresAtRaw ? parseInt(expiresAtRaw, 10) : null;
+    history.replaceState(null, '', window.location.pathname);
+    saveAuth({
+      accessToken: accessToken,
+      refreshToken: params.get('refresh_token') || null,
+      expiresAt: expiresAt,
+    });
+    window.location.replace('/');
+    return true;
+  }
+  if (handleVerificationHash()) return;
+
   /* ── Redirect if already authenticated ───────────────────────────────── */
   var existing = loadAuth();
   if (isAuthValid(existing)) {


### PR DESCRIPTION
## Summary
- Adds `handleVerificationHash()` at the top of the `login.js` IIFE that detects `type=signup` hash fragments from Supabase email verification links
- Stores access/refresh tokens and `expiresAt` (Unix seconds) in `sessionStorage` under the existing `authSession` key
- Redirects to `/` via `window.location.replace('/')` after storing the session
- The existing `isAuthValid()` redirect guard already blocks authenticated users from re-accessing `/login.html`

## Test plan
- [ ] Register a new account, click the verification link in the email, confirm the browser lands at `/` and the user is authenticated
- [ ] Navigate directly to `/login.html` while authenticated — confirm immediate redirect to `/`
- [ ] Navigate to `/login.html` with no hash or with `#type=recovery` — confirm the login form renders normally

Closes #87

Generated with [Claude Code](https://claude.com/claude-code)