### PR TITLE
feat: post-registration check-your-email overlay

### DIFF
--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -245,3 +245,67 @@ html, body {
 .login-status-output:empty {
   display: none;
 }
+
+/* ── Post-registration "check your email" overlay ───────────────── */
+.verify-overlay {
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+}
+
+.verify-overlay[style*="display: none"],
+.verify-overlay[style*="display:none"] {
+  /* handled by inline style; this is belt-and-suspenders */
+}
+
+.verify-heading {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.verify-body {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.verify-body strong {
+  color: var(--text);
+  word-break: break-all;
+}
+
+.verify-countdown {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.verify-countdown span {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.verify-back-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.verify-link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.verify-link-btn:hover {
+  color: var(--accent-hover);
+}

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -84,6 +84,22 @@
         <button type="submit" class="login-btn login-btn-primary" id="btn-register">Create account</button>
       </form>
 
+      <!-- ── Post-registration verification overlay ───────────────────── -->
+      <div id="verify-overlay" class="verify-overlay" style="display:none">
+        <h2 class="verify-heading">Check your email</h2>
+        <p class="verify-body">
+          We sent a verification link to <strong id="verify-email-address"></strong>.
+          Click the link in that email to activate your account.
+        </p>
+        <p class="verify-countdown">
+          Link expires in <span id="verify-timer">60:00</span>.
+        </p>
+        <button type="button" class="login-btn login-btn-primary" id="btn-verify-resend">Resend email</button>
+        <p class="verify-back-note">
+          Already verified? <button type="button" class="verify-link-btn" id="btn-verify-back">Return to sign in</button>
+        </p>
+      </div>
+
       <p class="login-error" id="login-error" style="display:none"></p>
       <p class="login-success" id="login-success" style="display:none"></p>
       <p class="login-contact-note" id="login-contact-note"></p>

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -43,6 +43,64 @@
     return true;
   }
 
+  /* ── Verify overlay helpers ─────────────────────────────────────────── */
+  var _countdownTimer = null;
+  var _countdownEnd = 0;
+
+  function startCountdown() {
+    _countdownEnd = Date.now() + 60 * 60 * 1000; // 60 minutes
+    tickCountdown();
+    _countdownTimer = setInterval(tickCountdown, 1000);
+  }
+
+  function tickCountdown() {
+    var remaining = Math.max(0, _countdownEnd - Date.now());
+    if (remaining === 0) {
+      $('verify-timer').textContent = 'Expired';
+      stopCountdown();
+      return;
+    }
+    var totalSec = Math.ceil(remaining / 1000);
+    var mm = Math.floor(totalSec / 60);
+    var ss = totalSec % 60;
+    $('verify-timer').textContent =
+      (mm < 10 ? '0' : '') + mm + ':' + (ss < 10 ? '0' : '') + ss;
+  }
+
+  function stopCountdown() {
+    if (_countdownTimer) { clearInterval(_countdownTimer); _countdownTimer = null; }
+  }
+
+  function showVerifyOverlay(email) {
+    setError(null);
+    setSuccess(null);
+    $('verify-email-address').textContent = email;
+    $('verify-overlay').style.display = 'flex';
+    document.querySelector('.login-tabs').style.display = 'none';
+    $('login-panel').classList.remove('active');
+    $('register-panel').classList.remove('active');
+    startCountdown();
+  }
+
+  function hideVerifyOverlay() {
+    stopCountdown();
+    var email = $('verify-email-address').textContent || '';
+    $('verify-overlay').style.display = 'none';
+    document.querySelector('.login-tabs').style.display = '';
+    // Restore to sign-in tab
+    tabs.forEach(function (t) {
+      var isLogin = t.dataset.tab === 'login';
+      t.classList.toggle('active', isLogin);
+      t.setAttribute('aria-selected', isLogin ? 'true' : 'false');
+    });
+    $('login-panel').classList.add('active');
+    $('register-panel').classList.remove('active');
+    // Pre-fill sign-in email field with the registered email
+    if (email) $('login-email').value = email;
+    setError(null);
+    setSuccess(null);
+  }
+
   /* ── Tabs ──────────────────────────────────────────────────────────── */
   var tabs = document.querySelectorAll('.login-tab');
   var panels = {
@@ -51,6 +109,10 @@
   };
   tabs.forEach(function (tab) {
     tab.addEventListener('click', function () {
+      // Dismiss verify overlay if visible
+      if ($('verify-overlay').style.display !== 'none') {
+        hideVerifyOverlay();
+      }
       var target = tab.dataset.tab;
       tabs.forEach(function (t) {
         var active = t === tab;
@@ -145,13 +207,8 @@
       .then(function (res) {
         btn.disabled = false;
         if (res.status >= 200 && res.status < 300 && res.body.ok) {
-          setError(null);
           resetRegisterForm();
-          // Stay on the register tab and prompt the user to verify their
-          // email (issue #76). Pre-fill the login email field so they can
-          // sign in once they have verified.
-          $('login-email').value = email;
-          setSuccess('Check your inbox to verify your email before logging in.');
+          showVerifyOverlay(email);
         } else if (res.body && res.body.error === 'underage') {
           setError('You must be at least 13 to register.');
         } else {
@@ -227,6 +284,34 @@
         btn.disabled = false;
         setError('Network error: ' + err.message);
       });
+  });
+
+  /* ── Verify overlay: resend button ─────────────────────────────────── */
+  $('btn-verify-resend').addEventListener('click', function () {
+    var email = $('verify-email-address').textContent || '';
+    if (!email) return;
+    var btn = $('btn-verify-resend');
+    btn.disabled = true;
+    fetch('/api/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email }),
+    }).then(function () {
+      btn.disabled = false;
+      stopCountdown();
+      startCountdown();
+      var orig = btn.textContent;
+      btn.textContent = 'Sent!';
+      setTimeout(function () { btn.textContent = orig; }, 2000);
+    }).catch(function () {
+      btn.disabled = false;
+      setError('Network error — please try again.');
+    });
+  });
+
+  /* ── Verify overlay: return to sign in ────────────────────────────── */
+  $('btn-verify-back').addEventListener('click', function () {
+    hideVerifyOverlay();
   });
 
   /* ── Verification hash (Supabase email confirmation callback) ────────── */


### PR DESCRIPTION
## Summary
- After successful registration, replaces inline success message with a dedicated overlay showing the registered email, a 60-minute countdown timer, and a Resend button
- "Return to sign in" button dismisses the overlay, switches to Sign in tab, and pre-fills the email field
- Tab clicks also dismiss the overlay if visible
- All new CSS classes use the `.verify-` prefix to avoid collisions

## Test plan
- [ ] Register a new account — confirm overlay appears with correct email and ticking countdown
- [ ] Click "Resend email" — confirm button disables briefly, countdown resets, button shows "Sent!" for 2 seconds
- [ ] Click "Return to sign in" — confirm overlay hides, tabs reappear on Sign in tab, email pre-filled
- [ ] Click a tab while overlay is showing — confirm overlay is dismissed
- [ ] Register with an already-registered email — confirm error message appears, no overlay

Closes #86

Generated with [Claude Code](https://claude.com/claude-code)