### PR TITLE
feat: forgot-password flow on login page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,13 +372,14 @@ Always returns `200 { ok: true }` — DB errors are caught and logged server-sid
 
 ---
 
-### POST /api/auth/register, POST /api/auth/login, POST /api/auth/resend-verification, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
+### POST /api/auth/register, POST /api/auth/login, POST /api/auth/resend-verification, POST /api/auth/forgot-password, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
 
 Supabase-backed individual-user login flow. **These endpoints are only registered if `SUPABASE_ANON_KEY` is set.** They do not gate `/api/chat`, `/api/sessions`, `/api/transcript`, or `/api/feedback` — the auth gate is enforced client-side via a JWT check in `app.js` that redirects unauthenticated users to `/login.html`.
 
 - `POST /api/auth/register` — body `{ email, password, name, birthdate, gradeLevel, state?, country? }`. Server-side validation (valid email, password ≥ 8, age ≥ 13, valid grade level). Calls `db.auth.admin.createUser({ email, password, email_confirm: false, user_metadata: {...} })`, then immediately sends the Supabase signup verification email via `anonDb.auth.resend({ type: "signup", email })`. Returns `{ ok: true }` on success, `{ ok: false, error: "underage" }` if age < 13, or `{ ok: false, error: "registration_failed" }` for other errors.
 - `POST /api/auth/login` — body `{ email, password }`. Calls `anonDb.auth.signInWithPassword(...)`. Returns `{ ok: true, accessToken, refreshToken, expiresAt }` on success. On failure, returns `{ ok: false, error: "email_not_confirmed" }` (HTTP 401) when the account is unconfirmed so the client can show a "Resend verification" affordance. All other failures return the opaque `{ ok: false, error: "invalid_credentials" }`.
 - `POST /api/auth/resend-verification` — body `{ email }`. Re-sends the Supabase signup confirmation email via `anonDb.auth.resend({ type: "signup", email })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). Errors logged server-side only.
+- `POST /api/auth/forgot-password` — body `{ email }`. Sends a Supabase password-reset email via `anonDb.auth.resetPasswordForEmail(email, { redirectTo })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). The `redirectTo` URL is derived from `req.headers.origin` (or `req.headers.host`). No new env vars required. Errors logged server-side only.
 - `POST /api/auth/refresh` — body `{ refreshToken }`. Calls `anonDb.auth.refreshSession(...)`. Returns `{ ok, accessToken?, refreshToken?, expiresAt? }`.
 - `POST /api/auth/logout` — requires `Authorization: Bearer <accessToken>`. Calls `db.auth.admin.signOut(userId)` (service-role admin API). Returns `{ ok: true }`.
 - `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId }`.
@@ -513,7 +514,7 @@ These apply to every Claude Code session in this repo.
 | `apps/web/public/gallery.js` | Gallery pane logic; exposes `openGallery`, `closeGallery`, `focusUpload`, `addToGallery`, `resetGallery` globals |
 | `apps/web/public/login.html` | Login/register page for the Supabase auth flow. Unauthenticated users are redirected here from `/`. |
 | `apps/web/public/login.css` | Styles for `login.html`. Self-contained dark theme mirroring `styles.css` palette. |
-| `apps/web/public/login.js` | Client logic for the login page: tabbed login/register forms, `/api/auth/*` calls, `sessionStorage` under key `authSession`. Redirects to `/` on successful login; redirects immediately if a valid session already exists. |
+| `apps/web/public/login.js` | Client logic for the login page: tabbed login/register forms, forgot-password panel, `/api/auth/*` calls, `sessionStorage` under key `authSession`. Handles Supabase hash callbacks (`type=signup`, `type=recovery`) on page load. Redirects to `/` on successful login; redirects immediately if a valid session already exists. |
 | `apps/web/public/maintenance.html` | Static maintenance page; served manually when the app is down for planned maintenance |
 | `apps/web/public/manifest.json` | PWA web app manifest — standalone display, theme colors, icon references |
 | `apps/web/public/icons/` | PWA app icons (192×192 and 512×512 PNGs) for home-screen and manifest |

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -223,6 +223,33 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   });
 
   /**
+   * POST /api/auth/forgot-password
+   *
+   * Sends a Supabase password-reset email. Always returns `{ ok: true }`
+   * regardless of whether the email exists (anti-enumeration). Derives the
+   * redirect URL from the request Origin header.
+   */
+  router.post("/forgot-password", async (req, res) => {
+    const body = req.body as { email?: unknown } | undefined;
+    const email = body?.email;
+    if (typeof email !== "string" || !EMAIL_RE.test(email)) {
+      res.json({ ok: true });
+      return;
+    }
+    const origin =
+      (req.headers.origin as string | undefined) ??
+      `https://${req.headers.host ?? "localhost"}`;
+    anonDb.auth
+      .resetPasswordForEmail(email, {
+        redirectTo: `${origin}/login.html`,
+      })
+      .catch((err: unknown) => {
+        console.error("[auth] forgot-password resetPasswordForEmail failed:", err);
+      });
+    res.json({ ok: true });
+  });
+
+  /**
    * POST /api/auth/refresh
    *
    * Exchanges a refresh token for a new access token pair via the anon

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -309,3 +309,19 @@ html, body {
 .verify-link-btn:hover {
   color: var(--accent-hover);
 }
+
+/* ── Forgot-password link ───────────────────────────────────────── */
+.login-forgot-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+}
+.login-forgot-link:hover {
+  color: var(--text);
+}

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -33,7 +33,19 @@
         </label>
         <button type="submit" class="login-btn login-btn-primary" id="btn-login">Sign in</button>
         <button type="button" class="login-btn" id="btn-resend-verification" style="display:none">Resend verification email</button>
+        <button type="button" class="login-forgot-link" id="btn-show-forgot">Forgot password?</button>
       </form>
+
+      <!-- ── Forgot password panel ─────────────────────────────────────── -->
+      <div class="login-panel" id="forgot-panel">
+        <button type="button" class="login-forgot-link" id="btn-back-to-login">&larr; Back to sign in</button>
+        <p class="login-label" style="margin:0">Enter your email and we'll send you a reset link.</p>
+        <label class="login-field">
+          <span class="login-label">Email</span>
+          <input type="email" id="forgot-email" class="login-input" autocomplete="email" required>
+        </label>
+        <button type="button" class="login-btn login-btn-primary" id="btn-forgot">Send reset link</button>
+      </div>
 
       <!-- ── Register panel ────────────────────────────────────────────── -->
       <form class="login-panel" id="register-panel" autocomplete="on">

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -122,6 +122,8 @@
       Object.keys(panels).forEach(function (key) {
         panels[key].classList.toggle('active', key === target);
       });
+      // Dismiss forgot-password panel on tab click
+      $('forgot-panel').classList.remove('active');
       setError(null);
       setSuccess(null);
       var resendBtn = $('btn-resend-verification');
@@ -314,26 +316,70 @@
     hideVerifyOverlay();
   });
 
-  /* ── Verification hash (Supabase email confirmation callback) ────────── */
+  /* ── Hash-based token handling (verification + password recovery) ────── */
   function handleVerificationHash() {
     var hash = window.location.hash;
     if (!hash) return false;
     var params = new URLSearchParams(hash.slice(1));
-    if (params.get('type') !== 'signup') return false;
+    var type = params.get('type');
     var accessToken = params.get('access_token');
-    if (!accessToken) return false;
-    var expiresAtRaw = params.get('expires_at');
-    var expiresAt = expiresAtRaw ? parseInt(expiresAtRaw, 10) : null;
-    history.replaceState(null, '', window.location.pathname);
-    saveAuth({
-      accessToken: accessToken,
-      refreshToken: params.get('refresh_token') || null,
-      expiresAt: expiresAt,
-    });
-    window.location.replace('/');
-    return true;
+    if ((type === 'signup' || type === 'recovery') && accessToken) {
+      var expiresAtRaw = params.get('expires_at');
+      var expiresAt = expiresAtRaw ? parseInt(expiresAtRaw, 10) : null;
+      history.replaceState(null, '', window.location.pathname);
+      saveAuth({
+        accessToken: accessToken,
+        refreshToken: params.get('refresh_token') || null,
+        expiresAt: expiresAt,
+      });
+      window.location.replace('/');
+      return true;
+    }
+    return false;
   }
   if (handleVerificationHash()) return;
+
+  /* ── Forgot password panel ─────────────────────────────────────────── */
+  $('btn-show-forgot').addEventListener('click', function () {
+    setError(null);
+    setSuccess(null);
+    $('login-panel').classList.remove('active');
+    $('register-panel').classList.remove('active');
+    $('forgot-panel').classList.add('active');
+  });
+
+  $('btn-back-to-login').addEventListener('click', function () {
+    setError(null);
+    setSuccess(null);
+    $('forgot-panel').classList.remove('active');
+    $('login-panel').classList.add('active');
+    // Restore tab highlights
+    tabs.forEach(function (t) {
+      var isLogin = t.dataset.tab === 'login';
+      t.classList.toggle('active', isLogin);
+      t.setAttribute('aria-selected', isLogin ? 'true' : 'false');
+    });
+  });
+
+  $('btn-forgot').addEventListener('click', function () {
+    var email = $('forgot-email').value.trim();
+    if (!email) { setError('Please enter your email address.'); return; }
+    var btn = $('btn-forgot');
+    btn.disabled = true;
+    $('forgot-email').disabled = true;
+    setError(null);
+    fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email }),
+    }).then(function () {
+      setSuccess('If that address is registered you\'ll receive a reset link shortly.');
+    }).catch(function () {
+      setError('Network error — please try again.');
+      btn.disabled = false;
+      $('forgot-email').disabled = false;
+    });
+  });
 
   /* ── Redirect if already authenticated ───────────────────────────────── */
   var existing = loadAuth();


### PR DESCRIPTION
## Summary
- Adds `POST /api/auth/forgot-password` endpoint that calls `anonDb.auth.resetPasswordForEmail()` with anti-enumeration (always returns `{ ok: true }`)
- Adds forgot-password panel to `login.html` with email input and submit button, accessible via "Forgot password?" link under the Sign in form
- Extends hash-token handling in `login.js` to detect `type=recovery` (and `type=signup`) for automatic login after password reset
- Updates CLAUDE.md API reference and file-level reference table

## Test plan
- [ ] Click "Forgot password?" on login page — confirm panel swap (login fields hidden, forgot fields shown)
- [ ] Click "Back to sign in" — confirm return to login panel
- [ ] Submit a registered email — confirm success message appears, button/input disabled
- [ ] Submit an unregistered email — confirm same success message (anti-enumeration)
- [ ] Click the reset link in the email — confirm redirect to `/` with authenticated session
- [ ] `curl -X POST /api/auth/forgot-password -d '{"email":"test@example.com"}'` returns `{"ok":true}`

Closes #88

Generated with [Claude Code](https://claude.com/claude-code)