### PR TITLE
feat: admin profiles table and isAdmin in /me

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,16 @@ One row per session.  Written by an automated transcript evaluation job using th
 | rationale | jsonb | {} | Per-criterion rationale strings keyed by column name. |
 | created_at | timestamptz | now() | |
 
+### profiles
+
+One row per registered user.  Created at registration time.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| user_id | uuid | | PK. FK → auth.users(id) ON DELETE CASCADE. |
+| is_admin | boolean | false | Grants access to model/prompt/thinking selectors in the chat header. |
+| created_at | timestamptz | now() | |
+
 ### disclaimer_acceptances
 
 | Column | Type | Notes |
@@ -382,7 +392,7 @@ Supabase-backed individual-user login flow. **These endpoints are only registere
 - `POST /api/auth/forgot-password` — body `{ email }`. Sends a Supabase password-reset email via `anonDb.auth.resetPasswordForEmail(email, { redirectTo })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). The `redirectTo` URL is derived from `req.headers.origin` (or `req.headers.host`). No new env vars required. Errors logged server-side only.
 - `POST /api/auth/refresh` — body `{ refreshToken }`. Calls `anonDb.auth.refreshSession(...)`. Returns `{ ok, accessToken?, refreshToken?, expiresAt? }`.
 - `POST /api/auth/logout` — requires `Authorization: Bearer <accessToken>`. Calls `db.auth.admin.signOut(userId)` (service-role admin API). Returns `{ ok: true }`.
-- `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId }`.
+- `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId, isAdmin: boolean }`. `isAdmin` is read from the `profiles` table; returns `false` for legacy users without a profile row (fail-closed).
 
 JWT verification is handled by `createRequireAuth()` (in `apps/api/src/middleware/require-auth.ts`), which reads the bearer token and calls `db.auth.getUser(token)`. There is no `SUPABASE_JWT_SECRET` — Supabase's own verification API is used.
 
@@ -463,6 +473,7 @@ These apply to every Claude Code session in this repo.
 | `supabase/migrations/000_schema.sql` | Consolidated database schema (sessions, messages, session_feedback, session_evaluations, disclaimer_acceptances) |
 | `supabase/migrations/001_extended_thinking.sql` | Adds `extended_thinking boolean NOT NULL DEFAULT true` column to the sessions table |
 | `supabase/migrations/002_users.sql` | Adds nullable `user_id uuid` column to sessions referencing `auth.users(id) ON DELETE SET NULL`, with partial index `sessions_user_id`. Backs the parallel Supabase-auth login flow (issue #73). |
+| `supabase/migrations/003_profiles.sql` | Creates `profiles` table keyed on `user_id` with `is_admin boolean NOT NULL DEFAULT false`. One row per registered user. |
 | `templates/tutor-prompt-v7.md` | Production tutor prompt — current version; loaded at runtime via `SYSTEM_PROMPT_PATH` |
 | `templates/tutor-prompt-v6.md` | Tutor prompt v6 — retained as rollback target |
 | `templates/system-instructions.md` | Global system instructions appended to every tutor prompt at load time (sentinel token, image-ref format) |
@@ -488,6 +499,7 @@ These apply to every Claude Code session in this repo.
 | `packages/db/src/session-feedback.ts` | `createSessionFeedback()`, `getSessionFeedback()` — session_feedback table CRUD |
 | `packages/db/src/session-evaluations.ts` | `createSessionEvaluation()`, `getSessionEvaluation()` — session_evaluations table CRUD |
 | `packages/db/src/disclaimer-acceptances.ts` | `createDisclaimerAcceptance()` — inserts a disclaimer acceptance row; `linkDisclaimerAcceptance()` — backfills session_id after session is created |
+| `packages/db/src/profiles.ts` | `createProfile(client, userId)` — inserts a profile row for a new user; `getProfile(client, userId)` — returns `{ isAdmin }` or `null` for legacy users |
 | `packages/email/src/transcript.ts` | `sendTranscript()` — session summary email via Resend; includes session ID, token usage, evaluation results, and student feedback |
 | `apps/api/src/index.ts` | Express server entry — routes, middleware, inactivity sweep |
 | `apps/api/src/routes/chat.ts` | `POST /api/chat` — streaming chat with file upload |

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createProfile, getProfile } from "@ai-tutor/db";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
 /**
@@ -137,7 +138,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
     }
 
     try {
-      const { error } = await db.auth.admin.createUser({
+      const { data: createData, error } = await db.auth.admin.createUser({
         email: parsed.email,
         password: parsed.password,
         email_confirm: false,
@@ -152,6 +153,14 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
       if (error) {
         res.status(400).json({ ok: false, error: "registration_failed" });
         return;
+      }
+      // Create a profile row for the new user (non-blocking on failure).
+      if (createData?.user?.id) {
+        try {
+          await createProfile(db, createData.user.id);
+        } catch (profileErr) {
+          console.error("[auth] createProfile failed for user", createData.user.id, profileErr);
+        }
       }
       sendVerificationEmail(parsed.email, "initial verification email failed");
       res.json({ ok: true });
@@ -300,12 +309,20 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   /**
    * GET /api/auth/me
    *
-   * Smoke-test endpoint — returns the authenticated user's ID so the login
-   * page can verify that the stored access token is working.
+   * Returns the authenticated user's ID and admin status. The profile
+   * lookup uses getProfile which returns null for legacy users (registered
+   * before the profiles table existed) — in that case isAdmin is false
+   * (fail-closed).
    */
-  router.get("/me", requireAuth, (req, res) => {
+  router.get("/me", requireAuth, async (req, res) => {
     const userId = (req as AuthedRequest).userId;
-    res.json({ ok: true, userId });
+    try {
+      const profile = await getProfile(db, userId);
+      res.json({ ok: true, userId, isAdmin: profile?.isAdmin ?? false });
+    } catch (err) {
+      console.error("[auth] getProfile failed for /me:", err);
+      res.json({ ok: true, userId, isAdmin: false });
+    }
   });
 
   return router;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,6 +13,9 @@ export { createSessionEvaluation, upsertSessionEvaluation, getSessionEvaluation 
 
 export { createDisclaimerAcceptance, linkDisclaimerAcceptance } from "./disclaimer-acceptances.js";
 
+export { createProfile, getProfile } from "./profiles.js";
+export type { DbProfile } from "./profiles.js";
+
 export type {
   DbSession,
   DbMessage,

--- a/packages/db/src/profiles.ts
+++ b/packages/db/src/profiles.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface DbProfile {
+  user_id: string;
+  is_admin: boolean;
+  created_at: string;
+}
+
+/**
+ * Create a profile row for a newly registered user.
+ * Defaults to `is_admin: false`.
+ */
+export async function createProfile(
+  client: SupabaseClient,
+  userId: string,
+): Promise<void> {
+  const { error } = await client
+    .from("profiles")
+    .insert({ user_id: userId });
+  if (error) throw new Error(`createProfile: ${error.message}`);
+}
+
+/**
+ * Get a user's profile. Returns `null` for legacy users who registered
+ * before the profiles table existed — callers must handle the null case.
+ */
+export async function getProfile(
+  client: SupabaseClient,
+  userId: string,
+): Promise<{ isAdmin: boolean } | null> {
+  const { data, error } = await client
+    .from("profiles")
+    .select("is_admin")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(`getProfile: ${error.message}`);
+  if (!data) return null;
+  return { isAdmin: data.is_admin as boolean };
+}

--- a/supabase/migrations/003_profiles.sql
+++ b/supabase/migrations/003_profiles.sql
@@ -1,0 +1,11 @@
+-- 003_profiles.sql — User profiles with admin flag.
+-- One row per auth.users user; created at registration time.
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+  user_id  uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  is_admin boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for potential future admin-listing queries.
+CREATE INDEX IF NOT EXISTS profiles_is_admin ON public.profiles (is_admin) WHERE is_admin = true;


### PR DESCRIPTION
## Summary
- Creates `supabase/migrations/003_profiles.sql` with `profiles` table (user_id PK, is_admin boolean default false)
- Adds `packages/db/src/profiles.ts` with `createProfile()` and `getProfile()` (uses `.maybeSingle()` for legacy user safety)
- Register handler calls `createProfile(db, userId)` after user creation (logs but does not fail on error)
- `GET /api/auth/me` now returns `{ ok: true, userId, isAdmin }` — fail-closed to `false` for legacy users
- Updates CLAUDE.md schema tables, API reference, and file-level reference table

## Test plan
- [ ] Register a new user — confirm profile row is created in `profiles` table
- [ ] `GET /api/auth/me` for a new user returns `isAdmin: false`
- [ ] Set `is_admin = true` in the DB for a user — confirm `GET /api/auth/me` returns `isAdmin: true`
- [ ] Legacy user (no profile row) — confirm `GET /api/auth/me` returns `isAdmin: false`
- [ ] `npm run build` passes cleanly

Closes #89

Generated with [Claude Code](https://claude.com/claude-code)