### PR TITLE
feat: hide model/prompt/thinking badges for non-admins

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -127,7 +127,6 @@
     const isHaiku = selectedModel.includes('haiku');
     modelBadge.classList.toggle('extended', selectedThinking && !isHaiku);
     modelBadge.title = selectedModel + (selectedThinking && !isHaiku ? ' — extended thinking on' : '');
-    modelBadge.style.display = '';
   }
 
   function updatePromptBadge() {
@@ -135,7 +134,6 @@
     // Strip "tutor-prompt-" prefix for compact display (e.g. "v7").
     const label = selectedPrompt.replace(/^tutor-prompt-/, '');
     promptBadge.textContent = label;
-    promptBadge.style.display = '';
     if (!appConfig.promptSelectionEnabled) {
       promptBadge.classList.add('locked');
       promptBadge.title = selectedPrompt + ' — prompt selection disabled';
@@ -149,7 +147,6 @@
     thinkingBadge.textContent = selectedThinking ? 'thinking: on' : 'thinking: off';
     thinkingBadge.classList.toggle('off', !selectedThinking);
     thinkingBadge.title = (selectedThinking ? 'Extended thinking on' : 'Extended thinking off') + ' — click to toggle';
-    thinkingBadge.style.display = '';
   }
 
   function updateBuildInfo() {
@@ -162,6 +159,31 @@
       ? `${appConfig.buildVersion} · ${dateStr}`
       : appConfig.buildVersion;
     buildInfoEl.title = `Build ${appConfig.buildVersion}` + (appConfig.buildDate ? ` — ${appConfig.buildDate}` : '');
+  }
+
+  // ── Admin badge visibility ────────────────────────────────────────────────
+  async function fetchUserInfo() {
+    try {
+      const authRaw = sessionStorage.getItem('authSession');
+      if (!authRaw) return;
+      const auth = JSON.parse(authRaw);
+      if (!auth || !auth.accessToken) return;
+
+      const res = await fetch('/api/auth/me', {
+        headers: { 'Authorization': 'Bearer ' + auth.accessToken }
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+
+      if (data.ok && data.isAdmin === true) {
+        modelBadge.classList.add('admin-visible');
+        promptBadge.classList.add('admin-visible');
+        thinkingBadge.classList.add('admin-visible');
+      }
+      // Non-admin or missing isAdmin: badges remain hidden (CSS default).
+    } catch {
+      // Network or parse failure: leave badges hidden.
+    }
   }
 
   // ── Header button state ───────────────────────────────────────────────────
@@ -1041,6 +1063,7 @@
   // ── Init ──────────────────────────────────────────────────────────────────
   showEmpty();
   fetchConfig();
+  fetchUserInfo();
   msgInput.focus();
 
   // ── iOS viewport stability ────────────────────────────────────────────────

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -130,6 +130,7 @@
     .model-badge,
     .prompt-badge,
     .thinking-badge {
+      display: none;
       font-family: var(--font-sans);
       font-size: 0.71rem;
       font-weight: 500;
@@ -142,6 +143,11 @@
       cursor: pointer;
       user-select: none;
       transition: border-color 0.15s, color 0.15s;
+    }
+    .model-badge.admin-visible,
+    .prompt-badge.admin-visible,
+    .thinking-badge.admin-visible {
+      display: inline-block;
     }
     .model-badge:hover,
     .prompt-badge:hover,


### PR DESCRIPTION
## Summary
- Adds `display: none` as CSS default for `.model-badge`, `.prompt-badge`, `.thinking-badge`
- Adds `.admin-visible` CSS class that restores `display: inline-block`
- Removes `element.style.display = ''` calls from `updateModelBadge()`, `updatePromptBadge()`, `updateThinkingBadge()`
- Adds `fetchUserInfo()` to `app.js` that calls `GET /api/auth/me` and adds `.admin-visible` if `isAdmin === true`
- Fires concurrently with `fetchConfig()` in init — no sequential waterfall

## Test plan
- [ ] Log in as non-admin user — confirm all three badges are hidden
- [ ] Log in as admin user (set `is_admin = true` in profiles table) — confirm all three badges appear
- [ ] Simulate network error (block /api/auth/me) — confirm badges remain hidden
- [ ] No flash: on slow network, badges should not appear briefly before /me response

Closes #90

Generated with [Claude Code](https://claude.com/claude-code)