### PR TITLE
feat: user identity and logout button in chat header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,9 +392,9 @@ Supabase-backed individual-user login flow. **These endpoints are only registere
 - `POST /api/auth/forgot-password` — body `{ email }`. Sends a Supabase password-reset email via `anonDb.auth.resetPasswordForEmail(email, { redirectTo })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). The `redirectTo` URL is derived from `req.headers.origin` (or `req.headers.host`). No new env vars required. Errors logged server-side only.
 - `POST /api/auth/refresh` — body `{ refreshToken }`. Calls `anonDb.auth.refreshSession(...)`. Returns `{ ok, accessToken?, refreshToken?, expiresAt? }`.
 - `POST /api/auth/logout` — requires `Authorization: Bearer <accessToken>`. Calls `db.auth.admin.signOut(userId)` (service-role admin API). Returns `{ ok: true }`.
-- `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId, isAdmin: boolean }`. `isAdmin` is read from the `profiles` table; returns `false` for legacy users without a profile row (fail-closed).
+- `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId, isAdmin: boolean, email, name }`. `isAdmin` is read from the `profiles` table; returns `false` for legacy users without a profile row (fail-closed). `email` is the user's email; `name` is from `user_metadata.name` (null if unset).
 
-JWT verification is handled by `createRequireAuth()` (in `apps/api/src/middleware/require-auth.ts`), which reads the bearer token and calls `db.auth.getUser(token)`. There is no `SUPABASE_JWT_SECRET` — Supabase's own verification API is used.
+JWT verification is handled by `createRequireAuth()` (in `apps/api/src/middleware/require-auth.ts`), which reads the bearer token and calls `db.auth.getUser(token)`. The middleware populates `userId`, `userEmail`, and `userName` on the request object. There is no `SUPABASE_JWT_SECRET` — Supabase's own verification API is used.
 
 ---
 

--- a/apps/api/src/middleware/require-auth.ts
+++ b/apps/api/src/middleware/require-auth.ts
@@ -7,6 +7,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
  */
 export interface AuthedRequest extends Request {
   userId: string;
+  userEmail: string;
+  userName: string | null;
 }
 
 /**
@@ -47,6 +49,9 @@ export function createRequireAuth(db: SupabaseClient): RequestHandler {
         return;
       }
       (req as AuthedRequest).userId = data.user.id;
+      (req as AuthedRequest).userEmail = data.user.email ?? "";
+      (req as AuthedRequest).userName =
+        (data.user.user_metadata?.name as string | undefined) ?? null;
       next();
     } catch {
       res.status(401).json({ ok: false, error: "unauthorized" });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -309,19 +309,25 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   /**
    * GET /api/auth/me
    *
-   * Returns the authenticated user's ID and admin status. The profile
-   * lookup uses getProfile which returns null for legacy users (registered
-   * before the profiles table existed) — in that case isAdmin is false
-   * (fail-closed).
+   * Returns the authenticated user's ID, admin status, email, and display name.
+   * isAdmin is read from the profiles table; returns false for legacy users
+   * without a profile row (fail-closed).
    */
   router.get("/me", requireAuth, async (req, res) => {
-    const userId = (req as AuthedRequest).userId;
+    const authed = req as AuthedRequest;
+    const { userId, userEmail, userName } = authed;
     try {
       const profile = await getProfile(db, userId);
-      res.json({ ok: true, userId, isAdmin: profile?.isAdmin ?? false });
+      res.json({
+        ok: true,
+        userId,
+        isAdmin: profile?.isAdmin ?? false,
+        email: userEmail,
+        name: userName ?? null,
+      });
     } catch (err) {
       console.error("[auth] getProfile failed for /me:", err);
-      res.json({ ok: true, userId, isAdmin: false });
+      res.json({ ok: true, userId, isAdmin: false, email: userEmail, name: userName ?? null });
     }
   });
 

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -89,6 +89,9 @@
   const btnCloseTx     = $('btn-close-tx');
   const btnCloseTx2    = $('btn-close-tx2');
   const btnCopyTx      = $('btn-copy-tx');
+  const userIdentityEl     = $('user-identity');
+  const userDisplayName    = $('user-display-name');
+  const btnLogout          = $('btn-logout');
   const dragOverlay        = $('drag-overlay');
   const wrappingUpOverlay  = $('wrapping-up-overlay');
   const toast              = $('toast');
@@ -161,7 +164,7 @@
     buildInfoEl.title = `Build ${appConfig.buildVersion}` + (appConfig.buildDate ? ` — ${appConfig.buildDate}` : '');
   }
 
-  // ── Admin badge visibility ────────────────────────────────────────────────
+  // ── Admin badge visibility + user identity ───────────────────────────────
   async function fetchUserInfo() {
     try {
       const authRaw = sessionStorage.getItem('authSession');
@@ -175,16 +178,42 @@
       if (!res.ok) return;
       const data = await res.json();
 
-      if (data.ok && data.isAdmin === true) {
-        modelBadge.classList.add('admin-visible');
-        promptBadge.classList.add('admin-visible');
-        thinkingBadge.classList.add('admin-visible');
+      if (data.ok) {
+        if (data.isAdmin === true) {
+          modelBadge.classList.add('admin-visible');
+          promptBadge.classList.add('admin-visible');
+          thinkingBadge.classList.add('admin-visible');
+        }
+        const displayName = data.name || data.email || '';
+        if (displayName) {
+          userDisplayName.textContent = displayName;
+          userIdentityEl.style.display = '';
+        }
       }
-      // Non-admin or missing isAdmin: badges remain hidden (CSS default).
     } catch {
-      // Network or parse failure: leave badges hidden.
+      // Network or parse failure: leave badges hidden and identity hidden.
     }
   }
+
+  async function handleLogout() {
+    try {
+      const authRaw = sessionStorage.getItem('authSession');
+      if (authRaw) {
+        const auth = JSON.parse(authRaw);
+        if (auth && auth.accessToken) {
+          await fetch('/api/auth/logout', {
+            method: 'POST',
+            headers: { 'Authorization': 'Bearer ' + auth.accessToken }
+          });
+        }
+      }
+    } catch {
+      // Proceed regardless of API result (fail-open).
+    }
+    sessionStorage.removeItem('authSession');
+    window.location.href = '/login.html';
+  }
+
 
   // ── Header button state ───────────────────────────────────────────────────
   function updateHeaderButtons() {
@@ -1027,6 +1056,8 @@
       closeConfigPicker();
     }
   });
+
+  btnLogout.addEventListener('click', handleLogout);
 
   btnSwitchConfirm.addEventListener('click', confirmSwitch);
   btnSwitchCancel.addEventListener('click',  () => { switchConfigOverlay.classList.remove('active'); pendingSwitch = null; });

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -56,6 +56,10 @@
       </span>
     </span>
     <div class="header-right">
+      <div id="user-identity" class="user-identity" style="display:none">
+        <span id="user-display-name" class="user-display-name"></span>
+        <button id="btn-logout" class="btn btn-sm btn-logout">Log out</button>
+      </div>
       <span id="build-info" class="build-info"></span>
       <span id="thinking-badge" class="thinking-badge" style="display:none" title="Extended thinking — click to toggle"></span>
       <span id="prompt-badge" class="prompt-badge" style="display:none" title="Active prompt — click to switch"></span>

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -171,6 +171,29 @@
       opacity: 0.6;
     }
 
+    /* ── User identity + logout ────────────────────────────────────────── */
+    .user-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .user-display-name {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      white-space: nowrap;
+      max-width: 140px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .btn-logout {
+      color: var(--text-muted);
+      border-color: var(--border);
+    }
+    .btn-logout:hover {
+      color: var(--danger);
+      border-color: var(--danger);
+    }
+
     /* ── Config picker dropdown ─────────────────────────────────────────── */
     .config-picker {
       position: fixed;
@@ -857,6 +880,7 @@
       #file-strip  { padding: 8px 12px 0; }
       .empty-chips { display: none; }
       .logo-company { font-size: 1rem; }
+      .user-display-name { display: none; }
     }
 
     /* ── Message appear animation ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Extends `AuthedRequest` interface with `userEmail` and `userName` fields populated by `createRequireAuth` middleware
- `GET /api/auth/me` now returns `{ ok, userId, email, name }` — no extra DB call, reads from the existing `getUser()` response
- Adds `#user-identity` container to `.header-right` in `index.html` with display name and Log out button
- `fetchUserInfo()` in `app.js` populates the identity element on init; fires concurrently with `fetchConfig()`
- Logout handler: calls `POST /api/auth/logout`, clears `authSession`, redirects to `/login.html` regardless of API result (fail-open)
- Display name hidden on mobile (< 600px); Log out button remains visible

## Test plan
- [ ] Log in with an account that has a name — confirm name appears in header
- [ ] Log in with an account without a name — confirm email appears instead
- [ ] Click Log out — confirm redirect to `/login.html`, `authSession` cleared from sessionStorage
- [ ] Simulate logout API failure — confirm redirect still happens (fail-open)
- [ ] On narrow viewport — confirm name hidden, Log out button visible
- [ ] `curl -H "Authorization: Bearer <token>" /api/auth/me` returns `{ ok, userId, email, name }`

Closes #91

Generated with [Claude Code](https://claude.com/claude-code)