### PR TITLE
feat: proactive token refresh before expiry

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1091,10 +1091,61 @@
     } catch (e) { window.location.href = '/login.html'; return; }
   })();
 
+  // ── Proactive token refresh ────────────────────────────────────────────────
+  var refreshTimer = null;
+  var REFRESH_LEAD_MS = 2 * 60 * 1000; // 2 minutes before expiry
+
+  function scheduleTokenRefresh() {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    try {
+      var raw = sessionStorage.getItem('authSession');
+      if (!raw) return;
+      var auth = JSON.parse(raw);
+      if (!auth || !auth.refreshToken || !auth.expiresAt) return;
+      var msUntilExpiry = auth.expiresAt * 1000 - Date.now();
+      var delay = Math.max(0, msUntilExpiry - REFRESH_LEAD_MS);
+      refreshTimer = setTimeout(doTokenRefresh, delay);
+    } catch (e) { /* silent */ }
+  }
+
+  function doTokenRefresh() {
+    var raw = sessionStorage.getItem('authSession');
+    if (!raw) return;
+    var auth;
+    try { auth = JSON.parse(raw); } catch (e) { return; }
+    if (!auth || !auth.refreshToken) return;
+
+    fetch('/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken: auth.refreshToken }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (res) {
+        if (res.ok && res.accessToken) {
+          sessionStorage.setItem('authSession', JSON.stringify({
+            accessToken: res.accessToken,
+            refreshToken: res.refreshToken,
+            expiresAt: res.expiresAt,
+          }));
+          scheduleTokenRefresh(); // re-arm for the next cycle
+        } else {
+          // Refresh token also expired — force re-login
+          sessionStorage.removeItem('authSession');
+          window.location.href = '/login.html?reason=session_expired';
+        }
+      })
+      .catch(function () {
+        // Network failure — do not log out; retry in 30 s (iOS screen lock)
+        refreshTimer = setTimeout(doTokenRefresh, 30000);
+      });
+  }
+
   // ── Init ──────────────────────────────────────────────────────────────────
   showEmpty();
   fetchConfig();
   fetchUserInfo();
+  scheduleTokenRefresh();
   msgInput.focus();
 
   // ── iOS viewport stability ────────────────────────────────────────────────

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -288,6 +288,12 @@
       });
   });
 
+  /* ── Session-expired notice ────────────────────────────────────────── */
+  var urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('reason') === 'session_expired') {
+    setError('Your session expired. Please sign in again.');
+  }
+
   /* ── Verify overlay: resend button ─────────────────────────────────── */
   $('btn-verify-resend').addEventListener('click', function () {
     var email = $('verify-email-address').textContent || '';


### PR DESCRIPTION
## Summary
- Adds `scheduleTokenRefresh()` to `app.js` that fires 2 minutes before the access token expires
- Calls `POST /api/auth/refresh` and stores fresh tokens on success; re-arms the timer for the next cycle
- On network failure: retries after 30 seconds (handles iOS screen lock gracefully)
- On refresh failure (non-network): clears `authSession` and redirects to `/login.html?reason=session_expired`
- `login.js` detects `?reason=session_expired` and shows "Your session expired. Please sign in again."

## Test plan
- [ ] Sign in and verify `scheduleTokenRefresh()` is called in init (check with breakpoint or console log)
- [ ] Manipulate `expiresAt` in sessionStorage to be ~2 min in the future — confirm refresh fires and tokens update
- [ ] Set `refreshToken` to garbage — confirm redirect to `/login.html?reason=session_expired` with notice
- [ ] Load `/login.html?reason=session_expired` directly — confirm error notice is shown
- [ ] Load `/login.html` without param — confirm no error notice

Closes #92

Generated with [Claude Code](https://claude.com/claude-code)