### PR TITLE
feat: rate limiting on auth endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@ai-tutor/email": "*",
     "cors": "^2.8.5",
     "express": "^4.19.0",
+    "express-rate-limit": "^8.3.2",
     "geoip-lite": "^1.4.10",
     "multer": "^1.4.5-lts.1"
   },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -81,6 +81,7 @@ const emailConfig = {
 const INACTIVITY_MS = 10 * 60 * 1000;
 
 const app = express();
+app.set("trust proxy", 1); // Trust first proxy (Render) for correct req.ip in rate limiting
 
 app.use(corsMiddleware);
 app.use(express.json());

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createProfile, getProfile } from "@ai-tutor/db";
+import rateLimit from "express-rate-limit";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
 /**
@@ -24,6 +25,35 @@ import { createRequireAuth, type AuthedRequest } from "../middleware/require-aut
 export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Router {
   const router = Router();
   const requireAuth = createRequireAuth(db);
+
+  // ── Rate limiters ────────────────────────────────────────────────────
+  const rateLimitHandler = (_req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+    res.status(429).json({ ok: false, error: "too_many_requests" });
+  };
+
+  const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: rateLimitHandler,
+  });
+
+  const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: rateLimitHandler,
+  });
+
+  const resendLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: rateLimitHandler,
+  });
 
   const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const BIRTHDATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -120,7 +150,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    * leaking which emails are registered; the one exception is the `underage`
    * error, which is surfaced so the client can show a specific message.
    */
-  router.post("/register", async (req, res) => {
+  router.post("/register", registerLimiter, async (req, res) => {
     const parsed = validateCredentials(req.body);
     if (typeof parsed === "string") {
       res.status(400).json({ ok: false, error: parsed });
@@ -179,7 +209,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    * is passed through so the client can offer a "resend verification email"
    * affordance (issue #76).
    */
-  router.post("/login", async (req, res) => {
+  router.post("/login", loginLimiter, async (req, res) => {
     const parsed = validateCredentials(req.body);
     if (typeof parsed === "string") {
       res.status(400).json({ ok: false, error: "invalid_credentials" });
@@ -219,7 +249,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    * email exists, to avoid account enumeration. Errors are logged
    * server-side but never surfaced to the client.
    */
-  router.post("/resend-verification", async (req, res) => {
+  router.post("/resend-verification", resendLimiter, async (req, res) => {
     const body = req.body as { email?: unknown } | undefined;
     const email = body?.email;
     if (typeof email !== "string" || !EMAIL_RE.test(email)) {
@@ -238,7 +268,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    * regardless of whether the email exists (anti-enumeration). Derives the
    * redirect URL from the request Origin header.
    */
-  router.post("/forgot-password", async (req, res) => {
+  router.post("/forgot-password", resendLimiter, async (req, res) => {
     const body = req.body as { email?: unknown } | undefined;
     const email = body?.email;
     if (typeof email !== "string" || !EMAIL_RE.test(email)) {

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -208,7 +208,10 @@
     }).then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
       .then(function (res) {
         btn.disabled = false;
-        if (res.status >= 200 && res.status < 300 && res.body.ok) {
+        if (res.status === 429) {
+          setError('Too many attempts \u2014 please wait a few minutes and try again.');
+        } else if (res.status >= 200 && res.status < 300 && res.body.ok) {
+          setError(null);
           resetRegisterForm();
           showVerifyOverlay(email);
         } else if (res.body && res.body.error === 'underage') {
@@ -245,7 +248,9 @@
     }).then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
       .then(function (res) {
         btn.disabled = false;
-        if (res.status >= 200 && res.status < 300 && res.body.ok) {
+        if (res.status === 429) {
+          setError('Too many attempts \u2014 please wait a few minutes and try again.');
+        } else if (res.status >= 200 && res.status < 300 && res.body.ok) {
           var auth = {
             email: email,
             accessToken: res.body.accessToken,
@@ -278,8 +283,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: email }),
     }).then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
-      .then(function () {
+      .then(function (res) {
         btn.disabled = false;
+        if (res.status === 429) {
+          setError('Too many attempts \u2014 please wait a few minutes and try again.');
+          return;
+        }
         setError(null);
         setSuccess('Verification email sent.');
       }).catch(function (err) {
@@ -304,8 +313,12 @@
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: email }),
-    }).then(function () {
+    }).then(function (r) {
       btn.disabled = false;
+      if (r.status === 429) {
+        setError('Too many attempts \u2014 please wait a few minutes and try again.');
+        return;
+      }
       stopCountdown();
       startCountdown();
       var orig = btn.textContent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@ai-tutor/email": "*",
         "cors": "^2.8.5",
         "express": "^4.19.0",
+        "express-rate-limit": "^8.3.2",
         "geoip-lite": "^1.4.10",
         "multer": "^1.4.5-lts.1"
       },
@@ -1099,6 +1100,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fast-deep-equal": {


### PR DESCRIPTION
## Summary
- Installs `express-rate-limit` (approved dependency) in `apps/api`
- Applies per-route rate limiters inside `createAuthRouter`:
  - `loginLimiter`: 10 requests per 15 minutes
  - `registerLimiter`: 5 requests per hour
  - `resendLimiter`: 3 requests per 15 minutes (applies to `/resend-verification`)
- All limiters return HTTP 429 with `{ ok: false, error: "too_many_requests" }`
- Adds `app.set('trust proxy', 1)` in `index.ts` for correct `req.ip` behind Render's proxy
- Frontend `login.js` handles 429 on login, register, and resend-verification handlers with "Too many attempts" message

## Test plan
- [ ] Send 11 login requests in 15 minutes — confirm 11th returns 429
- [ ] Send 6 register requests in 1 hour — confirm 6th returns 429
- [ ] Send 4 resend-verification requests in 15 minutes — confirm 4th returns 429
- [ ] Trigger 429 from the login form — confirm "Too many attempts" error message appears
- [ ] Trigger 429 from the register form — confirm same message
- [ ] Trigger 429 from the resend button — confirm same message
- [ ] `npm run build` passes cleanly

Closes #95

Generated with [Claude Code](https://claude.com/claude-code)