### PR TITLE
docs: remove stale passcode references, document auth system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm run cli                # Launch the terminal REPL
 npm run backfill:evaluations  # Backfill session_evaluations for sessions missing a row
 ```
 
-> Copy `env.sh.template` to `env.sh`, fill in your values, then `source env.sh` before running any command.  `ANTHROPIC_API_KEY`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY` are required to start the API server.
+> Copy `env.sh.template` to `env.sh`, fill in your values, then `source env.sh` before running any command.  `ANTHROPIC_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  Without `SUPABASE_ANON_KEY` the auth router will not register and the app will be inaccessible.
 
 ---
 
@@ -107,7 +107,7 @@ packages/core    ← @anthropic-ai/sdk
 packages/db      ← @supabase/supabase-js
 packages/email   ← resend
 
-apps/api         ← packages/core, packages/db, packages/email, express, cors, multer, geoip-lite
+apps/api         ← packages/core, packages/db, packages/email, express, cors, multer, geoip-lite, express-rate-limit
 apps/cli         ← packages/core
 apps/web         ← (no npm deps — CDN only)
 ```
@@ -218,7 +218,7 @@ One row per registered user.  Created at registration time.
 | client_user_agent | text | Nullable |
 | session_id | uuid | FK → sessions(id) ON DELETE SET NULL. Nullable; backfilled after first /api/chat call via linkDisclaimerAcceptance(). |
 | client_session_id | text | Nullable. The client-generated session UUID stored at acceptance time (no FK constraint). Used to backfill session_id. |
-| email | text | Nullable. Email address submitted through the access-wall overlay. |
+| email | text | Nullable. Email address submitted through the disclaimer overlay. |
 
 ---
 
@@ -363,14 +363,14 @@ Submit end-of-session feedback.  Saves one row to `session_feedback`.  No email 
 
 ### POST /api/disclaimer/accept
 
-Record that the user accepted the access-wall overlay.
+Record that the user accepted the disclaimer overlay.
 
 **Request**: `application/json`
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | sessionId | string (UUID) | no | Client's current session ID; links the acceptance to the session for analysis |
-| email | string | no | Email address submitted through the access-wall overlay; stored in disclaimer_acceptances.email |
+| email | string | no | Email address submitted through the disclaimer overlay; stored in disclaimer_acceptances.email |
 
 **Response**: `application/json`
 
@@ -395,6 +395,14 @@ Supabase-backed individual-user login flow. **These endpoints are only registere
 - `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId, isAdmin: boolean, email, name }`. `isAdmin` is read from the `profiles` table; returns `false` for legacy users without a profile row (fail-closed). `email` is the user's email; `name` is from `user_metadata.name` (null if unset).
 
 JWT verification is handled by `createRequireAuth()` (in `apps/api/src/middleware/require-auth.ts`), which reads the bearer token and calls `db.auth.getUser(token)`. The middleware populates `userId`, `userEmail`, and `userName` on the request object. There is no `SUPABASE_JWT_SECRET` — Supabase's own verification API is used.
+
+Rate limiting is applied via `express-rate-limit` to protect auth endpoints from abuse.  Per-endpoint limits:
+- `POST /api/auth/login` — 10 requests per 15 minutes per IP
+- `POST /api/auth/register` — 5 requests per hour per IP
+- `POST /api/auth/resend-verification` — 3 requests per 15 minutes per IP
+- `POST /api/auth/forgot-password` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
+
+All rate-limited endpoints return `429 { ok: false, error: "too_many_requests" }` when the limit is exceeded.  The server sets `trust proxy` to `1` (in `apps/api/src/index.ts`) so `express-rate-limit` keys on the real client IP behind Render's proxy.
 
 ---
 
@@ -506,8 +514,8 @@ These apply to every Claude Code session in this repo.
 | `apps/api/src/routes/sessions.ts` | `GET/DELETE /api/sessions/:id` |
 | `apps/api/src/routes/transcript.ts` | `GET /api/transcript/:id` |
 | `apps/api/src/routes/feedback.ts` | `POST /api/feedback` — saves one `session_feedback` row |
-| `apps/api/src/routes/disclaimer.ts` | `POST /api/disclaimer/accept` — records access-wall acceptance with IP/geo/user-agent/email |
-| `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — POST `/register`, `/login`, `/resend-verification`, `/refresh`, `/logout` and GET `/me` for the Supabase auth login flow. Registered only if `SUPABASE_ANON_KEY` is set. The frontend redirects unauthenticated users to `/login.html`. |
+| `apps/api/src/routes/disclaimer.ts` | `POST /api/disclaimer/accept` — records disclaimer acceptance with IP/geo/user-agent/email |
+| `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — POST `/register`, `/login`, `/resend-verification`, `/forgot-password`, `/refresh`, `/logout` and GET `/me` for the Supabase auth login flow. Registered only if `SUPABASE_ANON_KEY` is set. The frontend redirects unauthenticated users to `/login.html`. |
 | `apps/api/src/middleware/require-auth.ts` | `createRequireAuth(db)` — middleware that verifies `Authorization: Bearer <token>` via `db.auth.getUser(token)` and sets `req.userId`. Used by the `/api/auth/me` and `/api/auth/logout` routes. |
 | `apps/api/scripts/gen-build-info.js` | Generates `build-info.json` (commit SHA + timestamp) at build time; called by the API `build` script |
 | `apps/api/build-info.json` | Generated build metadata (gitignored); read at startup by the config route |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ That's it.  Hand your student the project link.  They'll see a clean chat interf
 
 This runs the full application on your computer (or on a server — see [Deploying on Render](#deploying-on-render) below).  It gives you a chat interface at a web address, plus session history, email transcripts, and feedback tracking.
 
-The web app requires three services to run: **Anthropic** (AI), **Supabase** (database), and an **access passcode** you choose.  Email transcripts via **Resend** are optional.
+The web app requires three services to run: **Anthropic** (AI), **Supabase** (database and authentication), and a **Supabase anon key** for the login flow.  Email transcripts via **Resend** are optional.
 
 **Before you start:**  You'll need [Node.js](https://nodejs.org) version 20 or later installed.  If you're not sure whether you have it, open a terminal and run `node --version`.  If you see a version number starting with 20 or higher, you're set.
 
@@ -83,9 +83,9 @@ The web app stores session transcripts, messages, and feedback in a database so 
 
 Follow the instructions in [Setting up Supabase](#setting-up-supabase) below, then come back here.
 
-**Step 4: Choose an access passcode**
+**Step 4: Set up the Supabase anon key**
 
-The web app has an access wall — anyone visiting the URL must enter a passcode before they can use the tutor.  Pick a 5-digit code and share it with your student.
+In your Supabase project dashboard, go to **Settings → API**.  Copy the **anon/public** key (not the service_role key — you already have that from Step 3).  This key is used server-side for the login flow and is never exposed to the browser.
 
 **Step 5: Export environment variables**
 
@@ -93,7 +93,7 @@ The web app has an access wall — anyone visiting the URL must enter a passcode
 export ANTHROPIC_API_KEY=sk-ant-...
 export SUPABASE_URL=https://your-project-ref.supabase.co
 export SUPABASE_SERVICE_ROLE_KEY=eyJ...
-export ACCESS_PASSCODE=12345  # your 5-digit code
+export SUPABASE_ANON_KEY=eyJ...
 ```
 
 **Step 6: Build and start**
@@ -105,7 +105,7 @@ npm run api
 
 **Step 7: Open and verify**
 
-Open `http://localhost:3000` in your browser.  You'll see the access wall — enter your passcode.  Your student gets a chat interface.  Your API key stays on your computer — it's never sent to the browser.
+Open `http://localhost:3000` in your browser.  You'll see the login page — register an account or sign in.  Your student gets a chat interface.  Your API key stays on your computer — it's never sent to the browser.
 
 To get email transcripts sent to you when sessions end, continue to [Optional: email transcripts](#optional-email-transcripts).
 
@@ -113,7 +113,7 @@ To get email transcripts sent to you when sessions end, continue to [Optional: e
 
 ### Option C: CLI (terminal)
 
-For parents comfortable in a terminal.  No web interface — you type your student's messages at a prompt and see the tutor's responses in the terminal.  Does not require Supabase or an access passcode.  You'll need [Node.js](https://nodejs.org) version 20 or later installed (same as Option B).
+For parents comfortable in a terminal.  No web interface — you type your student's messages at a prompt and see the tutor's responses in the terminal.  Does not require Supabase or user accounts.  You'll need [Node.js](https://nodejs.org) version 20 or later installed (same as Option B).
 
 ```bash
 npm install
@@ -140,7 +140,8 @@ Supabase is a free hosted database.  The web app requires it — the server will
 
 1. In your project dashboard, go to **Settings → API**.
 2. Copy the **Project URL** — this is your `SUPABASE_URL`.
-3. Under **Project API keys**, copy the **service_role** key (the secret one, not `anon`) — this is your `SUPABASE_SERVICE_ROLE_KEY`.  Keep this key secret.  It has full access to your database.
+3. Under **Project API keys**, copy the **service_role** key (the secret one) — this is your `SUPABASE_SERVICE_ROLE_KEY`.  Keep this key secret.  It has full access to your database.
+4. Also copy the **anon/public** key — this is your `SUPABASE_ANON_KEY`.  It is used server-side for the login flow.
 
 **Step 3: Run the schema migration**
 
@@ -155,7 +156,7 @@ export SUPABASE_URL=https://your-project-ref.supabase.co
 export SUPABASE_SERVICE_ROLE_KEY=eyJ...
 ```
 
-Done?  [Continue to Step 4: Choose an access passcode](#option-b-web-app-self-hosted).
+Done?  [Continue to Step 5: Export environment variables](#option-b-web-app-self-hosted).
 
 ---
 
@@ -203,11 +204,11 @@ This table is a quick reference.  If you followed Option B above, you've already
 | `ANTHROPIC_API_KEY` | **yes** | — | Your Anthropic API key. |
 | `SUPABASE_URL` | **yes (web app)** | — | Your Supabase project URL.  Server will not start without it. |
 | `SUPABASE_SERVICE_ROLE_KEY` | **yes (web app)** | — | Supabase service role key.  Keep secret. |
-| `ACCESS_PASSCODE` | **yes (web app)** | — | 5-digit passcode for the access wall.  Share with your student. |
+| `SUPABASE_ANON_KEY` | **yes (web app)** | — | Supabase anon/public key.  Required for the login flow. |
 | `RESEND_API_KEY` | no | — | Resend API key.  Emails skipped if absent. |
 | `PARENT_EMAIL` | no | — | Where transcript emails are sent. |
 | `EMAIL_FROM` | no | `tutor@tutor.schmim.com` | Sender address.  Must match a verified Resend domain. |
-| `CONTACT_EMAIL` | no | `wax.spirits8d@icloud.com` | Contact email shown in the access-wall overlay. |
+| `CONTACT_EMAIL` | no | `wax.spirits8d@icloud.com` | Contact email shown on the login page and returned by GET /api/config. |
 | `CORS_ORIGIN` | no | `*` | Allowed origin if you put the app behind a specific URL. |
 | `MODEL` | no | `claude-sonnet-4-6` | Claude model ID. |
 | `EXTENDED_THINKING` | no | `true` | Set to `false` to disable extended thinking (faster, lower cost, weaker tutoring quality). |
@@ -279,7 +280,7 @@ These emerged from multiple iterations and test runs across distinct scenarios:
 Command-line interface with extended thinking, transcript export, and configurable system prompt.
 
 ### Phase 2: Web UI ✅
-Express server with a single-page chat interface, file uploads, transcript export, session management, end-of-session email summaries (with session ID and token usage) sent to the parent via Resend, a live cumulative token counter in the header, an access-wall overlay with passcode entry, and an end-of-session feedback overlay that collects outcome, experience, and optional comment.  Session data is retained in the database for analysis.
+Express server with a single-page chat interface, file uploads, transcript export, session management, end-of-session email summaries (with session ID and token usage) sent to the parent via Resend, a live cumulative token counter in the header, Supabase-backed login/registration with email verification, and an end-of-session feedback overlay that collects outcome, experience, and optional comment.  Session data is retained in the database for analysis.
 
 ### Phase 3: Documentation and deployment ✅
 CLAUDE.md, package READMEs, deployment config (render.yaml, docs/deployment.md).

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -24,6 +24,7 @@ This is the only process that runs in production.  It:
 | `cors` | CORS middleware |
 | `multer` | Multipart file uploads |
 | `geoip-lite` | IP → city/country lookup (local database) |
+| `express-rate-limit` | Per-endpoint rate limiting for auth routes |
 
 ## API endpoints
 
@@ -35,8 +36,14 @@ This is the only process that runs in production.  It:
 | `DELETE` | `/api/sessions/:id` | End session; runs evaluation, sends transcript email, sets `ended_at` |
 | `GET` | `/api/transcript/:id` | Conversation transcript (prefers in-memory, falls back to DB) |
 | `POST` | `/api/feedback` | Submit end-of-session feedback (one `session_feedback` row) |
-| `POST` | `/api/disclaimer/accept` | Record access-wall acceptance (sessionId, email) |
-| `POST` | `/api/access/verify` | Validate 5-digit passcode |
+| `POST` | `/api/disclaimer/accept` | Record disclaimer acceptance (sessionId, email) |
+| `POST` | `/api/auth/register` | Create a new user account (email verification required) |
+| `POST` | `/api/auth/login` | Sign in with email and password |
+| `POST` | `/api/auth/resend-verification` | Re-send signup verification email |
+| `POST` | `/api/auth/forgot-password` | Send password-reset email |
+| `POST` | `/api/auth/refresh` | Exchange refresh token for new access token |
+| `POST` | `/api/auth/logout` | Revoke all refresh tokens (requires auth) |
+| `GET`  | `/api/auth/me` | Get authenticated user's profile (requires auth) |
 
 For full request/response schemas, see the [API endpoint reference](../../CLAUDE.md#api-endpoint-reference) in CLAUDE.md.
 
@@ -51,7 +58,7 @@ Required environment variables:
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `SUPABASE_URL` | Supabase project URL |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key |
-| `ACCESS_PASSCODE` | 5-digit passcode for the access wall |
+| `SUPABASE_ANON_KEY` | Supabase anon/public key (required for auth flow) |
 
 For the full table with defaults and optional variables, see the [environment variables reference](../../README.md#environment-variables--full-reference) in the root README.
 
@@ -89,10 +96,11 @@ apps/api/src/
 │   ├── transcript.ts       ← GET /api/transcript/:id
 │   ├── feedback.ts         ← POST /api/feedback
 │   ├── disclaimer.ts       ← POST /api/disclaimer/accept
-│   └── access.ts           ← POST /api/access/verify
+│   └── auth.ts             ← POST/GET /api/auth/* (register, login, refresh, etc.)
 ├── middleware/
 │   ├── cors.ts             ← CORS (origin from CORS_ORIGIN env var)
-│   └── errors.ts           ← Global error handler
+│   ├── errors.ts           ← Global error handler
+│   └── require-auth.ts     ← Bearer token verification middleware
 └── lib/
     ├── evaluation.ts       ← runSessionEvaluation(), buildEvaluationPayload()
     ├── session-store.ts    ← In-memory Map<sessionId, Session>

--- a/env.sh.template
+++ b/env.sh.template
@@ -20,7 +20,7 @@ export ANTHROPIC_API_KEY=""           # Required. Get from https://console.anthr
 
 export SUPABASE_URL=""                # Your project URL, e.g. https://xxxx.supabase.co
 export SUPABASE_SERVICE_ROLE_KEY=""   # Service role key (bypasses RLS); never expose client-side
-export SUPABASE_ANON_KEY=""           # Optional. Anon/public key. Enables /api/auth/* and /login.html (issue #73). Still held server-side; never exposed via /api/config.
+export SUPABASE_ANON_KEY=""           # Required. Anon/public key. Enables /api/auth/* and /login.html. Still held server-side; never exposed via /api/config.
 
 # ---------------------------------------------------------------------------
 # Email via Resend (optional — emails silently skipped if absent)
@@ -36,6 +36,7 @@ export EMAIL_FROM="tutor@tutor.schmim.com"  # Sender address (default: tutor@tut
 
 export PORT="3000"                    # HTTP listen port (default: 3000)
 export CORS_ORIGIN="*"               # Allowed CORS origin (default: *)
+export CONTACT_EMAIL="wax.spirits8d@icloud.com"     # Contact email shown on the login page and in /api/config (default: wax.spirits8d@icloud.com)
 
 # ---------------------------------------------------------------------------
 # Model / tutor behavior
@@ -45,9 +46,3 @@ export MODEL="claude-sonnet-4-6"                    # Anthropic model ID (defaul
 export EXTENDED_THINKING="true"                     # Set "false" to disable (default: true)
 export SYSTEM_PROMPT_PATH="templates/tutor-prompt-v7.md"  # Path from repo root (default: templates/tutor-prompt-v7.md)
 
-# ---------------------------------------------------------------------------
-# Access wall
-# ---------------------------------------------------------------------------
-
-export ACCESS_PASSCODE=""                            # Required. 5-digit numeric code shared with authorized users
-export CONTACT_EMAIL="wax.spirits8d@icloud.com"     # Shown in access-wall overlay (default: wax.spirits8d@icloud.com)

--- a/render.yaml
+++ b/render.yaml
@@ -13,6 +13,8 @@ services:
         sync: false
       - key: SUPABASE_SERVICE_ROLE_KEY
         sync: false
+      - key: SUPABASE_ANON_KEY
+        sync: false
       - key: RESEND_API_KEY
         sync: false
       - key: PARENT_EMAIL
@@ -27,8 +29,6 @@ services:
         value: "true"
       - key: PORT
         value: "3000"
-      - key: ACCESS_PASSCODE
-        sync: false
       - key: CONTACT_EMAIL
         sync: false
     healthCheckPath: /api/config


### PR DESCRIPTION
## Summary
- **render.yaml**: removed stale `ACCESS_PASSCODE` env var, added missing `SUPABASE_ANON_KEY`
- **env.sh.template**: deleted "Access wall" section, marked `SUPABASE_ANON_KEY` as required, relocated `CONTACT_EMAIL`
- **apps/api/README.md**: removed `POST /api/access/verify`, added 7 auth endpoints, updated deps and source tree
- **CLAUDE.md**: added rate limiting docs, added `express-rate-limit` to dependency diagram, updated file references
- **README.md**: rewrote setup guide (passcode → auth flow), updated env var table and roadmap

## Test plan
- [ ] `grep -ri "passcode\|access_passcode\|access/verify\|access wall" README.md CLAUDE.md render.yaml env.sh.template apps/api/README.md` returns zero matches
- [ ] `SUPABASE_ANON_KEY` documented in all 6 relevant files
- [ ] `npm run build` passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)