### PR TITLE
feat: persistent sessions with Remember me checkbox

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -167,7 +167,7 @@
   // ── Admin badge visibility + user identity ───────────────────────────────
   async function fetchUserInfo() {
     try {
-      const authRaw = sessionStorage.getItem('authSession');
+      const authRaw = sessionStorage.getItem('authSession') || localStorage.getItem('authSession');
       if (!authRaw) return;
       const auth = JSON.parse(authRaw);
       if (!auth || !auth.accessToken) return;
@@ -197,7 +197,7 @@
 
   async function handleLogout() {
     try {
-      const authRaw = sessionStorage.getItem('authSession');
+      const authRaw = sessionStorage.getItem('authSession') || localStorage.getItem('authSession');
       if (authRaw) {
         const auth = JSON.parse(authRaw);
         if (auth && auth.accessToken) {
@@ -211,6 +211,7 @@
       // Proceed regardless of API result (fail-open).
     }
     sessionStorage.removeItem('authSession');
+    localStorage.removeItem('authSession');
     window.location.href = '/login.html';
   }
 
@@ -439,7 +440,7 @@
       activeAbortController = new AbortController();
       const fetchOpts = { method: 'POST', body: fd, signal: activeAbortController.signal, headers: {} };
       try {
-        const authRaw = sessionStorage.getItem('authSession');
+        const authRaw = sessionStorage.getItem('authSession') || localStorage.getItem('authSession');
         if (authRaw) {
           const auth = JSON.parse(authRaw);
           if (auth && auth.accessToken) {
@@ -1078,13 +1079,14 @@
   // synchronously before any UI renders.
   (function () {
     try {
-      var raw = sessionStorage.getItem('authSession');
+      var raw = sessionStorage.getItem('authSession') || localStorage.getItem('authSession');
       if (!raw) { window.location.href = '/login.html'; return; }
       var auth = JSON.parse(raw);
       if (!auth || !auth.accessToken) { window.location.href = '/login.html'; return; }
       // Check token expiry (Supabase expiresAt is in Unix seconds)
       if (auth.expiresAt && Date.now() / 1000 > auth.expiresAt) {
         sessionStorage.removeItem('authSession');
+        localStorage.removeItem('authSession');
         window.location.href = '/login.html';
         return;
       }
@@ -1095,10 +1097,15 @@
   var refreshTimer = null;
   var REFRESH_LEAD_MS = 2 * 60 * 1000; // 2 minutes before expiry
 
+  /** Return whichever storage currently holds the auth session (sessionStorage wins). */
+  function authStorage() {
+    return sessionStorage.getItem('authSession') ? sessionStorage : localStorage;
+  }
+
   function scheduleTokenRefresh() {
     if (refreshTimer) clearTimeout(refreshTimer);
     try {
-      var raw = sessionStorage.getItem('authSession');
+      var raw = sessionStorage.getItem('authSession') || localStorage.getItem('authSession');
       if (!raw) return;
       var auth = JSON.parse(raw);
       if (!auth || !auth.refreshToken || !auth.expiresAt) return;
@@ -1109,7 +1116,8 @@
   }
 
   function doTokenRefresh() {
-    var raw = sessionStorage.getItem('authSession');
+    var store = authStorage();
+    var raw = store.getItem('authSession');
     if (!raw) return;
     var auth;
     try { auth = JSON.parse(raw); } catch (e) { return; }
@@ -1123,7 +1131,7 @@
       .then(function (r) { return r.json(); })
       .then(function (res) {
         if (res.ok && res.accessToken) {
-          sessionStorage.setItem('authSession', JSON.stringify({
+          store.setItem('authSession', JSON.stringify({
             accessToken: res.accessToken,
             refreshToken: res.refreshToken,
             expiresAt: res.expiresAt,
@@ -1132,6 +1140,7 @@
         } else {
           // Refresh token also expired — force re-login
           sessionStorage.removeItem('authSession');
+          localStorage.removeItem('authSession');
           window.location.href = '/login.html?reason=session_expired';
         }
       })

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -31,6 +31,10 @@
           <span class="login-label">Password</span>
           <input type="password" id="login-password" class="login-input" autocomplete="current-password" required minlength="8">
         </label>
+        <label class="login-checkbox-row">
+          <input type="checkbox" id="login-remember">
+          <span class="login-checkbox-label">Remember me</span>
+        </label>
         <button type="submit" class="login-btn login-btn-primary" id="btn-login">Sign in</button>
         <button type="button" class="login-btn" id="btn-resend-verification" style="display:none">Resend verification email</button>
         <button type="button" class="login-forgot-link" id="btn-show-forgot">Forgot password?</button>

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -25,16 +25,25 @@
   function loadAuth() {
     try {
       var raw = sessionStorage.getItem(AUTH_KEY);
+      if (raw) return JSON.parse(raw);
+      raw = localStorage.getItem(AUTH_KEY);
       return raw ? JSON.parse(raw) : null;
     } catch (e) { return null; }
   }
 
-  function saveAuth(obj) {
-    sessionStorage.setItem(AUTH_KEY, JSON.stringify(obj));
+  /** Detect which storage holds the current session (sessionStorage wins). */
+  function authStorage() {
+    return sessionStorage.getItem(AUTH_KEY) ? sessionStorage : localStorage;
+  }
+
+  function saveAuth(obj, persistent) {
+    var store = persistent ? localStorage : sessionStorage;
+    store.setItem(AUTH_KEY, JSON.stringify(obj));
   }
 
   function clearAuth() {
     sessionStorage.removeItem(AUTH_KEY);
+    localStorage.removeItem(AUTH_KEY);
   }
 
   function isAuthValid(auth) {
@@ -251,13 +260,14 @@
         if (res.status === 429) {
           setError('Too many attempts \u2014 please wait a few minutes and try again.');
         } else if (res.status >= 200 && res.status < 300 && res.body.ok) {
+          var remember = $('login-remember').checked;
           var auth = {
             email: email,
             accessToken: res.body.accessToken,
             refreshToken: res.body.refreshToken,
             expiresAt: res.body.expiresAt,
           };
-          saveAuth(auth);
+          saveAuth(auth, remember);
           window.location.href = '/';
           return;
         } else if (res.body && res.body.error === 'email_not_confirmed') {


### PR DESCRIPTION
## Summary
- Adds a "Remember me" checkbox to the login form that stores auth tokens in `localStorage` instead of `sessionStorage`, so sessions survive browser restarts
- Updates all auth reads in `app.js` to check `sessionStorage` first, fall back to `localStorage`
- Logout and token expiry clear both storages; token refresh writes back to whichever storage the session came from

Closes #96

## Test plan
- [ ] Sign in without "Remember me" checked -- close and reopen browser tab -- should be redirected to login
- [ ] Sign in with "Remember me" checked -- close and reopen browser tab -- should stay authenticated
- [ ] Log out from either mode -- both storages should be cleared
- [ ] Token refresh should write back to the same storage the session came from
- [ ] Hash callback flow (email verification, password recovery) should default to sessionStorage

Generated with [Claude Code](https://claude.com/claude-code)