### PR TITLE
feat: change-password endpoint and recovery redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ Always returns `200 { ok: true }` — DB errors are caught and logged server-sid
 
 ---
 
-### POST /api/auth/register, POST /api/auth/login, POST /api/auth/resend-verification, POST /api/auth/forgot-password, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
+### POST /api/auth/register, POST /api/auth/login, POST /api/auth/resend-verification, POST /api/auth/forgot-password, POST /api/auth/change-password, POST /api/auth/refresh, POST /api/auth/logout, GET /api/auth/me
 
 Supabase-backed individual-user login flow. **These endpoints are only registered if `SUPABASE_ANON_KEY` is set.** They do not gate `/api/chat`, `/api/sessions`, `/api/transcript`, or `/api/feedback` — the auth gate is enforced client-side via a JWT check in `app.js` that redirects unauthenticated users to `/login.html`.
 
@@ -390,6 +390,7 @@ Supabase-backed individual-user login flow. **These endpoints are only registere
 - `POST /api/auth/login` — body `{ email, password }`. Calls `anonDb.auth.signInWithPassword(...)`. Returns `{ ok: true, accessToken, refreshToken, expiresAt }` on success. On failure, returns `{ ok: false, error: "email_not_confirmed" }` (HTTP 401) when the account is unconfirmed so the client can show a "Resend verification" affordance. All other failures return the opaque `{ ok: false, error: "invalid_credentials" }`.
 - `POST /api/auth/resend-verification` — body `{ email }`. Re-sends the Supabase signup confirmation email via `anonDb.auth.resend({ type: "signup", email })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). Errors logged server-side only.
 - `POST /api/auth/forgot-password` — body `{ email }`. Sends a Supabase password-reset email via `anonDb.auth.resetPasswordForEmail(email, { redirectTo })`. Always returns `{ ok: true }` regardless of whether the address is registered (anti-enumeration). The `redirectTo` URL is derived from `req.headers.origin` (or `req.headers.host`). No new env vars required. Errors logged server-side only.
+- `POST /api/auth/change-password` — requires `Authorization: Bearer <accessToken>`. Body `{ newPassword }`. Validates `newPassword` >= 8 characters. Calls `db.auth.admin.updateUserById(userId, { password: newPassword })`. Returns `{ ok: true }` on success, `{ ok: false, error: "weak_password" }` if validation fails. Note: current password is not verified server-side (Supabase admin API limitation); the bearer token provides sufficient authorization.
 - `POST /api/auth/refresh` — body `{ refreshToken }`. Calls `anonDb.auth.refreshSession(...)`. Returns `{ ok, accessToken?, refreshToken?, expiresAt? }`.
 - `POST /api/auth/logout` — requires `Authorization: Bearer <accessToken>`. Calls `db.auth.admin.signOut(userId)` (service-role admin API). Returns `{ ok: true }`.
 - `GET /api/auth/me` — requires `Authorization: Bearer <accessToken>`. Returns `{ ok: true, userId, isAdmin: boolean, email, name }`. `isAdmin` is read from the `profiles` table; returns `false` for legacy users without a profile row (fail-closed). `email` is the user's email; `name` is from `user_metadata.name` (null if unset).
@@ -401,6 +402,7 @@ Rate limiting is applied via `express-rate-limit` to protect auth endpoints from
 - `POST /api/auth/register` — 5 requests per hour per IP
 - `POST /api/auth/resend-verification` — 3 requests per 15 minutes per IP
 - `POST /api/auth/forgot-password` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
+- `POST /api/auth/change-password` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
 
 All rate-limited endpoints return `429 { ok: false, error: "too_many_requests" }` when the limit is exceeded.  The server sets `trust proxy` to `1` (in `apps/api/src/index.ts`) so `express-rate-limit` keys on the real client IP behind Render's proxy.
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -320,6 +320,42 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
   });
 
   /**
+   * POST /api/auth/change-password
+   *
+   * Updates the authenticated user's password via the service-role admin API.
+   * Body: `{ newPassword: string }` — must be >= 8 characters.
+   *
+   * Note: The current password is NOT verified server-side. Supabase's
+   * `auth.admin.updateUserById` does not support verifying the old password,
+   * and `auth.updateUser` requires a valid client-side session (which we
+   * don't have on the service-role client). The user must already be
+   * authenticated (bearer token verified by requireAuth middleware), which
+   * provides sufficient authorization for this action.
+   */
+  router.post("/change-password", resendLimiter, requireAuth, async (req, res) => {
+    const body = req.body as { newPassword?: unknown } | undefined;
+    const newPassword = body?.newPassword;
+    if (typeof newPassword !== "string" || newPassword.length < 8) {
+      res.status(400).json({ ok: false, error: "weak_password" });
+      return;
+    }
+
+    const userId = (req as AuthedRequest).userId;
+    try {
+      const { error } = await db.auth.admin.updateUserById(userId, { password: newPassword });
+      if (error) {
+        console.error("[auth] change-password updateUserById failed:", error);
+        res.status(500).json({ ok: false, error: "server_error" });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      console.error("[auth] change-password unexpected error:", err);
+      res.status(500).json({ ok: false, error: "server_error" });
+    }
+  });
+
+  /**
    * POST /api/auth/logout
    *
    * Revokes all refresh tokens for the authenticated user via the

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -361,7 +361,12 @@
         refreshToken: params.get('refresh_token') || null,
         expiresAt: expiresAt,
       });
-      window.location.replace('/');
+      if (type === 'recovery') {
+        sessionStorage.setItem('authRecoveryPending', 'true');
+        window.location.replace('/settings.html?recovery=1');
+      } else {
+        window.location.replace('/');
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- Adds `POST /api/auth/change-password` endpoint requiring bearer auth, validating password >= 8 chars, rate-limited (3 req/15min via `resendLimiter`)
- Updates `login.js` recovery hash callback to set `authRecoveryPending` flag and redirect to `settings.html?recovery=1` instead of `/`
- Documents the new endpoint in CLAUDE.md API reference and rate-limit table

Closes #94

## Test plan
- [ ] `POST /api/auth/change-password` with valid token and newPassword >= 8 chars returns `{ ok: true }`
- [ ] `POST /api/auth/change-password` with newPassword < 8 chars returns 400 `{ ok: false, error: "weak_password" }`
- [ ] `POST /api/auth/change-password` without auth header returns 401
- [ ] Rate limiting: 4th request within 15 minutes returns 429
- [ ] Password recovery link in email redirects to `settings.html?recovery=1` with `authRecoveryPending` in sessionStorage

Generated with [Claude Code](https://claude.com/claude-code)