### PR TITLE
feat: account management dropdown in chat header

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -89,9 +89,11 @@
   const btnCloseTx     = $('btn-close-tx');
   const btnCloseTx2    = $('btn-close-tx2');
   const btnCopyTx      = $('btn-copy-tx');
-  const userIdentityEl     = $('user-identity');
+  const accountTrigger     = $('account-trigger');
+  const accountDropdown    = $('account-dropdown');
+  const accountDropdownInfo = $('account-dropdown-info');
   const userDisplayName    = $('user-display-name');
-  const btnLogout          = $('btn-logout');
+  const menuLogout         = $('menu-logout');
   const dragOverlay        = $('drag-overlay');
   const wrappingUpOverlay  = $('wrapping-up-overlay');
   const toast              = $('toast');
@@ -187,8 +189,10 @@
         const displayName = data.name || data.email || '';
         if (displayName) {
           userDisplayName.textContent = displayName;
-          userIdentityEl.style.display = '';
+          accountTrigger.style.display = '';
         }
+        // Populate dropdown info line with email (or name if no email)
+        accountDropdownInfo.textContent = data.email || displayName;
       }
     } catch {
       // Network or parse failure: leave badges hidden and identity hidden.
@@ -1056,9 +1060,45 @@
         e.target !== modelBadge && e.target !== promptBadge && e.target !== thinkingBadge) {
       closeConfigPicker();
     }
+    if (accountDropdown.style.display !== 'none' &&
+        !accountDropdown.contains(e.target) &&
+        !accountTrigger.contains(e.target)) {
+      closeAccountDropdown();
+    }
   });
 
-  btnLogout.addEventListener('click', handleLogout);
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && accountDropdown.style.display !== 'none') {
+      closeAccountDropdown();
+    }
+  });
+
+  // ── Account dropdown ──────────────────────────────────────────────────────
+  function openAccountDropdown() {
+    const rect = accountTrigger.getBoundingClientRect();
+    accountDropdown.style.top  = (rect.bottom + window.scrollY + 6) + 'px';
+    accountDropdown.style.left = Math.max(0, rect.right - 180) + 'px';
+    accountDropdown.style.display = '';
+    accountTrigger.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeAccountDropdown() {
+    accountDropdown.style.display = 'none';
+    accountTrigger.setAttribute('aria-expanded', 'false');
+  }
+
+  accountTrigger.addEventListener('click', () => {
+    if (accountDropdown.style.display !== 'none') {
+      closeAccountDropdown();
+    } else {
+      openAccountDropdown();
+    }
+  });
+
+  menuLogout.addEventListener('click', () => {
+    closeAccountDropdown();
+    handleLogout();
+  });
 
   btnSwitchConfirm.addEventListener('click', confirmSwitch);
   btnSwitchCancel.addEventListener('click',  () => { switchConfigOverlay.classList.remove('active'); pendingSwitch = null; });

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -56,9 +56,17 @@
       </span>
     </span>
     <div class="header-right">
-      <div id="user-identity" class="user-identity" style="display:none">
+      <button id="account-trigger" class="account-trigger" style="display:none" aria-haspopup="true" aria-expanded="false">
         <span id="user-display-name" class="user-display-name"></span>
-        <button id="btn-logout" class="btn btn-sm btn-logout">Log out</button>
+        <svg class="account-caret" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+      </button>
+      <div id="account-dropdown" class="account-dropdown" style="display:none" role="menu">
+        <div class="account-dropdown-info" id="account-dropdown-info"></div>
+        <div class="account-dropdown-divider"></div>
+        <button class="account-dropdown-item" id="menu-settings" role="menuitem" aria-disabled="true" disabled>Settings</button>
+        <button class="account-dropdown-item" id="menu-history" role="menuitem" aria-disabled="true" disabled>History</button>
+        <div class="account-dropdown-divider"></div>
+        <button class="account-dropdown-item account-dropdown-logout" id="menu-logout" role="menuitem">Log out</button>
       </div>
       <span id="build-info" class="build-info"></span>
       <span id="thinking-badge" class="thinking-badge" style="display:none" title="Extended thinking — click to toggle"></span>

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -171,27 +171,83 @@
       opacity: 0.6;
     }
 
-    /* ── User identity + logout ────────────────────────────────────────── */
-    .user-identity {
+    /* ── Account trigger + dropdown ───────────────────────────────────── */
+    .account-trigger {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 4px;
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 4px 10px;
+      cursor: pointer;
+      color: var(--text-muted);
+      font-family: var(--font-sans);
+      font-size: 0.75rem;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .account-trigger:hover {
+      color: var(--text);
+      border-color: var(--accent);
+    }
+    .account-caret {
+      width: 10px;
+      height: 6px;
+      flex-shrink: 0;
     }
     .user-display-name {
-      font-size: 0.75rem;
-      color: var(--text-muted);
       white-space: nowrap;
       max-width: 140px;
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .btn-logout {
-      color: var(--text-muted);
-      border-color: var(--border);
+    .account-dropdown {
+      position: fixed;
+      z-index: 300;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+      min-width: 180px;
+      padding: 4px 0;
     }
-    .btn-logout:hover {
+    .account-dropdown-info {
+      padding: 8px 14px;
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      word-break: break-all;
+    }
+    .account-dropdown-divider {
+      height: 1px;
+      background: var(--border);
+      margin: 4px 0;
+    }
+    .account-dropdown-item {
+      display: block;
+      width: 100%;
+      padding: 8px 14px;
+      background: none;
+      border: none;
+      text-align: left;
+      font-family: var(--font-sans);
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+    .account-dropdown-item:hover:not(:disabled) {
+      background: var(--surface-alt);
+      color: var(--text);
+    }
+    .account-dropdown-item:disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+    .account-dropdown-logout {
       color: var(--danger);
-      border-color: var(--danger);
+    }
+    .account-dropdown-logout:hover {
+      color: var(--danger);
     }
 
     /* ── Config picker dropdown ─────────────────────────────────────────── */
@@ -881,6 +937,7 @@
       .empty-chips { display: none; }
       .logo-company { font-size: 1rem; }
       .user-display-name { display: none; }
+      .account-caret { margin-left: 0; }
     }
 
     /* ── Message appear animation ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Replaces flat user-identity area (name + logout button) with a dropdown trigger button that opens an account menu
- Dropdown contains: user email display, disabled Settings/History stubs (for future pages), divider, and Logout action
- Uses same fixed-position pattern as the existing config-picker popup, with click-outside and Escape-key dismissal

Closes #106

## Test plan
- [ ] Dropdown trigger shows user name (or caret only on mobile), clicking toggles the dropdown
- [ ] Dropdown displays user email in the info area
- [ ] Settings and History items are visually disabled (`opacity: 0.5`, `pointer-events: none`, `aria-disabled`)
- [ ] Logout item calls the existing logout handler and redirects to login
- [ ] Click outside the dropdown closes it
- [ ] Pressing Escape closes the dropdown
- [ ] On mobile, the dropdown is still accessible (name hidden but caret visible)

Generated with [Claude Code](https://claude.com/claude-code)