### PR TITLE
feat: add session history page (#93)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,7 @@ import { createFeedbackRouter } from "./routes/feedback.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createDisclaimerRouter } from "./routes/disclaimer.js";
 import { createAuthRouter } from "./routes/auth.js";
+import { createHistoryRouter } from "./routes/history.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
@@ -99,6 +100,7 @@ app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defa
 app.use("/api/disclaimer", createDisclaimerRouter(db));
 if (anonDb) {
   app.use("/api/auth", createAuthRouter(db, anonDb));
+  app.use("/api/history", createHistoryRouter(db));
 }
 
 app.use(errorHandler);

--- a/apps/api/src/middleware/require-auth.ts
+++ b/apps/api/src/middleware/require-auth.ts
@@ -12,6 +12,17 @@ export interface AuthedRequest extends Request {
 }
 
 /**
+ * Request that MAY have passed through `createOptionalAuth`. Unlike
+ * `AuthedRequest`, `userId` is optional — it is set only when a valid
+ * Bearer token is present.
+ */
+export interface OptionalAuthRequest extends Request {
+  userId?: string;
+  userEmail?: string;
+  userName?: string | null;
+}
+
+/**
  * Create an auth-enforcing middleware bound to a Supabase service-role client.
  *
  * The middleware reads `Authorization: Bearer <token>` from the request,
@@ -56,5 +67,43 @@ export function createRequireAuth(db: SupabaseClient): RequestHandler {
     } catch {
       res.status(401).json({ ok: false, error: "unauthorized" });
     }
+  };
+}
+
+/**
+ * Create an optional-auth middleware bound to a Supabase service-role client.
+ *
+ * If a valid `Authorization: Bearer <token>` header is present, sets
+ * `req.userId`, `req.userEmail`, and `req.userName` on the request. If the
+ * header is missing, malformed, or the token is invalid, the middleware
+ * silently continues without populating user fields. It NEVER returns 401.
+ */
+export function createOptionalAuth(db: SupabaseClient): RequestHandler {
+  return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
+    const header = req.headers.authorization;
+    if (!header || typeof header !== "string") {
+      next();
+      return;
+    }
+
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    const token = match?.[1]?.trim();
+    if (!token) {
+      next();
+      return;
+    }
+
+    try {
+      const { data, error } = await db.auth.getUser(token);
+      if (!error && data?.user?.id) {
+        (req as OptionalAuthRequest).userId = data.user.id;
+        (req as OptionalAuthRequest).userEmail = data.user.email ?? "";
+        (req as OptionalAuthRequest).userName =
+          (data.user.user_metadata?.name as string | undefined) ?? null;
+      }
+    } catch {
+      // Token invalid or expired — proceed without auth.
+    }
+    next();
   };
 }

--- a/apps/api/src/routes/history.ts
+++ b/apps/api/src/routes/history.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getSessionsByUser } from "@ai-tutor/db";
+import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
+
+/**
+ * History router — returns ended sessions for the authenticated user.
+ *
+ * GET /api/history
+ *   Requires Bearer auth. Returns the 50 most recent ended sessions for the
+ *   calling user, ordered by started_at DESC.
+ */
+export function createHistoryRouter(db: SupabaseClient): Router {
+  const router = Router();
+  const requireAuth = createRequireAuth(db);
+
+  router.get("/", requireAuth, async (req, res, next) => {
+    try {
+      const { userId } = req as AuthedRequest;
+      const rows = await getSessionsByUser(db, userId);
+
+      const sessions = rows.map((r) => ({
+        id: r.id,
+        started_at: r.started_at,
+        ended_at: r.ended_at,
+        prompt_name: r.prompt_name,
+        model: r.model,
+        total_input_tokens: r.total_input_tokens,
+        total_output_tokens: r.total_output_tokens,
+      }));
+
+      res.json({ sessions });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/transcript.ts
+++ b/apps/api/src/routes/transcript.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
-import { getMessagesBySession } from "@ai-tutor/db";
+import { getMessagesBySession, getSession as getDbSession } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession } from "../lib/session-store.js";
 import { UUID_RE } from "../lib/validation.js";
+import { createOptionalAuth, type OptionalAuthRequest } from "../middleware/require-auth.js";
 
 export function createTranscriptRouter(db: SupabaseClient): Router {
   const router = Router();
+  const optionalAuth = createOptionalAuth(db);
 
   /**
    * GET /api/transcript/:sessionId
@@ -14,15 +16,32 @@ export function createTranscriptRouter(db: SupabaseClient): Router {
    * the most up-to-date data); falls back to the database if the session has
    * been removed from memory.
    *
+   * Ownership check: if a Bearer token is present, the middleware populates
+   * req.userId. When the session has a user_id that differs from the caller,
+   * the request is rejected with 403. When no Bearer token is provided the
+   * request proceeds unauthenticated (preserves the existing app.js path).
+   *
    * Response: { transcript: Array<{ role: string, text: string }> }
    */
-  router.get("/:sessionId", async (req, res, next) => {
+  router.get("/:sessionId", optionalAuth, async (req, res, next) => {
     try {
       const { sessionId } = req.params;
       if (!UUID_RE.test(sessionId)) {
         res.status(400).json({ error: "sessionId must be a valid UUID." });
         return;
       }
+
+      const callerId = (req as OptionalAuthRequest).userId;
+
+      // Ownership check — only for authenticated callers viewing DB sessions.
+      if (callerId) {
+        const dbRow = await getDbSession(db, sessionId);
+        if (dbRow?.user_id && dbRow.user_id !== callerId) {
+          res.status(403).json({ error: "forbidden" });
+          return;
+        }
+      }
+
       const session = getSession(sessionId);
 
       if (session) {

--- a/apps/web/public/history.css
+++ b/apps/web/public/history.css
@@ -1,0 +1,241 @@
+/* history.css — standalone styles for /history.html.
+ *
+ * Mirrors the login.css dark theme palette and CSS variable approach.
+ * Self-contained so the page can be tested in isolation.
+ */
+
+:root {
+  --bg: #0f1117;
+  --card: #1a1d27;
+  --border: #2a2e3a;
+  --text: #e7e9ee;
+  --text-muted: #9aa0ad;
+  --accent: #7c6af7;
+  --accent-hover: #8d7dfa;
+  --danger: #ef4444;
+  --success: #22c55e;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.history-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+}
+
+.history-card {
+  width: 100%;
+  max-width: 640px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.history-title {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.history-back-link {
+  color: var(--accent);
+  font-size: 0.85rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.history-back-link:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.history-loading,
+.history-empty {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.history-error {
+  color: var(--danger);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+/* ── Session list ──────────────────────────────────────────────── */
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-item {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  transition: border-color 0.15s;
+}
+
+.history-item:hover {
+  border-color: var(--accent);
+}
+
+.history-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.history-item-date {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.history-item-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.history-view-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.history-view-btn:hover {
+  background: var(--accent-hover);
+}
+
+/* ── Transcript overlay ────────────────────────────────────────── */
+
+.transcript-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.transcript-panel {
+  width: 100%;
+  max-width: 640px;
+  max-height: 80vh;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.transcript-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.transcript-panel-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.transcript-close-btn {
+  background: #2a2e3a;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.3rem 0.65rem;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.transcript-close-btn:hover {
+  background: #323745;
+}
+
+.transcript-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.transcript-msg {
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.transcript-msg-role {
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.15rem;
+}
+
+.transcript-msg-role.student {
+  color: var(--accent);
+}
+
+.transcript-msg-role.tutor {
+  color: var(--success);
+}
+
+.transcript-msg-text {
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Session History — Axiom AI Tutor</title>
+  <meta name="theme-color" content="#0f1117">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/history.css">
+</head>
+<body>
+  <main class="history-shell">
+    <div class="history-card">
+      <div class="history-header">
+        <h1 class="history-title">Session History</h1>
+        <a href="/" class="history-back-link">Back to tutor</a>
+      </div>
+
+      <div id="history-loading" class="history-loading">Loading sessions...</div>
+      <div id="history-empty" class="history-empty" style="display:none">No past sessions found.</div>
+      <div id="history-error" class="history-error" style="display:none"></div>
+
+      <ul id="history-list" class="history-list" style="display:none"></ul>
+
+      <!-- Transcript viewer overlay -->
+      <div id="transcript-overlay" class="transcript-overlay" style="display:none">
+        <div class="transcript-panel">
+          <div class="transcript-panel-header">
+            <h2 class="transcript-panel-title" id="transcript-title">Transcript</h2>
+            <button type="button" class="transcript-close-btn" id="transcript-close">Close</button>
+          </div>
+          <div class="transcript-messages" id="transcript-messages"></div>
+        </div>
+      </div>
+    </div>
+  </main>
+  <script src="/history.js"></script>
+</body>
+</html>

--- a/apps/web/public/history.js
+++ b/apps/web/public/history.js
@@ -1,0 +1,201 @@
+/* history.js — client logic for /history.html.
+ *
+ * Single IIFE, no bundler. Fetches GET /api/history and renders the session
+ * list. Supports viewing transcripts via GET /api/transcript/:id.
+ */
+(function () {
+  "use strict";
+
+  // ── Auth helpers ──────────────────────────────────────────────────────────
+  function getAuthSession() {
+    var raw = sessionStorage.getItem("authSession") || localStorage.getItem("authSession");
+    if (!raw) return null;
+    try { return JSON.parse(raw); } catch { return null; }
+  }
+
+  var auth = getAuthSession();
+  if (!auth || !auth.accessToken) {
+    window.location.replace("/login.html");
+    return;
+  }
+
+  function authHeaders() {
+    return { Authorization: "Bearer " + auth.accessToken };
+  }
+
+  // ── DOM refs ──────────────────────────────────────────────────────────────
+  var loadingEl = document.getElementById("history-loading");
+  var emptyEl = document.getElementById("history-empty");
+  var errorEl = document.getElementById("history-error");
+  var listEl = document.getElementById("history-list");
+  var overlayEl = document.getElementById("transcript-overlay");
+  var messagesEl = document.getElementById("transcript-messages");
+  var titleEl = document.getElementById("transcript-title");
+  var closeBtn = document.getElementById("transcript-close");
+
+  // ── Formatting helpers ────────────────────────────────────────────────────
+  function formatPromptName(name) {
+    if (!name) return "Unknown prompt";
+    // "tutor-prompt-v7" -> "Tutor v7"
+    var match = name.match(/^tutor-prompt-v(\d+)$/);
+    if (match) return "Tutor v" + match[1];
+    return name;
+  }
+
+  function formatDate(iso) {
+    if (!iso) return "";
+    var d = new Date(iso);
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function formatDuration(startIso, endIso) {
+    if (!startIso || !endIso) return "";
+    var ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+    var mins = Math.round(ms / 60000);
+    if (mins < 1) return "<1 min";
+    return mins + " min";
+  }
+
+  // ── Load sessions ─────────────────────────────────────────────────────────
+  function loadSessions() {
+    fetch("/api/history", { headers: authHeaders() })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        if (!res.ok) throw new Error("Failed to load sessions");
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        loadingEl.style.display = "none";
+
+        if (!data.sessions || data.sessions.length === 0) {
+          emptyEl.style.display = "";
+          return;
+        }
+
+        renderSessions(data.sessions);
+      })
+      .catch(function (err) {
+        loadingEl.style.display = "none";
+        errorEl.textContent = err.message || "Failed to load sessions.";
+        errorEl.style.display = "";
+      });
+  }
+
+  function renderSessions(sessions) {
+    listEl.innerHTML = "";
+    listEl.style.display = "";
+
+    sessions.forEach(function (s) {
+      var li = document.createElement("li");
+      li.className = "history-item";
+
+      var info = document.createElement("div");
+      info.className = "history-item-info";
+
+      var dateEl = document.createElement("div");
+      dateEl.className = "history-item-date";
+      dateEl.textContent = formatDate(s.started_at);
+      info.appendChild(dateEl);
+
+      var meta = document.createElement("div");
+      meta.className = "history-item-meta";
+      var parts = [formatPromptName(s.prompt_name)];
+      var duration = formatDuration(s.started_at, s.ended_at);
+      if (duration) parts.push(duration);
+      meta.textContent = parts.join(" \u2022 ");
+      info.appendChild(meta);
+
+      var btn = document.createElement("button");
+      btn.className = "history-view-btn";
+      btn.textContent = "View transcript";
+      btn.addEventListener("click", function () {
+        openTranscript(s.id, s.started_at);
+      });
+
+      li.appendChild(info);
+      li.appendChild(btn);
+      listEl.appendChild(li);
+    });
+  }
+
+  // ── Transcript viewer ─────────────────────────────────────────────────────
+  function openTranscript(sessionId, startedAt) {
+    titleEl.textContent = "Transcript — " + formatDate(startedAt);
+    messagesEl.innerHTML = "<div class=\"history-loading\">Loading transcript...</div>";
+    overlayEl.style.display = "";
+
+    fetch("/api/transcript/" + sessionId, { headers: authHeaders() })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        if (res.status === 403) throw new Error("Access denied.");
+        if (!res.ok) throw new Error("Failed to load transcript.");
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        messagesEl.innerHTML = "";
+
+        if (!data.transcript || data.transcript.length === 0) {
+          messagesEl.innerHTML = "<div class=\"history-empty\">No messages in this session.</div>";
+          return;
+        }
+
+        data.transcript.forEach(function (msg) {
+          var div = document.createElement("div");
+          div.className = "transcript-msg";
+
+          var roleDiv = document.createElement("div");
+          roleDiv.className = "transcript-msg-role " + (msg.role === "Student" ? "student" : "tutor");
+          roleDiv.textContent = msg.role;
+          div.appendChild(roleDiv);
+
+          var textDiv = document.createElement("div");
+          textDiv.className = "transcript-msg-text";
+          textDiv.textContent = msg.text;
+          div.appendChild(textDiv);
+
+          messagesEl.appendChild(div);
+        });
+      })
+      .catch(function (err) {
+        messagesEl.innerHTML = "";
+        var errDiv = document.createElement("div");
+        errDiv.className = "history-error";
+        errDiv.textContent = err.message || "Failed to load transcript.";
+        messagesEl.appendChild(errDiv);
+      });
+  }
+
+  function closeTranscript() {
+    overlayEl.style.display = "none";
+    messagesEl.innerHTML = "";
+  }
+
+  closeBtn.addEventListener("click", closeTranscript);
+
+  overlayEl.addEventListener("click", function (e) {
+    if (e.target === overlayEl) closeTranscript();
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && overlayEl.style.display !== "none") {
+      closeTranscript();
+    }
+  });
+
+  // ── Init ──────────────────────────────────────────────────────────────────
+  loadSessions();
+})();

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -64,7 +64,7 @@
         <div class="account-dropdown-info" id="account-dropdown-info"></div>
         <div class="account-dropdown-divider"></div>
         <button class="account-dropdown-item" id="menu-settings" role="menuitem" aria-disabled="true" disabled>Settings</button>
-        <button class="account-dropdown-item" id="menu-history" role="menuitem" aria-disabled="true" disabled>History</button>
+        <button class="account-dropdown-item" id="menu-history" role="menuitem" onclick="window.location.href='/history.html'">History</button>
         <div class="account-dropdown-divider"></div>
         <button class="account-dropdown-item account-dropdown-logout" id="menu-logout" role="menuitem">Log out</button>
       </div>

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,6 @@
 export { createSupabaseClient, createSupabaseAnonClient } from "./client.js";
 
-export { createSession, getSession, updateSession, markSessionEnded, getUserEmailForSession } from "./sessions.js";
+export { createSession, getSession, getSessionsByUser, updateSession, markSessionEnded, getUserEmailForSession } from "./sessions.js";
 
 export {
   createMessage,

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -69,6 +69,26 @@ export async function getUserEmailForSession(
 }
 
 /**
+ * Return ended sessions belonging to a specific user, most recent first.
+ * Used by the history page to list past tutoring sessions.
+ */
+export async function getSessionsByUser(
+  client: SupabaseClient,
+  userId: string,
+): Promise<DbSession[]> {
+  const { data, error } = await client
+    .from("sessions")
+    .select()
+    .eq("user_id", userId)
+    .not("ended_at", "is", null)
+    .order("started_at", { ascending: false })
+    .limit(50);
+
+  if (error) throw new Error(`getSessionsByUser: ${error.message}`);
+  return data ?? [];
+}
+
+/**
  * Mark a session as ended by setting ended_at to now.
  * Session data (messages, feedback) is retained for analysis.
  */


### PR DESCRIPTION
## Summary
- Add `GET /api/history` endpoint returning the 50 most recent ended sessions for the authenticated user
- Add standalone `/history.html` page with session list and transcript viewer overlay
- Add `createOptionalAuth` middleware for non-blocking auth on the transcript route (ownership check: 403 if session belongs to another user, unauthenticated path preserved)
- Enable the History button in the account dropdown menu
- Add `getSessionsByUser()` to the DB layer

## Test plan
- [ ] `npm run build` passes from repo root
- [ ] `curl GET /api/history` without auth returns 401
- [ ] `curl GET /api/history` with valid bearer returns 200 with sessions array
- [ ] `curl GET /api/transcript/:id` without auth (active session) returns 200 (unauthenticated path preserved)
- [ ] `curl GET /api/transcript/:id` with auth for another user's session returns 403
- [ ] Navigate to `/history.html` in browser, verify session list loads and transcript viewer works
- [ ] History button in account dropdown navigates to `/history.html`

Generated with [Claude Code](https://claude.com/claude-code)