### PR TITLE
feat: add settings management page (#107)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { createProfile, getProfile } from "@ai-tutor/db";
+import { createProfile, getProfile, updateProfile } from "@ai-tutor/db";
 import rateLimit from "express-rate-limit";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
@@ -394,6 +394,119 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
     } catch (err) {
       console.error("[auth] getProfile failed for /me:", err);
       res.json({ ok: true, userId, isAdmin: false, email: userEmail, name: userName ?? null });
+    }
+  });
+
+  /**
+   * GET /api/auth/settings
+   *
+   * Returns the authenticated user's profile settings for the settings page.
+   * Reads from both auth.users (name, email, birthdate, gradeLevel) and the
+   * profiles table (emailTranscriptsEnabled). Handles missing profile rows
+   * gracefully by defaulting emailTranscriptsEnabled to true.
+   */
+  router.get("/settings", requireAuth, async (req, res) => {
+    const authed = req as AuthedRequest;
+    const { userId } = authed;
+    try {
+      const [profileResult, userResult] = await Promise.all([
+        getProfile(db, userId),
+        db.auth.admin.getUserById(userId),
+      ]);
+      const meta = userResult.data?.user?.user_metadata ?? {};
+      const email = userResult.data?.user?.email ?? authed.userEmail;
+      res.json({
+        ok: true,
+        name: (meta.name as string | undefined) ?? null,
+        email,
+        birthdate: (meta.birthdate as string | undefined) ?? null,
+        gradeLevel: (meta.grade_level as string | undefined) ?? null,
+        emailTranscriptsEnabled: profileResult?.emailTranscriptsEnabled ?? true,
+      });
+    } catch (err) {
+      console.error("[auth] GET /settings error:", err);
+      res.status(500).json({ ok: false, error: "server_error" });
+    }
+  });
+
+  /**
+   * POST /api/auth/settings
+   *
+   * Updates mutable profile settings. Accepts `gradeLevel` (updates
+   * user_metadata on auth.users) and `emailTranscriptsEnabled` (updates
+   * profiles table). Uses selective merge for user_metadata to avoid wiping
+   * other fields.
+   */
+  router.post("/settings", requireAuth, async (req, res) => {
+    const authed = req as AuthedRequest;
+    const { userId } = authed;
+    const body = req.body as {
+      gradeLevel?: unknown;
+      emailTranscriptsEnabled?: unknown;
+    } | undefined;
+
+    try {
+      // Update gradeLevel in auth.users user_metadata if provided.
+      if (body?.gradeLevel !== undefined) {
+        const grade = body.gradeLevel;
+        if (typeof grade !== "string" || !ALLOWED_GRADES.has(grade)) {
+          res.status(400).json({ ok: false, error: "invalid_grade" });
+          return;
+        }
+        // Get current metadata first, then merge selectively.
+        const { data: { user } } = await db.auth.admin.getUserById(userId);
+        const currentMeta = user?.user_metadata ?? {};
+        await db.auth.admin.updateUserById(userId, {
+          user_metadata: { ...currentMeta, grade_level: grade },
+        });
+      }
+
+      // Update emailTranscriptsEnabled in profiles table if provided.
+      if (body?.emailTranscriptsEnabled !== undefined) {
+        const enabled = body.emailTranscriptsEnabled;
+        if (typeof enabled !== "boolean") {
+          res.status(400).json({ ok: false, error: "invalid_request" });
+          return;
+        }
+        await updateProfile(db, userId, { emailTranscriptsEnabled: enabled });
+      }
+
+      res.json({ ok: true });
+    } catch (err) {
+      console.error("[auth] POST /settings error:", err);
+      res.status(500).json({ ok: false, error: "server_error" });
+    }
+  });
+
+  /**
+   * POST /api/auth/change-email
+   *
+   * Updates the authenticated user's email address via the admin API.
+   * Body: `{ newEmail: string }`.
+   *
+   * // NOTE: verify resend behavior with Supabase email_change type in production
+   */
+  router.post("/change-email", resendLimiter, requireAuth, async (req, res) => {
+    const authed = req as AuthedRequest;
+    const { userId } = authed;
+    const body = req.body as { newEmail?: unknown } | undefined;
+    const newEmail = body?.newEmail;
+    if (typeof newEmail !== "string" || !EMAIL_RE.test(newEmail)) {
+      res.status(400).json({ ok: false, error: "invalid_email" });
+      return;
+    }
+
+    try {
+      const { error } = await db.auth.admin.updateUserById(userId, { email: newEmail });
+      if (error) {
+        console.error("[auth] change-email updateUserById failed:", error);
+        res.status(500).json({ ok: false, error: "server_error" });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      console.error("[auth] change-email unexpected error:", err);
+      res.status(500).json({ ok: false, error: "server_error" });
     }
   });
 

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -63,7 +63,7 @@
       <div id="account-dropdown" class="account-dropdown" style="display:none" role="menu">
         <div class="account-dropdown-info" id="account-dropdown-info"></div>
         <div class="account-dropdown-divider"></div>
-        <button class="account-dropdown-item" id="menu-settings" role="menuitem" aria-disabled="true" disabled>Settings</button>
+        <button class="account-dropdown-item" id="menu-settings" role="menuitem" onclick="window.location.href='/settings.html'">Settings</button>
         <button class="account-dropdown-item" id="menu-history" role="menuitem" aria-disabled="true" disabled>History</button>
         <div class="account-dropdown-divider"></div>
         <button class="account-dropdown-item account-dropdown-logout" id="menu-logout" role="menuitem">Log out</button>

--- a/apps/web/public/settings.css
+++ b/apps/web/public/settings.css
@@ -1,0 +1,210 @@
+/* settings.css — standalone styles for /settings.html.
+ *
+ * Mirrors the login.css dark theme palette and CSS variable approach.
+ * Self-contained so the page can be tested in isolation.
+ */
+
+:root {
+  --bg: #0f1117;
+  --card: #1a1d27;
+  --border: #2a2e3a;
+  --text: #e7e9ee;
+  --text-muted: #9aa0ad;
+  --accent: #7c6af7;
+  --accent-hover: #8d7dfa;
+  --danger: #ef4444;
+  --success: #22c55e;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.settings-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+}
+
+.settings-card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.settings-title {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.settings-back-link {
+  color: var(--accent);
+  font-size: 0.85rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.settings-back-link:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.settings-loading {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.settings-error {
+  color: var(--danger);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+/* ── Form sections ─────────────────────────────────────────────── */
+
+.settings-section {
+  border: none;
+  margin: 0 0 1.25rem 0;
+  padding: 0;
+}
+
+.settings-section-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.75rem;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.settings-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.settings-input {
+  background: #11131b;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.settings-input:focus {
+  border-color: var(--accent);
+}
+
+.settings-input[readonly] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.settings-checkbox-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+}
+
+.settings-checkbox-row input[type="checkbox"] {
+  margin-top: 0.15rem;
+}
+
+.settings-checkbox-label {
+  line-height: 1.4;
+}
+
+/* ── Buttons ───────────────────────────────────────────────────── */
+
+.settings-btn {
+  background: #2a2e3a;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.settings-btn:hover {
+  background: #323745;
+}
+
+.settings-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.settings-btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.settings-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+/* ── Feedback messages ─────────────────────────────────────────── */
+
+.settings-success {
+  margin: 0.85rem 0 0;
+  color: var(--success);
+  font-size: 0.85rem;
+}
+
+.settings-error-inline {
+  margin: 0.85rem 0 0;
+  color: var(--danger);
+  font-size: 0.85rem;
+}

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Settings — Axiom AI Tutor</title>
+  <meta name="theme-color" content="#0f1117">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/settings.css">
+</head>
+<body>
+  <main class="settings-shell">
+    <div class="settings-card">
+      <div class="settings-header">
+        <h1 class="settings-title">Settings</h1>
+        <a href="/" class="settings-back-link">Back to tutor</a>
+      </div>
+
+      <div id="settings-loading" class="settings-loading">Loading settings...</div>
+      <div id="settings-error" class="settings-error" style="display:none"></div>
+
+      <form id="settings-form" style="display:none" autocomplete="off">
+        <!-- Read-only fields -->
+        <fieldset class="settings-section">
+          <legend class="settings-section-title">Account</legend>
+          <label class="settings-field">
+            <span class="settings-label">Name</span>
+            <input type="text" id="settings-name" class="settings-input" readonly>
+          </label>
+          <label class="settings-field">
+            <span class="settings-label">Birthdate</span>
+            <input type="text" id="settings-birthdate" class="settings-input" readonly>
+          </label>
+        </fieldset>
+
+        <!-- Editable fields -->
+        <fieldset class="settings-section">
+          <legend class="settings-section-title">Preferences</legend>
+          <label class="settings-field">
+            <span class="settings-label">Grade level</span>
+            <select id="settings-grade" class="settings-input">
+              <option value="" disabled>Select grade</option>
+              <option value="6th">6th</option>
+              <option value="7th">7th</option>
+              <option value="8th">8th</option>
+              <option value="9th">9th</option>
+              <option value="10th">10th</option>
+              <option value="11th">11th</option>
+              <option value="12th">12th</option>
+              <option value="Other">Other</option>
+            </select>
+          </label>
+          <label class="settings-checkbox-row">
+            <input type="checkbox" id="settings-email-transcripts" checked>
+            <span class="settings-checkbox-label">Receive session transcript emails</span>
+          </label>
+        </fieldset>
+
+        <fieldset class="settings-section">
+          <legend class="settings-section-title">Email</legend>
+          <label class="settings-field">
+            <span class="settings-label">Email address</span>
+            <input type="email" id="settings-email" class="settings-input" autocomplete="email">
+          </label>
+          <button type="button" class="settings-btn" id="btn-change-email">Update email</button>
+        </fieldset>
+
+        <div class="settings-actions">
+          <button type="submit" class="settings-btn settings-btn-primary" id="btn-save">Save changes</button>
+        </div>
+
+        <p class="settings-success" id="settings-success" style="display:none"></p>
+        <p class="settings-error-inline" id="settings-error-inline" style="display:none"></p>
+      </form>
+    </div>
+  </main>
+  <script src="/settings.js"></script>
+</body>
+</html>

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -1,0 +1,205 @@
+/* settings.js — client logic for /settings.html.
+ *
+ * Single IIFE, no bundler. Fetches GET /api/auth/settings on load and
+ * provides forms to update grade level, email transcripts preference,
+ * and email address.
+ */
+(function () {
+  "use strict";
+
+  // ── Auth helpers ──────────────────────────────────────────────────────────
+  function getAuthSession() {
+    var raw = sessionStorage.getItem("authSession") || localStorage.getItem("authSession");
+    if (!raw) return null;
+    try { return JSON.parse(raw); } catch { return null; }
+  }
+
+  var auth = getAuthSession();
+  if (!auth || !auth.accessToken) {
+    window.location.replace("/login.html");
+    return;
+  }
+
+  function authHeaders() {
+    return {
+      Authorization: "Bearer " + auth.accessToken,
+      "Content-Type": "application/json",
+    };
+  }
+
+  // ── DOM refs ──────────────────────────────────────────────────────────────
+  var loadingEl = document.getElementById("settings-loading");
+  var errorEl = document.getElementById("settings-error");
+  var formEl = document.getElementById("settings-form");
+  var nameEl = document.getElementById("settings-name");
+  var birthdateEl = document.getElementById("settings-birthdate");
+  var gradeEl = document.getElementById("settings-grade");
+  var emailTranscriptsEl = document.getElementById("settings-email-transcripts");
+  var emailEl = document.getElementById("settings-email");
+  var changeEmailBtn = document.getElementById("btn-change-email");
+  var saveBtn = document.getElementById("btn-save");
+  var successEl = document.getElementById("settings-success");
+  var errorInlineEl = document.getElementById("settings-error-inline");
+
+  // Track original values to detect changes.
+  var original = {};
+
+  // ── Formatting helpers ────────────────────────────────────────────────────
+  function formatBirthdate(iso) {
+    if (!iso) return "";
+    var parts = iso.split("-");
+    if (parts.length !== 3) return iso;
+    return parts[1] + "/" + parts[2] + "/" + parts[0];
+  }
+
+  function showSuccess(msg) {
+    successEl.textContent = msg;
+    successEl.style.display = "";
+    errorInlineEl.style.display = "none";
+    setTimeout(function () { successEl.style.display = "none"; }, 4000);
+  }
+
+  function showError(msg) {
+    errorInlineEl.textContent = msg;
+    errorInlineEl.style.display = "";
+    successEl.style.display = "none";
+  }
+
+  function clearMessages() {
+    successEl.style.display = "none";
+    errorInlineEl.style.display = "none";
+  }
+
+  // ── Load settings ─────────────────────────────────────────────────────────
+  function loadSettings() {
+    fetch("/api/auth/settings", { headers: authHeaders() })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        if (!res.ok) throw new Error("Failed to load settings.");
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        loadingEl.style.display = "none";
+        formEl.style.display = "";
+
+        nameEl.value = data.name || "";
+        birthdateEl.value = formatBirthdate(data.birthdate);
+        emailEl.value = data.email || "";
+
+        if (data.gradeLevel) {
+          gradeEl.value = data.gradeLevel;
+        }
+        emailTranscriptsEl.checked = data.emailTranscriptsEnabled !== false;
+
+        original.gradeLevel = data.gradeLevel || "";
+        original.emailTranscriptsEnabled = data.emailTranscriptsEnabled !== false;
+        original.email = data.email || "";
+      })
+      .catch(function (err) {
+        loadingEl.style.display = "none";
+        errorEl.textContent = err.message || "Failed to load settings.";
+        errorEl.style.display = "";
+      });
+  }
+
+  // ── Save settings (grade + email transcripts) ─────────────────────────────
+  formEl.addEventListener("submit", function (e) {
+    e.preventDefault();
+    clearMessages();
+
+    var payload = {};
+    var gradeVal = gradeEl.value;
+    if (gradeVal && gradeVal !== original.gradeLevel) {
+      payload.gradeLevel = gradeVal;
+    }
+    var transcriptsVal = emailTranscriptsEl.checked;
+    if (transcriptsVal !== original.emailTranscriptsEnabled) {
+      payload.emailTranscriptsEnabled = transcriptsVal;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      showSuccess("No changes to save.");
+      return;
+    }
+
+    saveBtn.disabled = true;
+    fetch("/api/auth/settings", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(payload),
+    })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        saveBtn.disabled = false;
+        if (data.ok) {
+          if (payload.gradeLevel) original.gradeLevel = payload.gradeLevel;
+          if (payload.emailTranscriptsEnabled !== undefined) {
+            original.emailTranscriptsEnabled = payload.emailTranscriptsEnabled;
+          }
+          showSuccess("Settings saved.");
+        } else {
+          showError(data.error || "Failed to save settings.");
+        }
+      })
+      .catch(function () {
+        saveBtn.disabled = false;
+        showError("Network error. Please try again.");
+      });
+  });
+
+  // ── Change email ──────────────────────────────────────────────────────────
+  changeEmailBtn.addEventListener("click", function () {
+    clearMessages();
+    var newEmail = emailEl.value.trim();
+    if (!newEmail) {
+      showError("Please enter an email address.");
+      return;
+    }
+    if (newEmail === original.email) {
+      showSuccess("Email unchanged.");
+      return;
+    }
+
+    changeEmailBtn.disabled = true;
+    fetch("/api/auth/change-email", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ newEmail: newEmail }),
+    })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        changeEmailBtn.disabled = false;
+        if (data.ok) {
+          original.email = newEmail;
+          showSuccess("Email updated.");
+        } else {
+          showError(data.error || "Failed to update email.");
+        }
+      })
+      .catch(function () {
+        changeEmailBtn.disabled = false;
+        showError("Network error. Please try again.");
+      });
+  });
+
+  // ── Init ──────────────────────────────────────────────────────────────────
+  loadSettings();
+})();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,8 +13,8 @@ export { createSessionEvaluation, upsertSessionEvaluation, getSessionEvaluation 
 
 export { createDisclaimerAcceptance, linkDisclaimerAcceptance } from "./disclaimer-acceptances.js";
 
-export { createProfile, getProfile } from "./profiles.js";
-export type { DbProfile } from "./profiles.js";
+export { createProfile, getProfile, updateProfile } from "./profiles.js";
+export type { DbProfile, DbProfileUpdate } from "./profiles.js";
 
 export type {
   DbSession,

--- a/packages/db/src/profiles.ts
+++ b/packages/db/src/profiles.ts
@@ -3,7 +3,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 export interface DbProfile {
   user_id: string;
   is_admin: boolean;
+  email_transcripts_enabled: boolean;
   created_at: string;
+}
+
+export interface DbProfileUpdate {
+  emailTranscriptsEnabled?: boolean;
 }
 
 /**
@@ -27,13 +32,37 @@ export async function createProfile(
 export async function getProfile(
   client: SupabaseClient,
   userId: string,
-): Promise<{ isAdmin: boolean } | null> {
+): Promise<{ isAdmin: boolean; emailTranscriptsEnabled: boolean } | null> {
   const { data, error } = await client
     .from("profiles")
-    .select("is_admin")
+    .select("is_admin, email_transcripts_enabled")
     .eq("user_id", userId)
     .maybeSingle();
   if (error) throw new Error(`getProfile: ${error.message}`);
   if (!data) return null;
-  return { isAdmin: data.is_admin as boolean };
+  return {
+    isAdmin: data.is_admin as boolean,
+    emailTranscriptsEnabled: data.email_transcripts_enabled as boolean,
+  };
+}
+
+/**
+ * Update a user's profile settings. Uses upsert semantics so it works for
+ * legacy users who may not have a profiles row yet.
+ *
+ * // TODO: wire emailTranscriptsEnabled to evaluation.ts sweep in follow-on issue
+ */
+export async function updateProfile(
+  client: SupabaseClient,
+  userId: string,
+  patch: DbProfileUpdate,
+): Promise<void> {
+  const row: Record<string, unknown> = { user_id: userId };
+  if (patch.emailTranscriptsEnabled !== undefined) {
+    row.email_transcripts_enabled = patch.emailTranscriptsEnabled;
+  }
+  const { error } = await client
+    .from("profiles")
+    .upsert(row, { onConflict: "user_id" });
+  if (error) throw new Error(`updateProfile: ${error.message}`);
 }

--- a/supabase/migrations/004_profile_settings.sql
+++ b/supabase/migrations/004_profile_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS email_transcripts_enabled boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary
- Add `GET /api/auth/settings` and `POST /api/auth/settings` endpoints for reading/updating user preferences (grade level, email transcript opt-out)
- Add `POST /api/auth/change-email` endpoint for updating email address
- Add standalone `/settings.html` page with read-only account info (name, birthdate) and editable preferences
- Add `email_transcripts_enabled` column to profiles table via migration `004_profile_settings.sql`
- Add `updateProfile()` with upsert semantics to the DB layer (works for legacy users without profile rows)
- Enable the Settings button in the account dropdown menu

## Test plan
- [ ] `npm run build` passes from repo root
- [ ] `curl GET /api/auth/settings` with valid bearer returns 200 with user data
- [ ] `curl POST /api/auth/settings` with gradeLevel returns 200 `{ ok: true }`
- [ ] `curl POST /api/auth/settings` with emailTranscriptsEnabled returns 200 `{ ok: true }`
- [ ] `curl POST /api/auth/change-email` with newEmail returns 200 `{ ok: true }`
- [ ] Verify updateProfile upsert works for a user with no profiles row
- [ ] Navigate to `/settings.html` in browser, verify form loads user data
- [ ] Settings button in account dropdown navigates to `/settings.html`
- [ ] name and birthdate fields are read-only in the UI

Generated with [Claude Code](https://claude.com/claude-code)