### PR TITLE
fix: daily bug sweep — password recovery and transcript auth

### DIFF
--- a/apps/api/src/routes/transcript.ts
+++ b/apps/api/src/routes/transcript.ts
@@ -33,10 +33,11 @@ export function createTranscriptRouter(db: SupabaseClient): Router {
 
       const callerId = (req as OptionalAuthRequest).userId;
 
-      // Ownership check — only for authenticated callers viewing DB sessions.
-      if (callerId) {
-        const dbRow = await getDbSession(db, sessionId);
-        if (dbRow?.user_id && dbRow.user_id !== callerId) {
+      // Ownership check — sessions with a user_id require a matching Bearer token.
+      // Unauthenticated callers may not read sessions that belong to registered users.
+      const dbRow = await getDbSession(db, sessionId);
+      if (dbRow?.user_id) {
+        if (!callerId || dbRow.user_id !== callerId) {
           res.status(403).json({ error: "forbidden" });
           return;
         }

--- a/apps/web/public/settings.css
+++ b/apps/web/public/settings.css
@@ -208,3 +208,13 @@ html, body {
   color: var(--danger);
   font-size: 0.85rem;
 }
+
+.settings-recovery-banner {
+  background: rgba(124, 106, 247, 0.12);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.85rem;
+  color: var(--text);
+  margin-bottom: 0.85rem;
+}

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -67,6 +67,20 @@
           <button type="button" class="settings-btn" id="btn-change-email">Update email</button>
         </fieldset>
 
+        <fieldset class="settings-section">
+          <legend class="settings-section-title">Security</legend>
+          <div id="recovery-banner" class="settings-recovery-banner" style="display:none">Enter a new password to complete your password reset.</div>
+          <label class="settings-field">
+            <span class="settings-label">New password</span>
+            <input type="password" id="settings-new-password" class="settings-input" autocomplete="new-password" minlength="8" placeholder="At least 8 characters">
+          </label>
+          <label class="settings-field">
+            <span class="settings-label">Confirm new password</span>
+            <input type="password" id="settings-confirm-password" class="settings-input" autocomplete="new-password" placeholder="Repeat new password">
+          </label>
+          <button type="button" class="settings-btn" id="btn-change-password">Change password</button>
+        </fieldset>
+
         <div class="settings-actions">
           <button type="submit" class="settings-btn settings-btn-primary" id="btn-save">Save changes</button>
         </div>

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -37,6 +37,10 @@
   var emailTranscriptsEl = document.getElementById("settings-email-transcripts");
   var emailEl = document.getElementById("settings-email");
   var changeEmailBtn = document.getElementById("btn-change-email");
+  var changePasswordBtn = document.getElementById("btn-change-password");
+  var newPasswordEl = document.getElementById("settings-new-password");
+  var confirmPasswordEl = document.getElementById("settings-confirm-password");
+  var recoveryBannerEl = document.getElementById("recovery-banner");
   var saveBtn = document.getElementById("btn-save");
   var successEl = document.getElementById("settings-success");
   var errorInlineEl = document.getElementById("settings-error-inline");
@@ -98,6 +102,13 @@
         original.gradeLevel = data.gradeLevel || "";
         original.emailTranscriptsEnabled = data.emailTranscriptsEnabled !== false;
         original.email = data.email || "";
+
+        // Detect password recovery redirect from login.js (?recovery=1).
+        if (new URLSearchParams(window.location.search).get("recovery") === "1") {
+          recoveryBannerEl.style.display = "";
+          sessionStorage.removeItem("authRecoveryPending");
+          newPasswordEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
       })
       .catch(function (err) {
         loadingEl.style.display = "none";
@@ -196,6 +207,55 @@
       })
       .catch(function () {
         changeEmailBtn.disabled = false;
+        showError("Network error. Please try again.");
+      });
+  });
+
+  // ── Change password ───────────────────────────────────────────────────────
+  changePasswordBtn.addEventListener("click", function () {
+    clearMessages();
+    var newPwd = newPasswordEl.value;
+    var confirmPwd = confirmPasswordEl.value;
+    if (!newPwd) {
+      showError("Please enter a new password.");
+      return;
+    }
+    if (newPwd.length < 8) {
+      showError("Password must be at least 8 characters.");
+      return;
+    }
+    if (newPwd !== confirmPwd) {
+      showError("Passwords do not match.");
+      return;
+    }
+
+    changePasswordBtn.disabled = true;
+    fetch("/api/auth/change-password", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ newPassword: newPwd }),
+    })
+      .then(function (res) {
+        if (res.status === 401) {
+          window.location.replace("/login.html");
+          return null;
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        changePasswordBtn.disabled = false;
+        if (data.ok) {
+          newPasswordEl.value = "";
+          confirmPasswordEl.value = "";
+          recoveryBannerEl.style.display = "none";
+          showSuccess("Password changed successfully.");
+        } else {
+          showError(data.error || "Failed to change password.");
+        }
+      })
+      .catch(function () {
+        changePasswordBtn.disabled = false;
         showError("Network error. Please try again.");
       });
   });


### PR DESCRIPTION
## Summary

- **CRITICAL** Password recovery flow was completely broken: `login.js` redirected `type=recovery` Supabase hash callbacks to `/settings.html?recovery=1` but `settings.html` had no change-password form and `settings.js` never read the `?recovery=1` param. Added a Security fieldset with password inputs and wired it to `POST /api/auth/change-password`. Recovery banner shows and `authRecoveryPending` sessionStorage key is consumed on load.
- **MEDIUM** Unauthenticated callers could read transcripts for sessions belonging to registered users: the ownership check in `GET /api/transcript/:id` was gated on a Bearer token being present. Now always fetches the DB session row and rejects unauthenticated requests when `user_id` is non-null.

## Confirmed bugs (from automated sweep)

| Severity | File | Root cause |
|----------|------|------------|
| CRITICAL | `apps/web/public/settings.{html,js,css}` | Password recovery redirected to settings page with no change-password form; `authRecoveryPending` was dead code |
| MEDIUM | `apps/api/src/routes/transcript.ts:37-43` | Ownership check skipped for unauthenticated callers, exposing user-owned transcripts |

## False positives discarded

- `change-email` via admin API without re-auth: documented limitation, consistent with `change-password` design
- `POST /api/feedback` missing ownership check: random UUIDs + UNIQUE constraint make risk negligible
- `sendVerificationEmail` fire-and-forget: intentional, documented, retry path exists
- Inactivity sweep fire-and-forget on SIGTERM: inherent design limitation
- `email_sent` not set when email keys absent: correctly reverted — marking `email_sent=true` without sending an email would corrupt the idempotency invariant

## Test plan

- [ ] Go through forgot-password flow → receive email → click link → land on `/settings.html` with recovery banner visible and change-password form focused
- [ ] Submit new password from recovery flow → success message, banner hides, fields clear
- [ ] `curl GET /api/transcript/<session-with-user-id>` without Authorization header → `403 {"error":"forbidden"}`
- [ ] `curl GET /api/transcript/<session-with-user-id>` with correct Bearer token → transcript returned
- [ ] `curl GET /api/transcript/<anonymous-session-id>` without Authorization header → transcript returned (no regression for anonymous sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)