### PR TITLE
feat: remove transcript button from chat header (#124)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -71,7 +71,6 @@
   const btnFbSkip          = $('btn-fb-skip');
   const fbComment          = $('fb-comment');
   const inputRow           = $('input-row');
-  const btnTranscript       = $('btn-transcript');
   const promptBadge    = $('prompt-badge');
   const modelBadge     = $('model-badge');
   const thinkingBadge  = $('thinking-badge');
@@ -84,11 +83,6 @@
   const btnSwitchConfirm    = $('btn-switch-confirm');
   const btnSwitchCancel     = $('btn-switch-cancel');
   const btnSwitchCancelX    = $('btn-switch-cancel-x');
-  const modalTranscript = $('modal-transcript');
-  const txBody         = $('tx-body');
-  const btnCloseTx     = $('btn-close-tx');
-  const btnCloseTx2    = $('btn-close-tx2');
-  const btnCopyTx      = $('btn-copy-tx');
   const accountTrigger     = $('account-trigger');
   const accountDropdown    = $('account-dropdown');
   const accountDropdownInfo = $('account-dropdown-info');
@@ -223,7 +217,6 @@
   // ── Header button state ───────────────────────────────────────────────────
   function updateHeaderButtons() {
     const hasMessages = msgList.length > 0;
-    btnTranscript.disabled       = !hasMessages;
     btnEndSessionHeader.disabled = !hasMessages;
   }
 
@@ -814,47 +807,6 @@
   }
 
   // ── Transcript modal ──────────────────────────────────────────────────────
-  async function openTranscript() {
-    modalTranscript.classList.add('active');
-    txBody.innerHTML = '<p style="color:var(--text-muted);font-size:.88rem">Loading…</p>';
-    try {
-      const res = await fetch(`/api/transcript/${sessionId}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const { transcript } = await res.json();
-      if (!transcript?.length) {
-        txBody.innerHTML = '<p style="color:var(--text-muted);font-size:.88rem">No messages yet.</p>';
-        return;
-      }
-      txBody.innerHTML = transcript.map(e => `
-        <div class="tx-entry ${e.role === 'Student' ? 'student' : ''}">
-          <div class="tx-role">${escHtml(e.role)}</div>
-          <div class="tx-text">${escHtml(e.text)}</div>
-        </div>`).join('');
-    } catch {
-      txBody.innerHTML = '<p style="color:var(--danger);font-size:.88rem">Could not load transcript.</p>';
-    }
-  }
-
-  function closeTranscript() {
-    modalTranscript.classList.remove('active');
-  }
-
-  async function copyTranscript() {
-    const entries = txBody.querySelectorAll('.tx-entry');
-    if (!entries.length) return;
-    const text = Array.from(entries).map(el => {
-      const role    = el.querySelector('.tx-role')?.textContent ?? '';
-      const content = el.querySelector('.tx-text')?.textContent ?? '';
-      return `${role}:\n${content}`;
-    }).join('\n\n');
-    try {
-      await navigator.clipboard.writeText(text);
-      showToast('Copied to clipboard!');
-    } catch {
-      showToast('Copy failed — try selecting text manually.');
-    }
-  }
-
   // ── New session ───────────────────────────────────────────────────────────
   async function newSession() {
     if (isStreaming) return;
@@ -1005,14 +957,6 @@
 
   btnEndSession.addEventListener('click', endSession);
   btnEndSessionHeader.addEventListener('click', endSession);
-  btnTranscript.addEventListener('click', openTranscript);
-
-  btnCloseTx.addEventListener('click', closeTranscript);
-  btnCloseTx2.addEventListener('click', closeTranscript);
-  btnCopyTx.addEventListener('click', copyTranscript);
-  modalTranscript.addEventListener('click', e => {
-    if (e.target === modalTranscript) closeTranscript();
-  });
 
   // Feedback card option toggle
   fbCard.addEventListener('click', e => {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -75,7 +75,6 @@
       <span id="token-counter"></span>
       <span id="inactivity-timer"></span>
       <button class="btn btn-sm" id="btn-gallery-toggle" title="Toggle uploads gallery" disabled>🖼</button>
-      <button class="btn btn-sm" id="btn-transcript" disabled>Transcript</button>
       <button class="btn btn-sm" id="btn-end-session-header" disabled>End session</button>
     </div>
   </header>
@@ -158,23 +157,6 @@
       <div class="gallery-thumbs" id="gallery-thumbs"></div>
     </aside>
   </main>
-
-  <!-- ── Transcript modal ────────────────────────────────────────────────── -->
-  <div class="modal-backdrop" id="modal-transcript">
-    <div class="modal-card">
-      <div class="modal-head">
-        <h2>Session Transcript</h2>
-        <button class="btn btn-icon" id="btn-close-tx">✕</button>
-      </div>
-      <div class="modal-body" id="tx-body">
-        <p style="color:var(--text-muted);font-size:.88rem">Loading…</p>
-      </div>
-      <div class="modal-foot">
-        <button class="btn btn-sm" id="btn-copy-tx">Copy to clipboard</button>
-        <button class="btn btn-sm" id="btn-close-tx2">Close</button>
-      </div>
-    </div>
-  </div>
 
   <!-- ── Wrapping-up overlay ─────────────────────────────────────────────── -->
   <div class="modal-backdrop" id="wrapping-up-overlay">

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -833,24 +833,6 @@
       border-top: 1px solid var(--border);
     }
 
-    /* Transcript entries */
-    .tx-entry { margin-bottom: 14px; }
-    .tx-entry:last-child { margin-bottom: 0; }
-    .tx-role {
-      font-size: 0.69rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      margin-bottom: 3px;
-      color: var(--text-muted);
-    }
-    .tx-entry.student .tx-role { color: var(--accent); }
-    .tx-text {
-      white-space: pre-wrap;
-      font-size: 0.88rem;
-      line-height: 1.55;
-    }
-
     /* ── Toast notification ────────────────────────────────────────────────── */
     #toast {
       position: fixed;


### PR DESCRIPTION
## Summary

Closes #124.

Purely subtractive frontend cleanup:
- Removes `#btn-transcript` and the `#modal-transcript` modal from `index.html`
- Removes `btnTranscript`, `modalTranscript`, `txBody`, `btnCloseTx`, `btnCopyTx` DOM references and associated handlers from `app.js`
- Removes transcript-specific CSS (`.tx-entry`, `.tx-role`, `.tx-text`) from `styles.css`
- Retains `GET /api/transcript/:id` endpoint (still used by the history page)
- Retains shared modal CSS (used by other modals)

## Test plan

- [ ] Load `/` — confirm no JS console errors and transcript button is gone
- [ ] Send a message — confirm chat still streams normally
- [ ] Switch model/prompt — confirm switch-config modal still works
- [ ] End session — confirm wrapping-up overlay still works
- [ ] `curl /api/transcript/<id>` still returns a valid JSON response

🤖 Generated with [Claude Code](https://claude.com/claude-code)