### PR TITLE
feat: move end session button inline with chat input (#125)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -65,7 +65,7 @@
   const fileStrip      = $('file-strip');
   const endBanner      = $('end-banner');
   const btnEndSession       = $('btn-end-session');
-  const btnEndSessionHeader = $('btn-end-session-header');
+  const btnEndSessionInline = $('btn-end-session-inline');
   const fbCard             = $('fb-card');
   const btnFbSubmit        = $('btn-fb-submit');
   const btnFbSkip          = $('btn-fb-skip');
@@ -217,7 +217,7 @@
   // ── Header button state ───────────────────────────────────────────────────
   function updateHeaderButtons() {
     const hasMessages = msgList.length > 0;
-    btnEndSessionHeader.disabled = !hasMessages;
+    btnEndSessionInline.disabled = !hasMessages;
   }
 
   // ── Empty-state toggle ────────────────────────────────────────────────────
@@ -516,7 +516,7 @@
     msgInput.disabled         = disabled;
     btnAttach.disabled        = disabled;
     // When re-enabling after streaming, respect the "has messages" gate
-    btnEndSessionHeader.disabled = disabled || msgList.length === 0;
+    btnEndSessionInline.disabled = disabled || msgList.length === 0;
   }
 
   // ── Session DELETE helpers ────────────────────────────────────────────────
@@ -761,7 +761,7 @@
     msgInput.disabled = true;
     btnSend.disabled  = true;
     btnAttach.disabled = true;
-    btnEndSessionHeader.disabled = true;
+    btnEndSessionInline.disabled = true;
     msgInput.placeholder = 'Session ended.';
     showToast(message, 5000);
   }
@@ -956,7 +956,7 @@
   });
 
   btnEndSession.addEventListener('click', endSession);
-  btnEndSessionHeader.addEventListener('click', endSession);
+  btnEndSessionInline.addEventListener('click', endSession);
 
   // Feedback card option toggle
   fbCard.addEventListener('click', e => {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -75,7 +75,6 @@
       <span id="token-counter"></span>
       <span id="inactivity-timer"></span>
       <button class="btn btn-sm" id="btn-gallery-toggle" title="Toggle uploads gallery" disabled>🖼</button>
-      <button class="btn btn-sm" id="btn-end-session-header" disabled>End session</button>
     </div>
   </header>
 
@@ -138,6 +137,7 @@
                accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
         <textarea id="msg-input" placeholder="What are you stuck on?" rows="1"></textarea>
         <button class="btn btn-primary" id="btn-send">Send</button>
+        <button class="btn btn-sm" id="btn-end-session-inline" disabled title="End this session">End</button>
       </div>
     </div>
     </div><!-- /.chat-column -->

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -707,6 +707,25 @@
       width: 100%;
     }
 
+    /* ── Inline end-session button ─────────────────────────────────────────── */
+    #btn-end-session-inline {
+      color: var(--danger);
+      border-color: transparent;
+      background: transparent;
+      opacity: 0.6;
+      flex-shrink: 0;
+    }
+    #btn-end-session-inline:not(:disabled):hover {
+      background: rgba(248, 113, 113, 0.1);
+      border-color: var(--danger);
+      color: var(--danger);
+      opacity: 1;
+    }
+    #btn-end-session-inline:disabled {
+      opacity: 0.25;
+      cursor: default;
+    }
+
     #msg-input {
       flex: 1;
       resize: none;


### PR DESCRIPTION
## Summary

Closes #125. Depends on #128 (#124).

- Removes `#btn-end-session-header` from the header
- Adds `#btn-end-session-inline` inside `#input-row`, styled as a compact ghost-danger button
- Renames `btnEndSessionHeader` -> `btnEndSessionInline` throughout `app.js`
- Leaves the `#end-banner` sentinel-triggered End button untouched

## Test plan

- [ ] Load `/` as an authenticated user — inline "End" button visible right of Send, disabled initially
- [ ] Send a message — inline End button becomes enabled
- [ ] Click inline End — feedback card appears, session ends correctly
- [ ] Wait for tutor sentinel — `#end-banner` "End session" still works
- [ ] Mobile viewport (<=600px) — input row still fits without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)