### PR TITLE
feat: move user account button to rightmost header position (#123)

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -56,7 +56,20 @@
       </span>
     </span>
     <div class="header-right">
+      <span id="build-info" class="build-info"></span>
+      <span id="thinking-badge" class="thinking-badge" style="display:none" title="Extended thinking — click to toggle"></span>
+      <span id="prompt-badge" class="prompt-badge" style="display:none" title="Active prompt — click to switch"></span>
+      <span id="model-badge" class="model-badge" style="display:none" title="Active model — click to switch"></span>
+      <span id="token-counter"></span>
+      <span id="inactivity-timer"></span>
+      <button class="btn btn-sm" id="btn-gallery-toggle" title="Toggle uploads gallery" disabled>🖼</button>
       <button id="account-trigger" class="account-trigger" style="display:none" aria-haspopup="true" aria-expanded="false">
+        <svg class="account-avatar-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+             aria-hidden="true">
+          <circle cx="12" cy="8" r="4"/>
+          <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
+        </svg>
         <span id="user-display-name" class="user-display-name"></span>
         <svg class="account-caret" width="10" height="6" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
       </button>
@@ -68,13 +81,6 @@
         <div class="account-dropdown-divider"></div>
         <button class="account-dropdown-item account-dropdown-logout" id="menu-logout" role="menuitem">Log out</button>
       </div>
-      <span id="build-info" class="build-info"></span>
-      <span id="thinking-badge" class="thinking-badge" style="display:none" title="Extended thinking — click to toggle"></span>
-      <span id="prompt-badge" class="prompt-badge" style="display:none" title="Active prompt — click to switch"></span>
-      <span id="model-badge" class="model-badge" style="display:none" title="Active model — click to switch"></span>
-      <span id="token-counter"></span>
-      <span id="inactivity-timer"></span>
-      <button class="btn btn-sm" id="btn-gallery-toggle" title="Toggle uploads gallery" disabled>🖼</button>
     </div>
   </header>
 

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -195,6 +195,12 @@
       height: 6px;
       flex-shrink: 0;
     }
+    .account-avatar-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      opacity: 0.7;
+    }
     .user-display-name {
       white-space: nowrap;
       max-width: 140px;


### PR DESCRIPTION
## Summary

Closes #123. Depends on #128 (#124) and #129 (#125).

- Reorders `.header-right` so `#account-trigger` and `#account-dropdown` sit at the far right
- Adds an inline SVG user-avatar icon inside the account trigger (no new dependencies)
- Adds `.account-avatar-icon` CSS rule
- Purely presentational; `app.js` is unchanged

## Test plan

- [ ] Load `/` as a logged-in user — account button (avatar + name + caret) is at the far right of the header
- [ ] Click the button — dropdown positions correctly and opens
- [ ] Mobile viewport (<=600px) — name text hidden; avatar + caret visible; dropdown still opens
- [ ] Unauthenticated state — `#account-trigger` stays hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)