### PR TITLE
feat: include user's rating in the session history table (#127)

### DIFF
--- a/apps/api/src/routes/history.ts
+++ b/apps/api/src/routes/history.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { getSessionsByUser } from "@ai-tutor/db";
+import { getSessionsByUser, getFeedbackForSessions } from "@ai-tutor/db";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
 /**
@@ -18,16 +18,22 @@ export function createHistoryRouter(db: SupabaseClient): Router {
     try {
       const { userId } = req as AuthedRequest;
       const rows = await getSessionsByUser(db, userId);
+      const feedbackMap = await getFeedbackForSessions(db, rows.map((r) => r.id));
 
-      const sessions = rows.map((r) => ({
-        id: r.id,
-        started_at: r.started_at,
-        ended_at: r.ended_at,
-        prompt_name: r.prompt_name,
-        model: r.model,
-        total_input_tokens: r.total_input_tokens,
-        total_output_tokens: r.total_output_tokens,
-      }));
+      const sessions = rows.map((r) => {
+        const fb = feedbackMap.get(r.id);
+        return {
+          id: r.id,
+          started_at: r.started_at,
+          ended_at: r.ended_at,
+          prompt_name: r.prompt_name,
+          model: r.model,
+          total_input_tokens: r.total_input_tokens,
+          total_output_tokens: r.total_output_tokens,
+          outcome: fb?.outcome ?? null,
+          experience: fb?.experience ?? null,
+        };
+      });
 
       res.json({ sessions });
     } catch (err) {

--- a/apps/web/public/history.css
+++ b/apps/web/public/history.css
@@ -239,3 +239,28 @@ html, body {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ── Feedback rating pills ─────────────────────────────────────────────── */
+.history-item-rating {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+
+.rating-pill {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+  border: 1px solid transparent;
+}
+
+.rating-pill.outcome-solved    { background: rgba(34,197,94,0.15);  border-color: rgba(34,197,94,0.4);  color: #22c55e; }
+.rating-pill.outcome-partial   { background: rgba(234,179,8,0.15);  border-color: rgba(234,179,8,0.4);  color: #eab308; }
+.rating-pill.outcome-stuck     { background: rgba(239,68,68,0.15);  border-color: rgba(239,68,68,0.4);  color: #ef4444; }
+
+.rating-pill.experience-positive { background: rgba(124,106,247,0.15); border-color: rgba(124,106,247,0.4); color: #7c6af7; }
+.rating-pill.experience-neutral  { background: rgba(154,160,173,0.15); border-color: rgba(154,160,173,0.4); color: #9aa0ad; }
+.rating-pill.experience-negative { background: rgba(239,68,68,0.15);   border-color: rgba(239,68,68,0.4);   color: #ef4444; }

--- a/apps/web/public/history.js
+++ b/apps/web/public/history.js
@@ -62,6 +62,16 @@
     return mins + " min";
   }
 
+  function formatOutcome(v) {
+    var labels = { solved: "Solved", partial: "Partially solved", stuck: "Stuck" };
+    return labels[v] || v;
+  }
+
+  function formatExperience(v) {
+    var labels = { positive: "Good experience", neutral: "Neutral", negative: "Difficult" };
+    return labels[v] || v;
+  }
+
   // ── Load sessions ─────────────────────────────────────────────────────────
   function loadSessions() {
     fetch("/api/history", { headers: authHeaders() })
@@ -114,6 +124,26 @@
       if (duration) parts.push(duration);
       meta.textContent = parts.join(" \u2022 ");
       info.appendChild(meta);
+
+      if (s.outcome || s.experience) {
+        var rating = document.createElement("div");
+        rating.className = "history-item-rating";
+
+        if (s.outcome) {
+          var outcomePill = document.createElement("span");
+          outcomePill.className = "rating-pill outcome-" + s.outcome;
+          outcomePill.textContent = formatOutcome(s.outcome);
+          rating.appendChild(outcomePill);
+        }
+        if (s.experience) {
+          var expPill = document.createElement("span");
+          expPill.className = "rating-pill experience-" + s.experience;
+          expPill.textContent = formatExperience(s.experience);
+          rating.appendChild(expPill);
+        }
+
+        info.appendChild(rating);
+      }
 
       var btn = document.createElement("button");
       btn.className = "history-view-btn";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,6 @@
 export { createSupabaseClient, createSupabaseAnonClient } from "./client.js";
 
-export { createSession, getSession, getSessionsByUser, updateSession, markSessionEnded, getUserEmailForSession } from "./sessions.js";
+export { createSession, getSession, getSessionsByUser, updateSession, markSessionEnded, getUserEmailForSession, getFeedbackForSessions } from "./sessions.js";
 
 export {
   createMessage,

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -89,6 +89,35 @@ export async function getSessionsByUser(
 }
 
 /**
+ * Fetch feedback (outcome + experience) for a batch of session IDs.
+ * Returns a map keyed by session_id.  Sessions with no feedback row are
+ * absent from the map.
+ */
+export async function getFeedbackForSessions(
+  client: SupabaseClient,
+  sessionIds: string[],
+): Promise<Map<string, { outcome: string | null; experience: string | null }>> {
+  if (sessionIds.length === 0) return new Map();
+
+  const { data, error } = await client
+    .from("session_feedback")
+    .select("session_id, outcome, experience")
+    .in("session_id", sessionIds);
+
+  if (error) throw new Error(`getFeedbackForSessions: ${error.message}`);
+
+  const map = new Map<string, { outcome: string | null; experience: string | null }>();
+  for (const row of (data ?? []) as Array<{
+    session_id: string;
+    outcome: string | null;
+    experience: string | null;
+  }>) {
+    map.set(row.session_id, { outcome: row.outcome, experience: row.experience });
+  }
+  return map;
+}
+
+/**
  * Mark a session as ended by setting ended_at to now.
  * Session data (messages, feedback) is retained for analysis.
  */


### PR DESCRIPTION
## Summary

Closes #127.

- New `getFeedbackForSessions()` batch helper in `packages/db/src/sessions.ts` (indexed `IN (...)` on `session_id`)
- `GET /api/history` now includes `outcome` and `experience` per session
- History page renders colored outcome + experience pills under each session row

No migrations required. Additive, backwards-compatible API change.

## Test plan

- [ ] Log in as a user with at least one session with student feedback — pills render with correct colors/labels
- [ ] Session with null outcome/experience — no pills render
- [ ] Session where student skipped feedback — no pills render
- [ ] User with no ended sessions — history page shows empty state without errors
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)