### PR TITLE
feat: include user info in transcript emails and honor opt-out preference (#126)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import {
   createSupabaseClient,
   createSupabaseAnonClient,
   markSessionEnded,
+  getUserInfoForSession,
 } from "@ai-tutor/db";
 import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/errors.js";
@@ -127,14 +128,16 @@ setInterval(() => {
       if (!session.emailSent && session.transcript.length > 0) {
         void (async () => {
           try {
-            const [evalResult, feedback] = await Promise.all([
+            const [evalResult, feedback, userInfo] = await Promise.all([
               runSessionEvaluation(db, sessionId, session.transcript),
               getOrCreateTimeoutFeedback(db, sessionId, "sweep"),
+              getUserInfoForSession(db, sessionId).catch(() => null),
             ]);
 
             const payload = buildTranscriptEmailPayload(
               session, sessionId, evalResult, feedback,
-              { model: config.model, promptName: defaultPromptName, extendedThinking: config.extendedThinking }
+              { model: config.model, promptName: defaultPromptName, extendedThinking: config.extendedThinking },
+              userInfo,
             );
             await sendTranscript(emailConfig, payload);
             if (emailConfig.apiKey && emailConfig.to) {

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -2,8 +2,8 @@ import { evaluateTranscript } from "@ai-tutor/core";
 import type { EvaluationResult, Session } from "@ai-tutor/core";
 import type { TranscriptEmailPayload } from "@ai-tutor/email";
 import { sendUserTranscript } from "@ai-tutor/email";
-import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback, getUserEmailForSession } from "@ai-tutor/db";
-import type { DbSessionFeedback } from "@ai-tutor/db";
+import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback, getUserProfileForSession } from "@ai-tutor/db";
+import type { DbSessionFeedback, UserSessionInfo } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 const DIMENSION_LABELS: Record<string, string> = {
@@ -44,6 +44,7 @@ export function buildTranscriptEmailPayload(
   evalResult: EvaluationResult | null,
   feedback: DbSessionFeedback | null,
   fallbacks?: { model?: string; promptName?: string; extendedThinking?: boolean },
+  userInfo?: UserSessionInfo | null,
 ): TranscriptEmailPayload {
   const summary = session.getSessionSummary();
   return {
@@ -60,6 +61,7 @@ export function buildTranscriptEmailPayload(
     model: session.model ?? fallbacks?.model,
     promptName: session.promptName ?? fallbacks?.promptName,
     extendedThinking: session.extendedThinking ?? fallbacks?.extendedThinking,
+    userInfo: userInfo ?? null,
   };
 }
 
@@ -156,11 +158,17 @@ export async function sendUserTranscriptIfApplicable(
   db: SupabaseClient,
 ): Promise<void> {
   try {
-    const email = await getUserEmailForSession(db, sessionId);
-    if (!email) return;
+    const profile = await getUserProfileForSession(db, sessionId);
+    if (!profile) return;
+    if (!profile.emailTranscriptsEnabled) {
+      console.log(
+        `[email] User transcript suppressed for ${sessionId} (emailTranscriptsEnabled=false).`
+      );
+      return;
+    }
 
     const apiKey = process.env.RESEND_API_KEY;
-    await sendUserTranscript(email, { apiKey, from: emailFrom }, {
+    await sendUserTranscript(profile.email, { apiKey, from: emailFrom }, {
       transcript: transcript as Array<{ role: "Student" | "Tutor"; text: string }>,
       startedAt,
       durationMs,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import {
   getSession as getDbSession,
   markSessionEnded,
+  getUserInfoForSession,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getSession, removeSession } from "../lib/session-store.js";
@@ -69,12 +70,14 @@ export function createSessionsRouter(
 
       try {
         if (!discard && session && !session.emailSent && session.transcript.length > 0) {
-          const [evalResult, feedback] = await Promise.all([
+          const [evalResult, feedback, userInfo] = await Promise.all([
             runSessionEvaluation(db, sessionId, session.transcript),
             getOrCreateTimeoutFeedback(db, sessionId, "sessions"),
+            getUserInfoForSession(db, sessionId).catch(() => null),
           ]);
           const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback,
-            { model: defaultModel, promptName: defaultPromptName, extendedThinking: defaultExtendedThinking });
+            { model: defaultModel, promptName: defaultPromptName, extendedThinking: defaultExtendedThinking },
+            userInfo);
           try {
             await sendTranscript(emailConfig, payload);
             if (emailConfig.apiKey && emailConfig.to) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,17 @@
 export { createSupabaseClient, createSupabaseAnonClient } from "./client.js";
 
-export { createSession, getSession, getSessionsByUser, updateSession, markSessionEnded, getUserEmailForSession, getFeedbackForSessions } from "./sessions.js";
+export {
+  createSession,
+  getSession,
+  getSessionsByUser,
+  updateSession,
+  markSessionEnded,
+  getUserEmailForSession,
+  getUserInfoForSession,
+  getUserProfileForSession,
+  getFeedbackForSessions,
+} from "./sessions.js";
+export type { UserSessionInfo, UserSessionProfile } from "./sessions.js";
 
 export {
   createMessage,

--- a/packages/db/src/profiles.ts
+++ b/packages/db/src/profiles.ts
@@ -49,8 +49,6 @@ export async function getProfile(
 /**
  * Update a user's profile settings. Uses upsert semantics so it works for
  * legacy users who may not have a profiles row yet.
- *
- * // TODO: wire emailTranscriptsEnabled to evaluation.ts sweep in follow-on issue
  */
 export async function updateProfile(
   client: SupabaseClient,

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -68,6 +68,79 @@ export async function getUserEmailForSession(
   }
 }
 
+export interface UserSessionInfo {
+  email: string;
+  name: string | null;
+}
+
+/**
+ * Look up the name and email of the authenticated user who owns a session.
+ * Returns null if the session has no user_id or if any lookup fails.
+ */
+export async function getUserInfoForSession(
+  client: SupabaseClient,
+  sessionId: string,
+): Promise<UserSessionInfo | null> {
+  try {
+    const session = await getSession(client, sessionId);
+    if (!session?.user_id) return null;
+
+    const { data, error } = await client.auth.admin.getUserById(session.user_id);
+    if (error || !data?.user?.email) return null;
+
+    return {
+      email: data.user.email,
+      name: (data.user.user_metadata?.name as string | undefined) ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface UserSessionProfile {
+  email: string;
+  name: string | null;
+  emailTranscriptsEnabled: boolean;
+}
+
+/**
+ * Look up the user's email, name, and transcript preference for a session.
+ * Returns null if the session has no user_id or if any lookup fails.
+ * emailTranscriptsEnabled defaults to true for users without a profiles row.
+ */
+export async function getUserProfileForSession(
+  client: SupabaseClient,
+  sessionId: string,
+): Promise<UserSessionProfile | null> {
+  try {
+    const session = await getSession(client, sessionId);
+    if (!session?.user_id) return null;
+
+    const [authResult, profileResult] = await Promise.all([
+      client.auth.admin.getUserById(session.user_id),
+      client
+        .from("profiles")
+        .select("email_transcripts_enabled")
+        .eq("user_id", session.user_id)
+        .maybeSingle(),
+    ]);
+
+    if (authResult.error || !authResult.data?.user?.email) return null;
+
+    const profileData = profileResult.data as
+      | { email_transcripts_enabled: boolean | null }
+      | null;
+
+    return {
+      email: authResult.data.user.email,
+      name: (authResult.data.user.user_metadata?.name as string | undefined) ?? null,
+      emailTranscriptsEnabled: profileData?.email_transcripts_enabled ?? true,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Return ended sessions belonging to a specific user, most recent first.
  * Used by the history page to list past tutoring sessions.

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -45,6 +45,9 @@ export interface TranscriptEmailPayload {
     comment: string | null;
     skipped: boolean;
   } | null;
+
+  /** Authenticated user who initiated the session.  Null for anonymous sessions. */
+  userInfo?: { email: string; name: string | null } | null;
 }
 
 /** Maximum total attachment size Resend accepts (40 MB in bytes). */
@@ -189,9 +192,18 @@ function buildHtml(payload: TranscriptEmailPayload): string {
     model,
     promptName,
     extendedThinking,
+    userInfo,
   } = payload;
 
   const exchangeCount = Math.floor(transcript.length / 2);
+
+  const userRow = userInfo
+    ? `<tr><td style="padding:6px 0;color:#555;width:160px;">User</td><td>${
+        userInfo.name
+          ? `${escapeHtml(userInfo.name)} &lt;${escapeHtml(userInfo.email)}&gt;`
+          : escapeHtml(userInfo.email)
+      }</td></tr>`
+    : `<tr><td style="padding:6px 0;color:#555;width:160px;">User</td><td style="color:#999;">Anonymous</td></tr>`;
 
   const filesHtml =
     files.length > 0
@@ -221,6 +233,7 @@ function buildHtml(payload: TranscriptEmailPayload): string {
   <h1 style="font-size:1.4rem;border-bottom:2px solid #4f46e5;padding-bottom:8px;">Tutor Session Summary</h1>
   <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
     <tr><td style="padding:6px 0;color:#555;width:160px;">Session ID</td><td style="font-size:0.85em;">${sessionId ?? "unknown"}</td></tr>
+    ${userRow}
     <tr><td style="padding:6px 0;color:#555;">Model</td><td>${model ?? "unknown"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Prompt</td><td>${promptName ?? "unknown"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Extended thinking</td><td>${extendedThinking === undefined ? "unknown" : extendedThinking ? "On" : "Off"}</td></tr>


### PR DESCRIPTION
## Summary

Closes #126.

**Admin email** — `sendTranscript` now shows a "User" row with the authenticated user's name and email (or "Anonymous" for unauthenticated sessions).

**User email preference** — `profiles.email_transcripts_enabled` (stored since migration 004 but previously unconsulted) now gates `sendUserTranscriptIfApplicable`. Opting out via the settings page suppresses the user copy of the transcript (admin copy still sent).

## Implementation

- New `getUserInfoForSession()` + `getUserProfileForSession()` in `packages/db/src/sessions.ts`, exported from `@ai-tutor/db`
- Optional `userInfo` on `TranscriptEmailPayload`; rendered in admin email's summary table
- `buildTranscriptEmailPayload()` gains an optional 6th `userInfo` parameter; both call sites (inactivity sweep, DELETE handler) updated
- `sendUserTranscriptIfApplicable()` switches to `getUserProfileForSession` and logs suppression when the preference is off
- Resolves and removes the TODO in `packages/db/src/profiles.ts`

No migrations, no new env vars, no new dependencies.

## Test plan

- [ ] End an anonymous session — admin email shows "Anonymous" in the User row
- [ ] End an authenticated session — admin email shows the user's name + email
- [ ] Toggle settings `emailTranscriptsEnabled` off — end a session — user copy is NOT sent; admin copy still arrives; log shows suppression
- [ ] Let a session time out — same user-info behavior as the explicit end path
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)