### PR TITLE
fix: escape untrusted HTML in transcript emails

### DIFF
--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -89,7 +89,8 @@ function escapeHtml(text: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
 }
 
 function scoreBadge(score: string): string {
@@ -240,10 +241,10 @@ function buildHtml(payload: TranscriptEmailPayload): string {
 <body style="font-family:sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#222;">
   <h1 style="font-size:1.4rem;border-bottom:2px solid #4f46e5;padding-bottom:8px;">Tutor Session Summary</h1>
   <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
-    <tr><td style="padding:6px 0;color:#555;width:160px;">Session ID</td><td style="font-size:0.85em;">${sessionId ?? "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;width:160px;">Session ID</td><td style="font-size:0.85em;">${escapeHtml(sessionId ?? "unknown")}</td></tr>
     ${userRow}
-    <tr><td style="padding:6px 0;color:#555;">Model</td><td>${model ?? "unknown"}</td></tr>
-    <tr><td style="padding:6px 0;color:#555;">Prompt</td><td>${promptName ?? "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Model</td><td>${escapeHtml(model ?? "unknown")}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">Prompt</td><td>${escapeHtml(promptName ?? "unknown")}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Extended thinking</td><td>${extendedThinking === undefined ? "unknown" : extendedThinking ? "On" : "Off"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Started</td><td>${formatDate(startedAt)}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Duration</td><td>${formatDuration(durationMs)}</td></tr>

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -84,6 +84,14 @@ function formatGeo(geo: Record<string, unknown> | null | undefined): string {
   return parts.length > 0 ? parts.join(", ") : "unknown";
 }
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 function scoreBadge(score: string): string {
   const colorMap: Record<string, string> = {
     pass: "#16a34a",
@@ -95,7 +103,7 @@ function scoreBadge(score: string): string {
     abandoned: "#9ca3af",
   };
   const color = colorMap[score] ?? "#9ca3af";
-  return `<span style="display:inline-block;padding:2px 8px;border-radius:4px;background:${color};color:#fff;font-size:0.8em;font-weight:bold;">${score}</span>`;
+  return `<span style="display:inline-block;padding:2px 8px;border-radius:4px;background:${color};color:#fff;font-size:0.8em;font-weight:bold;">${escapeHtml(score)}</span>`;
 }
 
 function buildEvaluationHtml(
@@ -111,9 +119,9 @@ function buildEvaluationHtml(
     .map(
       (d) => `
     <tr>
-      <td style="padding:8px 10px;border:1px solid #ddd;">${d.label}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;">${escapeHtml(d.label)}</td>
       <td style="padding:8px 10px;border:1px solid #ddd;text-align:center;">${scoreBadge(d.score)}</td>
-      <td style="padding:8px 10px;border:1px solid #ddd;font-size:0.9em;color:#444;">${d.rationale}</td>
+      <td style="padding:8px 10px;border:1px solid #ddd;font-size:0.9em;color:#444;">${escapeHtml(d.rationale)}</td>
     </tr>`
     )
     .join("");
@@ -156,10 +164,10 @@ function buildStudentFeedbackHtml(
     body = "<p>Student feedback: skipped.</p>";
   } else {
     const outcomeLabel = studentFeedback.outcome
-      ? (outcomeLabels[studentFeedback.outcome] ?? studentFeedback.outcome)
+      ? (outcomeLabels[studentFeedback.outcome] ?? escapeHtml(studentFeedback.outcome))
       : "—";
     const experienceLabel = studentFeedback.experience
-      ? (experienceLabels[studentFeedback.experience] ?? studentFeedback.experience)
+      ? (experienceLabels[studentFeedback.experience] ?? escapeHtml(studentFeedback.experience))
       : "—";
     const commentRow = studentFeedback.comment
       ? `<tr><td style="padding:6px 0;color:#555;width:120px;">Comment</td><td>${escapeHtml(studentFeedback.comment)}</td></tr>`
@@ -334,14 +342,6 @@ export interface UserTranscriptPayload {
  * conversation transcript.  Omits evaluation, feedback, IP/geo, token
  * counts, model info, session ID, and prompt name.
  */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
 function buildUserHtml(payload: UserTranscriptPayload): string {
   const { transcript, startedAt, durationMs } = payload;
 

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -162,7 +162,7 @@ function buildStudentFeedbackHtml(
       ? (experienceLabels[studentFeedback.experience] ?? studentFeedback.experience)
       : "—";
     const commentRow = studentFeedback.comment
-      ? `<tr><td style="padding:6px 0;color:#555;width:120px;">Comment</td><td>${studentFeedback.comment}</td></tr>`
+      ? `<tr><td style="padding:6px 0;color:#555;width:120px;">Comment</td><td>${escapeHtml(studentFeedback.comment)}</td></tr>`
       : "";
 
     body = `
@@ -210,7 +210,7 @@ function buildHtml(payload: TranscriptEmailPayload): string {
       ? `<ul>${files
           .map(
             (f) =>
-              `<li>${f.filename} (${f.mimetype}, ${(f.buffer.length / 1024).toFixed(1)} KB)</li>`
+              `<li>${escapeHtml(f.filename)} (${escapeHtml(f.mimetype)}, ${(f.buffer.length / 1024).toFixed(1)} KB)</li>`
           )
           .join("")}</ul>`
       : "<p>None</p>";
@@ -222,7 +222,7 @@ function buildHtml(payload: TranscriptEmailPayload): string {
       const label = isStudent
         ? "<strong>Student</strong>"
         : "<strong>Tutor</strong>";
-      return `<div style="background:${bg};padding:12px 16px;margin:8px 0;border-radius:6px;white-space:pre-wrap;">${label}<br>${entry.text}</div>`;
+      return `<div style="background:${bg};padding:12px 16px;margin:8px 0;border-radius:6px;white-space:pre-wrap;">${label}<br>${escapeHtml(entry.text)}</div>`;
     })
     .join("");
 
@@ -241,9 +241,9 @@ function buildHtml(payload: TranscriptEmailPayload): string {
     <tr><td style="padding:6px 0;color:#555;">Duration</td><td>${formatDuration(durationMs)}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Exchanges</td><td>${exchangeCount}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Tokens</td><td>${tokenUsage ? formatTokens(tokenUsage) : "N/A"}</td></tr>
-    <tr><td style="padding:6px 0;color:#555;">IP</td><td>${clientInfo.ip ?? "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">IP</td><td>${clientInfo.ip ? escapeHtml(clientInfo.ip) : "unknown"}</td></tr>
     <tr><td style="padding:6px 0;color:#555;">Location</td><td>${formatGeo(clientInfo.geo)}</td></tr>
-    <tr><td style="padding:6px 0;color:#555;">User agent</td><td style="font-size:0.85em;">${clientInfo.userAgent ?? "unknown"}</td></tr>
+    <tr><td style="padding:6px 0;color:#555;">User agent</td><td style="font-size:0.85em;">${clientInfo.userAgent ? escapeHtml(clientInfo.userAgent) : "unknown"}</td></tr>
   </table>
   <h2 style="font-size:1.1rem;">Uploaded files</h2>
   ${filesHtml}


### PR DESCRIPTION
## Summary
- Applies `escapeHtml()` to all previously unescaped interpolations in `buildHtml()` inside `packages/email/src/transcript.ts`: student feedback comment, transcript message text, uploaded file name/mimetype, and client IP and user-agent.
- Prevents stored XSS / HTML injection in the parent/admin transcript email when any of these untrusted values contain HTML metacharacters.

## Changes
- `studentFeedback.comment` (was line 165)
- `entry.text` in transcript loop (was line 225)
- `f.filename` and `f.mimetype` in `filesHtml` (was lines 211/213)
- `clientInfo.ip` and `clientInfo.userAgent` (was lines 244/246)

The `escapeHtml()` helper was already defined in this file (line 337) and is reused.

## Test plan
- [x] `npm run build` passes from repo root
- [ ] Manual verify: send a transcript email with `<script>` in a comment; confirm it renders as literal text in the received email

Closes #134
Closes #135
Closes #136
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)