### PR TITLE
fix: make CORS fail closed when CORS_ORIGIN is unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | RESEND_API_KEY | no | — | email, api | Resend API key (email skipped if absent) |
 | PARENT_EMAIL | no | — | api | Recipient for transcript/feedback emails |
 | EMAIL_FROM | no | tutor@tutor.schmim.com | email, api | Sender address |
-| CORS_ORIGIN | no | * | api | Allowed CORS origin |
+| CORS_ORIGIN | no | false (fail-closed) | api | Allowed CORS origin. When unset, all cross-origin requests are rejected. Set explicitly for all deployments. |
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -1,12 +1,20 @@
 import cors from "cors";
 
 /**
- * CORS middleware.  In production, restrict `origin` to your frontend domain.
- * In development, all origins are allowed so the frontend can run on a
- * different port than the API server.
+ * CORS middleware.  Fails closed: when `CORS_ORIGIN` is not set, cross-origin
+ * requests are rejected.  Set `CORS_ORIGIN` explicitly to the allowed origin
+ * (e.g. your frontend domain) for every deployment — including local dev when
+ * the frontend runs on a different port than the API server.
  */
+const corsOrigin = process.env.CORS_ORIGIN ?? false;
+if (!process.env.CORS_ORIGIN) {
+  console.warn(
+    "[cors] CORS_ORIGIN not set — cross-origin requests will be rejected",
+  );
+}
+
 export const corsMiddleware = cors({
-  origin: process.env.CORS_ORIGIN ?? "*",
+  origin: corsOrigin,
   methods: ["GET", "POST", "DELETE", "OPTIONS"],
   allowedHeaders: ["Content-Type", "Authorization"],
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
-| `CORS_ORIGIN` | no | Your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`) | No |
+| `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
 
 You can skip `RESEND_API_KEY`, `PARENT_EMAIL`, and `EMAIL_FROM` if you don't want email transcripts.  The app will work without them.


### PR DESCRIPTION
## Summary
- `apps/api/src/middleware/cors.ts` no longer falls back to `*` (allow-all) when `CORS_ORIGIN` is unset. The fallback is now `false`, so the `cors` library rejects cross-origin requests when the variable is missing.
- Adds a startup warning logged at server boot so a missing `CORS_ORIGIN` is visible in the logs.
- Updates `CLAUDE.md` and `docs/deployment.md` to document the new fail-closed default.

## Test plan
- [x] `npm run build` passes from repo root
- [ ] Manual verify: start the API with `CORS_ORIGIN` unset and confirm the `[cors] CORS_ORIGIN not set` warning appears
- [ ] Manual verify: with `CORS_ORIGIN` unset, a request from a different origin receives a CORS failure; with `CORS_ORIGIN` set, the same request succeeds

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)