### PR TITLE
fix: add rate limiter to /api/auth/refresh (#140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,7 @@ Rate limiting is applied via `express-rate-limit` to protect auth endpoints from
 - `POST /api/auth/resend-verification` — 3 requests per 15 minutes per IP
 - `POST /api/auth/forgot-password` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
 - `POST /api/auth/change-password` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
+- `POST /api/auth/refresh` — 3 requests per 15 minutes per IP (shares the `resendLimiter`)
 
 All rate-limited endpoints return `429 { ok: false, error: "too_many_requests" }` when the limit is exceeded.  The server sets `trust proxy` to `1` (in `apps/api/src/index.ts`) so `express-rate-limit` keys on the real client IP behind Render's proxy.
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -294,7 +294,7 @@ export function createAuthRouter(db: SupabaseClient, anonDb: SupabaseClient): Ro
    * Exchanges a refresh token for a new access token pair via the anon
    * client.
    */
-  router.post("/refresh", async (req, res) => {
+  router.post("/refresh", resendLimiter, async (req, res) => {
     const body = req.body as { refreshToken?: unknown } | undefined;
     const refreshToken = body?.refreshToken;
     if (typeof refreshToken !== "string" || !refreshToken) {


### PR DESCRIPTION
## Summary
- Applies the existing `resendLimiter` (3 requests / 15 min / IP) to `POST /api/auth/refresh` — closes the only auth endpoint without throttling.
- Updates CLAUDE.md to document the new per-endpoint limit.

Closes #140.

## Test plan
- [x] `npm run build` passes
- [ ] Manual: POST to `/api/auth/refresh` more than 3 times in 15 min from the same IP returns `429 { ok: false, error: "too_many_requests" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)