### PR TITLE
feat: single end-session control with sentinel pulse (#125)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -64,7 +64,6 @@
   const fileInput      = $('file-input');
   const fileStrip      = $('file-strip');
   const endBanner      = $('end-banner');
-  const btnEndSession       = $('btn-end-session');
   const btnEndSessionInline = $('btn-end-session-inline');
   const fbCard             = $('fb-card');
   const btnFbSubmit        = $('btn-fb-submit');
@@ -364,6 +363,7 @@
     if (hasSentinel && !endAvailable && !sessionEnded) {
       endAvailable = true;
       endBanner.classList.add('active');
+      btnEndSessionInline.classList.add('end-ready');
     }
 
     scrollBottom();
@@ -637,6 +637,7 @@
     messagesEl.innerHTML = '';
     showEmpty();
     endBanner.classList.remove('active');
+    btnEndSessionInline.classList.remove('end-ready');
 
     fbCard.classList.remove('active');
     fbCard.querySelectorAll('.fb-opt.chosen').forEach(el => el.classList.remove('chosen'));
@@ -731,6 +732,7 @@
     sessionEnded = true;
     stopCountdownDisplay();
     endBanner.classList.remove('active');
+    btnEndSessionInline.classList.remove('end-ready');
 
     await deleteSession(sessionId);
     lockSession('Session ended due to inactivity. Your transcript has been emailed.');
@@ -743,6 +745,7 @@
     if (inactivityTimer) clearTimeout(inactivityTimer);
     stopCountdownDisplay();
     endBanner.classList.remove('active');
+    btnEndSessionInline.classList.remove('end-ready');
 
     const tutorMessages = msgList.filter(e => e.role === 'tutor');
     if (tutorMessages.length > 0) {
@@ -762,6 +765,7 @@
     btnSend.disabled  = true;
     btnAttach.disabled = true;
     btnEndSessionInline.disabled = true;
+    btnEndSessionInline.classList.remove('end-ready');
     msgInput.placeholder = 'Session ended.';
     showToast(message, 5000);
   }
@@ -955,7 +959,6 @@
     if (fileInput.files?.length) { addFiles(fileInput.files); fileInput.value = ''; }
   });
 
-  btnEndSession.addEventListener('click', endSession);
   btnEndSessionInline.addEventListener('click', endSession);
 
   // Feedback card option toggle

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -107,7 +107,7 @@
       <div id="drag-overlay">📎 Drop files here</div>
     </div>
       <div id="end-banner" class="end-banner">
-        Looks like you're all set! <button id="btn-end-session" class="btn btn-sm">End session</button>
+        Looks like you're all set! Hit <strong>End session</strong> below when you're ready.
       </div>
 
     <!-- Input wrapper -->
@@ -143,7 +143,7 @@
                accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
         <textarea id="msg-input" placeholder="What are you stuck on?" rows="1"></textarea>
         <button class="btn btn-primary" id="btn-send">Send</button>
-        <button class="btn btn-sm" id="btn-end-session-inline" disabled title="End this session">End</button>
+        <button class="btn btn-sm" id="btn-end-session-inline" disabled title="End this session">End session</button>
       </div>
     </div>
     </div><!-- /.chat-column -->

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -731,6 +731,17 @@
       opacity: 0.25;
       cursor: default;
     }
+    #btn-end-session-inline.end-ready {
+      opacity: 1;
+      background: rgba(248, 113, 113, 0.12);
+      border-color: var(--danger);
+      color: var(--danger);
+      animation: end-pulse 1.5s ease-in-out 2;
+    }
+    @keyframes end-pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(248, 113, 113, 0); }
+      50%       { box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.3); }
+    }
 
     #msg-input {
       flex: 1;


### PR DESCRIPTION
## Summary
- Removes the duplicate `#btn-end-session` button from `#end-banner`; the inline input-row button (`#btn-end-session-inline`) is now the sole control and has its label restored to "End session".
- Adds an `end-ready` CSS class with a short pulse animation; the class is applied when the tutor emits the end-session sentinel so the user's eye is drawn to where to click.
- Clears the `end-ready` class in `resetSessionState()`, `onInactivityTimeout()`, `endSession()`, and `lockSession()` so the highlight doesn't linger across session state transitions.
- Removes stale `btnEndSession` references from `app.js`.

Addresses #125.

## Test plan
- [x] Syntax check of `app.js` passes
- [ ] Manual: load `/`, confirm inline "End session" button renders in input row and is disabled before any message.
- [ ] Manual: send a message — button becomes enabled.
- [ ] Manual: trigger the sentinel — `#end-banner` shows the text-only hint; inline button gets highlighted with two pulse cycles.
- [ ] Manual: click "End session" — session ends, feedback card appears, highlight clears.
- [ ] Manual: start a new session — `end-ready` state is gone.
- [ ] Manual on mobile viewport: "End session" label fits without overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)