### PR TITLE
fix: Settings and History menu items broken by CSP script-src-attr (#123)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -87,6 +87,8 @@
   const accountDropdown    = $('account-dropdown');
   const accountDropdownInfo = $('account-dropdown-info');
   const userDisplayName    = $('user-display-name');
+  const menuSettings       = $('menu-settings');
+  const menuHistory        = $('menu-history');
   const menuLogout         = $('menu-logout');
   const dragOverlay        = $('drag-overlay');
   const wrappingUpOverlay  = $('wrapping-up-overlay');
@@ -1039,6 +1041,14 @@
     }
   });
 
+  menuSettings.addEventListener('click', () => {
+    closeAccountDropdown();
+    window.location.href = '/settings.html';
+  });
+  menuHistory.addEventListener('click', () => {
+    closeAccountDropdown();
+    window.location.href = '/history.html';
+  });
   menuLogout.addEventListener('click', () => {
     closeAccountDropdown();
     handleLogout();

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -76,8 +76,8 @@
       <div id="account-dropdown" class="account-dropdown" style="display:none" role="menu">
         <div class="account-dropdown-info" id="account-dropdown-info"></div>
         <div class="account-dropdown-divider"></div>
-        <button class="account-dropdown-item" id="menu-settings" role="menuitem" onclick="window.location.href='/settings.html'">Settings</button>
-        <button class="account-dropdown-item" id="menu-history" role="menuitem" onclick="window.location.href='/history.html'">History</button>
+        <button class="account-dropdown-item" id="menu-settings" role="menuitem">Settings</button>
+        <button class="account-dropdown-item" id="menu-history" role="menuitem">History</button>
         <div class="account-dropdown-divider"></div>
         <button class="account-dropdown-item account-dropdown-logout" id="menu-logout" role="menuitem">Log out</button>
       </div>


### PR DESCRIPTION
## Summary

- Removes inline `onclick` attributes from the Settings and History dropdown buttons in `index.html`
- Adds `addEventListener` for both buttons in `app.js`, matching the existing Logout button pattern
- Root cause: Helmet 8 sets `script-src-attr: 'none'` by default, which blocks all inline `onclick`/`onXxx` attributes regardless of `'unsafe-inline'` in `script-src`. The Logout button used `addEventListener` (working), Settings/History used `onclick="..."` (silently blocked by CSP).

## Test plan

- [ ] Open chat page, click account avatar — dropdown opens
- [ ] Click Settings — navigates to `/settings.html`
- [ ] Click History — navigates to `/history.html`  
- [ ] Click Log out — still works
- [ ] Click outside dropdown — still closes

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)