### PR TITLE
feat(api): harden helmet security headers

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -99,9 +99,17 @@ app.use(
         styleSrc: ["'self'", "cdn.jsdelivr.net", "fonts.googleapis.com", "'unsafe-inline'"],
         fontSrc: ["'self'", "fonts.gstatic.com", "data:"],
         imgSrc: ["'self'", "data:", "blob:"],
-        connectSrc: ["'self'", "fonts.googleapis.com", "fonts.gstatic.com"],
+        connectSrc: [
+          "'self'",
+          "fonts.googleapis.com",
+          "fonts.gstatic.com",
+          ...(process.env.SUPABASE_URL ? [process.env.SUPABASE_URL] : []),
+        ],
       },
     },
+    xContentTypeOptions: true,
+    strictTransportSecurity: { maxAge: 31536000, includeSubDomains: true },
+    xFrameOptions: { action: "deny" },
   }),
 );
 


### PR DESCRIPTION
## Summary
- Add explicit \`X-Content-Type-Options: nosniff\`, \`Strict-Transport-Security\` (1 year, includeSubDomains), and \`X-Frame-Options: DENY\` to the helmet() configuration
- Thread \`SUPABASE_URL\` into CSP \`connectSrc\` so supabase-js can reach the project from the browser

Closes #153
Closes #154
Closes #155
Closes #156

## Test plan
- [x] \`npm run build\` passes
- [ ] Verify response headers in dev include the new directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)