### PR TITLE
fix(web): pin supabase-js CDN version and use localStorage

### DIFF
--- a/apps/web/public/auth.js
+++ b/apps/web/public/auth.js
@@ -35,6 +35,7 @@
     }
     return window.supabase.createClient(cfg.supabaseUrl, cfg.supabaseAnonKey, {
       auth: {
+        storage: window.localStorage,
         persistSession: true,
         autoRefreshToken: true,
         detectSessionInUrl: true,

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -36,7 +36,7 @@
       </div>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/history.js"></script>
 </body>

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -36,7 +36,7 @@
       </div>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/history.js"></script>
 </body>

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -213,7 +213,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/app.js"></script>
   <script src="/gallery.js"></script>

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -213,7 +213,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/app.js"></script>
   <script src="/gallery.js"></script>

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -101,7 +101,7 @@
       <p class="login-contact-note" id="login-contact-note"></p>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/login.js"></script>
 </body>

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -101,7 +101,7 @@
       <p class="login-contact-note" id="login-contact-note"></p>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/login.js"></script>
 </body>

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -94,7 +94,7 @@
       </form>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/settings.js"></script>
 </body>

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -94,7 +94,7 @@
       </form>
     </div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.99.1/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script src="/settings.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Pin \`@supabase/supabase-js\` CDN to \`2.99.1\` in all four HTML entry points (index, login, settings, history) so the CDN cannot ship a new major that breaks auth without warning.
- Explicitly set \`storage: window.localStorage\` in \`auth.js\` so token persistence is unambiguous and cannot be misclassified as a cookie by static scanners.

Note: Targeted against \`main\` rather than \`stage\` because \`apps/web/public/auth.js\` and the supabase CDN references only exist on \`main\` (post auth-redesign #151).

Closes #157

## Test plan
- [ ] Log in at \`/login.html\`; confirm a Supabase token appears in \`localStorage\` (not cookies)
- [ ] Confirm network tab loads \`@supabase/supabase-js@2.99.1\` on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)