### PR TITLE
style(web): align end-session button with adjacent controls

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -143,7 +143,7 @@
                accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
         <textarea id="msg-input" placeholder="What are you stuck on?" rows="1"></textarea>
         <button class="btn btn-primary" id="btn-send">Send</button>
-        <button class="btn btn-sm" id="btn-end-session-inline" disabled title="End this session">End session</button>
+        <button class="btn" id="btn-end-session-inline" disabled title="End this session">End session</button>
       </div>
     </div>
     </div><!-- /.chat-column -->

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -715,8 +715,9 @@
 
     /* ── Inline end-session button ─────────────────────────────────────────── */
     #btn-end-session-inline {
+      height: 40px;
       color: var(--danger);
-      border-color: transparent;
+      border-color: var(--border-bright);
       background: transparent;
       opacity: 0.6;
       flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Remove \`btn-sm\` from the inline end-session button so it matches the default button sizing
- Set explicit \`height: 40px\` and \`border-color: var(--border-bright)\` on the idle state so it sits flush with the Send and attach (📎) buttons in the input row

Note: Targeted \`main\` because the inline end-session button DOM/CSS block only lives there post #147. Stage has an older variant of the same element.

Closes #125

## Test plan
- [ ] Verify the End session button is the same height and has a visible border matching Send/attach
- [ ] Disabled state still reads as subtle; hover/active states unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)