### PR TITLE
feat(web): add post-registration verification panel

### DIFF
--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -96,6 +96,17 @@
         <button type="submit" class="login-btn login-btn-primary" id="btn-register">Create account</button>
       </form>
 
+      <!-- ── Post-registration verification panel ─────────────────────── -->
+      <div class="login-panel verify-overlay" id="verify-panel">
+        <h2 class="verify-heading">Check your email</h2>
+        <p class="verify-body">We sent a verification link to <strong id="verify-email"></strong>. Click the link in that email to activate your account, then sign in.</p>
+        <p class="verify-countdown">This link expires in <span id="verify-countdown">60:00</span>.</p>
+        <button type="button" class="login-btn" id="btn-resend-signup" disabled>Resend verification email</button>
+        <p class="verify-back-note">
+          <button type="button" class="verify-link-btn" id="btn-verify-back">Back to sign in</button>
+        </p>
+      </div>
+
       <p class="login-error" id="login-error" style="display:none"></p>
       <p class="login-success" id="login-success" style="display:none"></p>
       <p class="login-contact-note" id="login-contact-note"></p>

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -74,7 +74,6 @@
     var btn = $('btn-resend-signup');
     var remaining = 60;
     btn.disabled = true;
-    var label = btn.textContent;
     btn.textContent = 'Resend verification email (' + remaining + 's)';
     if (resendCooldownTimer) clearInterval(resendCooldownTimer);
     resendCooldownTimer = setInterval(function () {
@@ -87,7 +86,6 @@
       } else {
         btn.textContent = 'Resend verification email (' + remaining + 's)';
       }
-      void label; // no-op, keep original label capture for clarity
     }, 1000);
   }
 
@@ -124,9 +122,6 @@
     startResendCooldown();
   }
 
-  // Expose for the resend click handler + external callers.
-  window.__showVerifyPanel = showVerifyPanel;
-
   $('btn-resend-signup').addEventListener('click', function () {
     var email = $('verify-email').textContent.trim();
     if (!email) return;
@@ -136,6 +131,7 @@
     window.auth.init().then(function () {
       return window.auth.getClient().auth.resend({ type: 'signup', email: email });
     }).then(function () {
+      setSuccess('Verification email sent — check your inbox.');
       startResendCooldown();
     }).catch(function () {
       // Re-enable immediately so the user can retry.

--- a/apps/web/public/login.js
+++ b/apps/web/public/login.js
@@ -38,10 +38,114 @@
         panels[key].classList.toggle('active', key === target);
       });
       $('forgot-panel').classList.remove('active');
+      hideVerifyPanel();
       setError(null);
       setSuccess(null);
       $('btn-resend-verification').style.display = 'none';
     });
+  });
+
+  /* ── Post-registration verify panel ───────────────────────────────── */
+  // Shows a "check your email" panel after successful registration with:
+  //   - a 60-minute countdown (matches the Supabase signup-link expiry),
+  //   - a resend button with a 60-second cooldown calling supabase.auth.resend().
+  // hideVerifyPanel() always clears both timers to avoid interval leaks.
+  var verifyCountdownTimer = null;
+  var resendCooldownTimer = null;
+
+  function clearVerifyTimers() {
+    if (verifyCountdownTimer) { clearInterval(verifyCountdownTimer); verifyCountdownTimer = null; }
+    if (resendCooldownTimer)  { clearInterval(resendCooldownTimer);  resendCooldownTimer = null; }
+  }
+
+  function hideVerifyPanel() {
+    clearVerifyTimers();
+    $('verify-panel').classList.remove('active');
+  }
+
+  function formatMMSS(seconds) {
+    if (seconds < 0) seconds = 0;
+    var mm = Math.floor(seconds / 60);
+    var ss = seconds % 60;
+    return (mm < 10 ? '0' : '') + mm + ':' + (ss < 10 ? '0' : '') + ss;
+  }
+
+  function startResendCooldown() {
+    var btn = $('btn-resend-signup');
+    var remaining = 60;
+    btn.disabled = true;
+    var label = btn.textContent;
+    btn.textContent = 'Resend verification email (' + remaining + 's)';
+    if (resendCooldownTimer) clearInterval(resendCooldownTimer);
+    resendCooldownTimer = setInterval(function () {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(resendCooldownTimer);
+        resendCooldownTimer = null;
+        btn.disabled = false;
+        btn.textContent = 'Resend verification email';
+      } else {
+        btn.textContent = 'Resend verification email (' + remaining + 's)';
+      }
+      void label; // no-op, keep original label capture for clarity
+    }, 1000);
+  }
+
+  function showVerifyPanel(email) {
+    clearVerifyTimers();
+
+    // Hide other panels and tab selection.
+    $('login-panel').classList.remove('active');
+    $('register-panel').classList.remove('active');
+    $('forgot-panel').classList.remove('active');
+    tabs.forEach(function (t) {
+      t.classList.remove('active');
+      t.setAttribute('aria-selected', 'false');
+    });
+    setError(null);
+    setSuccess(null);
+
+    $('verify-email').textContent = email;
+    $('verify-panel').classList.add('active');
+
+    // 60-minute countdown (in seconds).
+    var secondsLeft = 60 * 60;
+    $('verify-countdown').textContent = formatMMSS(secondsLeft);
+    verifyCountdownTimer = setInterval(function () {
+      secondsLeft -= 1;
+      $('verify-countdown').textContent = formatMMSS(secondsLeft);
+      if (secondsLeft <= 0) {
+        clearInterval(verifyCountdownTimer);
+        verifyCountdownTimer = null;
+      }
+    }, 1000);
+
+    // Resend button: 60-second cooldown; calls supabase.auth.resend({type:'signup'}).
+    startResendCooldown();
+  }
+
+  // Expose for the resend click handler + external callers.
+  window.__showVerifyPanel = showVerifyPanel;
+
+  $('btn-resend-signup').addEventListener('click', function () {
+    var email = $('verify-email').textContent.trim();
+    if (!email) return;
+    var btn = $('btn-resend-signup');
+    if (btn.disabled) return;
+    btn.disabled = true;
+    window.auth.init().then(function () {
+      return window.auth.getClient().auth.resend({ type: 'signup', email: email });
+    }).then(function () {
+      startResendCooldown();
+    }).catch(function () {
+      // Re-enable immediately so the user can retry.
+      btn.disabled = false;
+    });
+  });
+
+  $('btn-verify-back').addEventListener('click', function () {
+    hideVerifyPanel();
+    document.querySelector('.login-tab[data-tab="login"]').click();
   });
 
   /* ── Contact email from config ─────────────────────────────────────── */
@@ -136,10 +240,9 @@
           setError('Too many attempts — please wait a few minutes and try again.');
         } else if (res.status >= 200 && res.status < 300 && res.body.ok) {
           resetRegisterForm();
-          setSuccess('Account created. Check your email for a verification link, then sign in.');
-          // Switch to sign-in tab and pre-fill email
-          document.querySelector('.login-tab[data-tab="login"]').click();
+          // Pre-fill the sign-in form so returning from the verify panel is frictionless.
           $('login-email').value = email;
+          showVerifyPanel(email);
         } else if (res.body && res.body.error === 'underage') {
           setError('You must be at least 13 to register.');
         } else {
@@ -227,6 +330,7 @@
   /* ── Forgot password ───────────────────────────────────────────────── */
   $('btn-show-forgot').addEventListener('click', function () {
     setError(null); setSuccess(null);
+    hideVerifyPanel();
     $('login-panel').classList.remove('active');
     $('register-panel').classList.remove('active');
     $('forgot-panel').classList.add('active');


### PR DESCRIPTION
## Summary
- After a successful registration, swap to a dedicated \`#verify-panel\` instead of snapping back to the sign-in tab.
- Panel shows the target email, a 60-minute countdown (matches Supabase's signup-link expiry), and a resend-verification button with a 60-second cooldown that calls \`supabase.auth.resend({ type: 'signup' })\`.
- All intervals are cleared on panel dismissal (tab switch, forgot-password click, explicit back button) so there are no interval leaks.

Reuses the \`.verify-*\` CSS classes already present in \`login.css\`.

Note: Targeted \`main\` because \`auth.js\`/supabase-js auth flow this depends on only lives on \`main\` (post #151).

Closes #152

## Test plan
- [ ] Submit the register form with a fresh email → verify panel shows with the email, countdown starts at 60:00 and ticks down
- [ ] Resend button is disabled for 60 s after panel opens, re-enables, then re-disables when clicked
- [ ] Click \"Back to sign in\" → verify panel hides, sign-in tab active, email pre-filled
- [ ] Switching tabs mid-countdown clears the interval (no console errors, no runaway timers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)