### PR TITLE
feat(web): export transcripts as email, PDF, or Excel (#169)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,25 @@ Get conversation transcript.  Prefers in-memory session; falls back to DB.
 
 ---
 
+### POST /api/transcript/:sessionId/email
+
+Email a copy of the session transcript to the authenticated user's registered address via Resend.  Auth-gated; the session must belong to the caller.  Rate-limited to 3 requests per 15 minutes per IP.
+
+**Response**: `application/json`
+
+```json
+{ "ok": true }
+```
+
+Error responses:
+- `400 { "ok": false, "error": "invalid_session_id" | "empty_transcript" | "no_user_email" }`
+- `404 { "ok": false, "error": "not_found" }` — session missing or not owned by caller
+- `429 { "ok": false, "error": "too_many_requests" }`
+- `500 { "ok": false, "error": "failed" }` — Resend error
+- `503 { "ok": false, "error": "email_not_configured" }` — `RESEND_API_KEY` is not set
+
+---
+
 ### POST /api/feedback
 
 Submit end-of-session feedback.  Saves one row to `session_feedback`.  No email is sent on submission — feedback is included in the transcript email sent when the session ends.
@@ -480,6 +499,7 @@ These apply to every Claude Code session in this repo.
 | `apps/api/src/routes/chat.ts` | `POST /api/chat` — streaming chat with file upload |
 | `apps/api/src/routes/sessions.ts` | `GET/DELETE /api/sessions/:id` |
 | `apps/api/src/routes/transcript.ts` | `GET /api/transcript/:id` |
+| `apps/api/src/routes/transcript-email.ts` | `POST /api/transcript/:id/email` — rate-limited, auth-gated, ownership-checked. Sends the transcript to the caller's registered email via `sendUserTranscript`. |
 | `apps/api/src/routes/feedback.ts` | `POST /api/feedback` — saves one `session_feedback` row (requires auth + ownership) |
 | `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — rate-limited proxies for `POST /register`, `/login`, `/forgot-password`. All other auth operations are client-side via supabase-js. Registered only if `SUPABASE_ANON_KEY` is set. |
 | `apps/api/src/middleware/require-auth.ts` | `createRequireAuth(db)` — verifies `Authorization: Bearer <token>` via `db.auth.getUser(token)` and sets `req.userId`, `req.userEmail`, `req.userName`, `req.isAdmin` (from `app_metadata.is_admin` JWT claim). |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import { errorHandler } from "./middleware/errors.js";
 import { createChatRouter } from "./routes/chat.js";
 import { createSessionsRouter } from "./routes/sessions.js";
 import { createTranscriptRouter } from "./routes/transcript.js";
+import { createTranscriptEmailRouter } from "./routes/transcript-email.js";
 import { createFeedbackRouter } from "./routes/feedback.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createAuthRouter } from "./routes/auth.js";
@@ -123,6 +124,7 @@ app.use(express.static(path.join(__dirname, "../../web/public")));
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db, promptMap, defaultPromptName, config.model, config.extendedThinking));
 app.use("/api/sessions", createSessionsRouter(db, emailConfig, config.model, defaultPromptName, config.extendedThinking));
+app.use("/api/transcript", createTranscriptEmailRouter(db, { apiKey: emailConfig.apiKey, from: emailConfig.from }));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));

--- a/apps/api/src/routes/transcript-email.ts
+++ b/apps/api/src/routes/transcript-email.ts
@@ -1,0 +1,107 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import {
+  getMessagesBySession,
+  getSession as getDbSession,
+} from "@ai-tutor/db";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { sendUserTranscript } from "@ai-tutor/email";
+import type { UserTranscriptPayload } from "@ai-tutor/email";
+import { UUID_RE } from "../lib/validation.js";
+import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
+
+export interface TranscriptEmailRouteConfig {
+  apiKey: string | undefined;
+  from: string;
+}
+
+/**
+ * POST /api/transcript/:sessionId/email
+ *
+ * Sends a copy of the session transcript to the authenticated user's
+ * registered email via Resend. Auth-gated; the session must belong to the
+ * caller. Rate-limited to 3 requests per 15 minutes per IP.
+ *
+ * Response:
+ *   { ok: true }                                on success
+ *   { ok: false, error: "email_not_configured" } 503 — Resend not set up
+ *   { ok: false, error: "failed" }              500 — Resend error
+ */
+export function createTranscriptEmailRouter(
+  db: SupabaseClient,
+  emailConfig: TranscriptEmailRouteConfig,
+): Router {
+  const router = Router();
+  const requireAuth = createRequireAuth(db);
+
+  const rateLimitHandler = (
+    _req: unknown,
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+  ) => {
+    res.status(429).json({ ok: false, error: "too_many_requests" });
+  };
+
+  const emailLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: rateLimitHandler,
+  });
+
+  router.post("/:sessionId/email", emailLimiter, requireAuth, async (req, res, next) => {
+    try {
+      const { sessionId } = req.params;
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ ok: false, error: "invalid_session_id" });
+        return;
+      }
+
+      const authedReq = req as AuthedRequest;
+      const row = await getDbSession(db, sessionId);
+      if (!row || row.user_id !== authedReq.userId) {
+        res.status(404).json({ ok: false, error: "not_found" });
+        return;
+      }
+
+      if (!emailConfig.apiKey) {
+        res.status(503).json({ ok: false, error: "email_not_configured" });
+        return;
+      }
+      if (!authedReq.userEmail) {
+        res.status(400).json({ ok: false, error: "no_user_email" });
+        return;
+      }
+
+      const messages = await getMessagesBySession(db, sessionId);
+      if (messages.length === 0) {
+        res.status(400).json({ ok: false, error: "empty_transcript" });
+        return;
+      }
+
+      const transcript = messages.map((m) => ({
+        role: (m.role === "user" ? "Student" : "Tutor") as "Student" | "Tutor",
+        text: m.content,
+      }));
+      const startedAt = new Date(row.started_at);
+      const endedAt = row.ended_at ? new Date(row.ended_at) : new Date(row.last_activity_at);
+      const durationMs = Math.max(0, endedAt.getTime() - startedAt.getTime());
+
+      const payload: UserTranscriptPayload = { transcript, startedAt, durationMs };
+
+      try {
+        await sendUserTranscript(authedReq.userEmail, emailConfig, payload);
+      } catch (err) {
+        console.error(`[transcript-email] Send failed for ${sessionId}:`, err);
+        res.status(500).json({ ok: false, error: "failed" });
+        return;
+      }
+
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/web/public/history.css
+++ b/apps/web/public/history.css
@@ -204,6 +204,60 @@ html, body {
   background: #323745;
 }
 
+.transcript-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex: 1;
+  justify-content: flex-end;
+  margin-right: 0.5rem;
+}
+
+.transcript-action-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.transcript-action-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.transcript-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.transcript-action-status {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-align: center;
+  padding: 0.4rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.transcript-action-status.success {
+  color: var(--success);
+}
+
+.transcript-action-status.error {
+  color: var(--danger);
+}
+
+@media (max-width: 480px) {
+  .transcript-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
 .transcript-messages {
   flex: 1;
   overflow-y: auto;

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -29,8 +29,14 @@
         <div class="transcript-panel">
           <div class="transcript-panel-header">
             <h2 class="transcript-panel-title" id="transcript-title">Transcript</h2>
+            <div class="transcript-actions" id="transcript-actions" style="display:none">
+              <button type="button" class="transcript-action-btn" id="transcript-email-btn">Email me this</button>
+              <button type="button" class="transcript-action-btn" id="transcript-pdf-btn">Download PDF</button>
+              <button type="button" class="transcript-action-btn" id="transcript-xlsx-btn">Download Excel</button>
+            </div>
             <button type="button" class="transcript-close-btn" id="transcript-close">Close</button>
           </div>
+          <div class="transcript-action-status" id="transcript-action-status" style="display:none"></div>
           <div class="transcript-messages" id="transcript-messages"></div>
         </div>
       </div>
@@ -38,6 +44,8 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="/history.js"></script>
 </body>
 </html>

--- a/apps/web/public/history.js
+++ b/apps/web/public/history.js
@@ -15,6 +15,16 @@
   var messagesEl = document.getElementById("transcript-messages");
   var titleEl = document.getElementById("transcript-title");
   var closeBtn = document.getElementById("transcript-close");
+  var actionsEl = document.getElementById("transcript-actions");
+  var statusEl = document.getElementById("transcript-action-status");
+  var emailBtn = document.getElementById("transcript-email-btn");
+  var pdfBtn = document.getElementById("transcript-pdf-btn");
+  var xlsxBtn = document.getElementById("transcript-xlsx-btn");
+
+  // ── Module state ──────────────────────────────────────────────────────────
+  var currentSessionId = null;
+  var currentTranscriptData = null;
+  var currentStartedAt = null;
 
   // ── Formatting helpers ────────────────────────────────────────────────────
   function formatPromptName(name) {
@@ -142,6 +152,11 @@
     titleEl.textContent = "Transcript — " + formatDate(startedAt);
     messagesEl.innerHTML = "<div class=\"history-loading\">Loading transcript...</div>";
     overlayEl.style.display = "";
+    currentSessionId = sessionId;
+    currentTranscriptData = null;
+    currentStartedAt = startedAt;
+    actionsEl.style.display = "none";
+    clearStatus();
 
     window.auth.authedFetch("/api/transcript/" + sessionId)
       .then(function (res) {
@@ -157,6 +172,9 @@
           messagesEl.innerHTML = "<div class=\"history-empty\">No messages in this session.</div>";
           return;
         }
+
+        currentTranscriptData = data.transcript;
+        actionsEl.style.display = "";
 
         data.transcript.forEach(function (msg) {
           var div = document.createElement("div");
@@ -187,7 +205,157 @@
   function closeTranscript() {
     overlayEl.style.display = "none";
     messagesEl.innerHTML = "";
+    currentSessionId = null;
+    currentTranscriptData = null;
+    currentStartedAt = null;
+    actionsEl.style.display = "none";
+    clearStatus();
   }
+
+  // ── Export actions ────────────────────────────────────────────────────────
+  function setActionsDisabled(disabled) {
+    emailBtn.disabled = disabled;
+    pdfBtn.disabled = disabled;
+    xlsxBtn.disabled = disabled;
+  }
+
+  function showStatus(text, kind) {
+    statusEl.textContent = text;
+    statusEl.className = "transcript-action-status" + (kind ? " " + kind : "");
+    statusEl.style.display = "";
+  }
+
+  function clearStatus() {
+    statusEl.textContent = "";
+    statusEl.style.display = "none";
+    statusEl.className = "transcript-action-status";
+  }
+
+  function filenameBase() {
+    var prefix = currentSessionId ? currentSessionId.split("-")[0] : "session";
+    var d = new Date();
+    var pad = function (n) { return n < 10 ? "0" + n : String(n); };
+    var stamp = d.getFullYear() + pad(d.getMonth() + 1) + pad(d.getDate());
+    return "transcript-" + prefix + "-" + stamp;
+  }
+
+  function emailTranscript() {
+    if (!currentSessionId) return;
+    setActionsDisabled(true);
+    showStatus("Sending…");
+
+    window.auth.authedFetch("/api/transcript/" + currentSessionId + "/email", {
+      method: "POST",
+    })
+      .then(function (res) {
+        return res.json().catch(function () { return { ok: false }; }).then(function (body) {
+          return { status: res.status, body: body };
+        });
+      })
+      .then(function (r) {
+        if (r.status === 200 && r.body && r.body.ok) {
+          showStatus("Sent!", "success");
+          return;
+        }
+        if (r.status === 429) {
+          showStatus("Too many requests. Try again in a few minutes.", "error");
+          return;
+        }
+        if (r.status === 503) {
+          showStatus("Email is not configured on this server.", "error");
+          return;
+        }
+        showStatus("Could not send. Try again later.", "error");
+      })
+      .catch(function () {
+        showStatus("Could not send. Try again later.", "error");
+      })
+      .then(function () {
+        setActionsDisabled(false);
+      });
+  }
+
+  function downloadPdf() {
+    if (!currentTranscriptData || !window.jspdf) {
+      showStatus("PDF library not loaded.", "error");
+      return;
+    }
+    setActionsDisabled(true);
+    try {
+      var doc = new window.jspdf.jsPDF({ unit: "pt", format: "letter" });
+      var margin = 48;
+      var pageHeight = doc.internal.pageSize.getHeight();
+      var pageWidth = doc.internal.pageSize.getWidth();
+      var maxWidth = pageWidth - margin * 2;
+      var y = margin;
+
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(14);
+      doc.text("Tutor session transcript", margin, y);
+      y += 20;
+      if (currentStartedAt) {
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(10);
+        doc.text(formatDate(currentStartedAt), margin, y);
+        y += 16;
+      }
+      y += 6;
+
+      currentTranscriptData.forEach(function (msg) {
+        doc.setFont("helvetica", "bold");
+        doc.setFontSize(11);
+        if (y > pageHeight - margin) { doc.addPage(); y = margin; }
+        doc.text(msg.role, margin, y);
+        y += 14;
+
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(10);
+        var lines = doc.splitTextToSize(msg.text || "", maxWidth);
+        for (var i = 0; i < lines.length; i++) {
+          if (y > pageHeight - margin) { doc.addPage(); y = margin; }
+          doc.text(lines[i], margin, y);
+          y += 13;
+        }
+        y += 8;
+      });
+
+      doc.save(filenameBase() + ".pdf");
+      showStatus("PDF downloaded.", "success");
+    } catch (err) {
+      showStatus("PDF generation failed.", "error");
+      console.error("[history] PDF error:", err);
+    } finally {
+      setActionsDisabled(false);
+    }
+  }
+
+  function downloadXlsx() {
+    if (!currentTranscriptData || !window.XLSX) {
+      showStatus("Excel library not loaded.", "error");
+      return;
+    }
+    setActionsDisabled(true);
+    try {
+      var rows = [["Role", "Message"]];
+      currentTranscriptData.forEach(function (msg) {
+        rows.push([msg.role, msg.text || ""]);
+      });
+      var ws = window.XLSX.utils.aoa_to_sheet(rows);
+      var wb = window.XLSX.utils.book_new();
+      window.XLSX.utils.book_append_sheet(wb, ws, "Transcript");
+      window.XLSX.writeFile(wb, filenameBase() + ".xlsx");
+      showStatus("Excel downloaded.", "success");
+    } catch (err) {
+      showStatus("Excel generation failed.", "error");
+      console.error("[history] XLSX error:", err);
+    } finally {
+      setActionsDisabled(false);
+    }
+  }
+
+  emailBtn.addEventListener("click", emailTranscript);
+  pdfBtn.addEventListener("click", downloadPdf);
+  xlsxBtn.addEventListener("click", downloadXlsx);
 
   closeBtn.addEventListener("click", closeTranscript);
 


### PR DESCRIPTION
## Summary
- New \`POST /api/transcript/:sessionId/email\` route — auth-gated, ownership-checked, rate-limited (3 req / 15 min / IP), delegates to existing \`sendUserTranscript\`
- Transcript history viewer gains three buttons: Email me this, Download PDF, Download Excel
- PDF and Excel are generated client-side via CDN libraries (jspdf 2.5.1, xlsx 0.18.5) — no new npm dependencies
- Email router mounted before the general transcript router so \`POST /:id/email\` is not shadowed
- Graceful errors when Resend is not configured (503) or rate limit hit (429)

Closes #169

## Test plan
- [ ] Open a session transcript from /history.html — three action buttons appear
- [ ] Click \"Email me this\" — status shows \"Sending…\" then \"Sent!\"; email arrives
- [ ] Click \"Email me this\" 4 times within 15 minutes — 4th shows rate-limit message
- [ ] Click \"Download PDF\" — file downloads with correct role labels and page breaks
- [ ] Click \"Download Excel\" — file opens in Numbers/Excel with header row
- [ ] With RESEND_API_KEY unset — email button shows \"Email is not configured on this server.\"
- [ ] Buttons disable while an action is in flight; re-enable on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)