### PR TITLE
chore(api): replace personal contact email fallback (#181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ Get non-secret runtime config.
   "model": "claude-sonnet-4-6",
   "extendedThinking": true,
   "inactivityMs": 600000,
-  "contactEmail": "wax.spirits8d@icloud.com",
+  "contactEmail": "",
   "availableModels": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"],
   "availablePrompts": ["tutor-prompt-v7", "tutor-prompt-v6"],
   "defaultPrompt": "tutor-prompt-v7",
@@ -409,7 +409,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
-| CONTACT_EMAIL | no | wax.spirits8d@icloud.com | api | Contact email returned by GET /api/config and shown on the login page |
+| CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
 | ALLOW_PROMPT_SELECTION | no | — (locked) | api | Set `"true"` to allow users to switch prompt versions via the header badge; omitting locks the picker (fail-closed). Surfaced as `promptSelectionEnabled` in `GET /api/config`. |
 | SUPABASE_ANON_KEY | **yes (API)** | — | db, api | Supabase anon/public key. Required for the `/api/auth/*` endpoints that back the login flow at `/login.html`. Still held server-side only — never exposed via `/api/config`. When unset, the auth router is not registered and the app will be inaccessible (the login page cannot authenticate). |
 

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -42,7 +42,7 @@ export function createConfigRouter(
       model: config.model,
       extendedThinking: config.extendedThinking,
       inactivityMs,
-      contactEmail: process.env.CONTACT_EMAIL ?? "wax.spirits8d@icloud.com",
+      contactEmail: process.env.CONTACT_EMAIL ?? "",
       availableModels: [...ALLOWED_MODELS],
       availablePrompts: [...promptMap.keys()],
       defaultPrompt: defaultPromptName,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `RESEND_API_KEY` | no | Resend dashboard → API Keys | **Yes** |
 | `PARENT_EMAIL` | no | Your email address (where transcripts will be sent) | No |
 | `EMAIL_FROM` | no | Your verified sending address (e.g., `tutor@yourdomain.com`) | No |
-| `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config | No |
+| `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config. Defaults to `""` — required before going public. The contact line is hidden when absent. | No |
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `wax.spirits8d@icloud.com` fallback in `/api/config` with an empty string
- The login page already guards on `if (email)` and hides the contact note when empty
- Updates CLAUDE.md and docs/deployment.md to document the new default

Closes #181

## Test plan
- [x] `npm run build` passes
- [ ] With `CONTACT_EMAIL` unset, `/api/config` returns `"contactEmail": ""` and login page omits the contact line
- [ ] With `CONTACT_EMAIL` set, login page shows the configured address

🤖 Generated with [Claude Code](https://claude.com/claude-code)