### PR TITLE
style(web): redesign color system for warm, student-friendly palette (#173)

### DIFF
--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- Shifts core CSS custom properties in styles.css and login.css to a warm periwinkle + amber palette
- Updates --bg, --surface, --accent, --tutor-accent, --tutor-bg, --accent-light
- Fixes two hardcoded hex values in styles.css (btn-primary gradient end stop, empty-icon gradient)
- gallery.css inherits via var() — no edits required

Closes #173

## Test plan
- [ ] Load / and verify chat UI uses warm periwinkle accent and amber tutor bubble accent
- [ ] Load /login.html and verify matching background and accent colors
- [ ] Verify /history.html and /settings.html still render (they use their own token copies — out of scope)
- [ ] Spot-check empty state icon gradient renders without the old cyan

🤖 Generated with [Claude Code](https://claude.com/claude-code)