### PR TITLE
style(web): improve contrast on muted text and controls (#175)

### DIFF
--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -10,7 +10,7 @@
   --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
-  --text-muted: #9aa0ad;
+  --text-muted: #b4b9c8;
   --accent: #6d8ef5;
   --accent-hover: #8ba8f8;
   --danger: #ef4444;
@@ -120,6 +120,11 @@ html, body {
 
 .login-input:focus {
   border-color: var(--accent);
+}
+
+.login-input::placeholder {
+  opacity: 1;
+  color: var(--text-muted);
 }
 
 .login-hint {

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -7,7 +7,7 @@
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
-      --text-muted:    #6b7194;
+      --text-muted:    #9499c0;
       --accent:        #6d8ef5;
       /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
       --accent-light:  #1e2a52;
@@ -135,7 +135,7 @@
       font-family: var(--font-sans);
       font-size: 0.71rem;
       font-weight: 500;
-      color: var(--text-muted);
+      color: var(--text);
       background: var(--surface-alt);
       padding: 3px 10px;
       border-radius: var(--radius-pill);
@@ -717,6 +717,7 @@
     /* ── Inline end-session button ─────────────────────────────────────────── */
     #btn-end-session-inline {
       height: 40px;
+      min-height: 44px;
       color: var(--danger);
       border-color: var(--border-bright);
       background: transparent;
@@ -809,10 +810,13 @@
       padding: 8px;
       width: 40px;
       height: 40px;
+      min-width: 44px;
+      min-height: 44px;
       font-size: 1rem;
     }
 
     #btn-attach, #btn-send { height: 40px; }
+    #btn-attach { min-width: 44px; min-height: 44px; }
     #btn-send { padding: 0 16px; }
 
     /* ── Modal backdrop ────────────────────────────────────────────────────── */

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- Raises --text-muted to #9499c0 (styles.css) and #b4b9c8 (login.css), clearing 4.5:1 against #173's new --bg
- Promotes .model-badge / .prompt-badge / .thinking-badge base text to --text for stronger header legibility
- Raises touch targets to 44×44 on #btn-attach and .btn-icon; adds min-height 44px on #btn-end-session-inline
- Adds explicit .login-input::placeholder rule so UA-default faint placeholders don't dim below --text-muted

Closes #175

Stacked on top of #185 (feature/173-warm-color-system). Merge after #185.

## Test plan
- [ ] Run a dev session and verify header badges read as --text (not dim)
- [ ] Tap targets on iPhone: attach, send, icon buttons, end-session each ≥ 44px
- [ ] Login form placeholders visible at the raised muted value

🤖 Generated with [Claude Code](https://claude.com/claude-code)