### PR TITLE
style(web): make empty-state mode pills clearly actionable (#174)

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -97,9 +97,9 @@
           <p class="empty-heading">What are you stuck on?</p>
           <p class="empty-sub">Drop a question or upload a photo of your homework.</p>
           <div class="empty-chips">
-            <button class="empty-chip" data-fill="Can you help me understand this problem?">Help me understand</button>
-            <button class="empty-chip" data-fill="Check my work: ">Check my work</button>
-            <button class="empty-chip" data-fill="Explain ">Explain a concept</button>
+            <button class="empty-chip" data-fill="Can you help me understand this problem?">🧭 Help me understand</button>
+            <button class="empty-chip" data-fill="Check my work: ">✅ Check my work</button>
+            <button class="empty-chip" data-fill="Explain ">💡 Explain a concept</button>
           </div>
         </div>
         <div id="messages"></div>
@@ -141,7 +141,7 @@
         <button class="btn btn-icon" id="btn-attach" title="Attach files (images or PDF)">📎</button>
         <input type="file" id="file-input" multiple
                accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
-        <textarea id="msg-input" placeholder="What are you stuck on?" rows="1"></textarea>
+        <textarea id="msg-input" placeholder="Describe what you're working on, or drag in a photo…" rows="1"></textarea>
         <button class="btn btn-primary" id="btn-send">Send</button>
         <button class="btn" id="btn-end-session-inline" disabled title="End this session">End session</button>
       </div>

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1015,14 +1015,15 @@
       font-family: var(--font-sans);
       font-size: 0.82rem;
       font-weight: 500;
-      padding: 6px 14px;
+      padding: 8px 16px;
       cursor: pointer;
-      transition: background 0.15s, color 0.15s, border-color 0.15s;
+      transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s;
     }
     .empty-chip:hover {
       background: var(--accent-light);
       border-color: var(--accent);
       color: var(--text);
+      box-shadow: 0 0 10px var(--accent-glow);
     }
     @keyframes float {
       0%, 100% { transform: translateY(0); }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- Emoji-prefix the three empty-state chips so they read as clickable actions
- Update the msg-input placeholder to invite both text and photo input
- Bump .empty-chip padding and add an accent-glow hover shadow

Closes #174

Stacked on top of #185 (feature/173-warm-color-system). Merge after #185.

## Test plan
- [ ] Load / with empty chat and confirm three chips have emoji prefixes
- [ ] Hover a chip — glow + background shift are visible
- [ ] Click each chip — msg-input is populated with the unchanged data-fill string

🤖 Generated with [Claude Code](https://claude.com/claude-code)