### PR TITLE
style(web): unify input bar button treatments (#176)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -540,11 +540,23 @@
   }
 
   function setInputDisabled(disabled) {
-    btnSend.disabled          = disabled;
     msgInput.disabled         = disabled;
     btnAttach.disabled        = disabled;
+    updateSendState();
     // When re-enabling after streaming, respect the "has messages" gate
     btnEndSessionInline.disabled = disabled || msgList.length === 0;
+  }
+
+  /**
+   * Single source of truth for Send button state.
+   *
+   * Disables Send when the input is empty or we're mid-stream or session is
+   * ended / otherwise locked. All callers that previously wrote directly to
+   * btnSend.disabled should go through this instead.
+   */
+  function updateSendState() {
+    const empty = !msgInput.value.trim() && attachments.length === 0;
+    btnSend.disabled = empty || isStreaming || sessionEnded || msgInput.disabled;
   }
 
   // ── Session DELETE helpers ────────────────────────────────────────────────
@@ -675,8 +687,8 @@
     msgInput.value = '';
     msgInput.placeholder = 'What are you stuck on?';
     msgInput.disabled = false;
-    btnSend.disabled = false;
     btnAttach.disabled = false;
+    updateSendState();
     updateHeaderButtons();
     resizeInput();
   }
@@ -791,9 +803,9 @@
 
   function lockSession(message) {
     msgInput.disabled = true;
-    btnSend.disabled  = true;
     btnAttach.disabled = true;
     btnEndSessionInline.disabled = true;
+    updateSendState();
     btnEndSessionInline.classList.remove('end-ready');
     msgInput.placeholder = 'Session ended.';
     showToast(message, 5000);
@@ -927,9 +939,13 @@
 
   function renderStrip() {
     fileStrip.innerHTML = '';
-    if (!attachments.length) { fileStrip.classList.remove('active'); return; }
-    fileStrip.classList.add('active');
-    for (const a of attachments) fileStrip.appendChild(a.chipEl);
+    if (!attachments.length) {
+      fileStrip.classList.remove('active');
+    } else {
+      fileStrip.classList.add('active');
+      for (const a of attachments) fileStrip.appendChild(a.chipEl);
+    }
+    updateSendState();
   }
 
   // ── Drag and drop ─────────────────────────────────────────────────────────
@@ -978,7 +994,8 @@
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
   });
 
-  msgInput.addEventListener('input', resizeInput);
+  msgInput.addEventListener('input', () => { resizeInput(); updateSendState(); });
+  updateSendState();
 
   btnAttach.addEventListener('click', () => {
     if (!sessionEnded) fileInput.click();

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -10,7 +10,7 @@
   --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
-  --text-muted: #9aa0ad;
+  --text-muted: #b4b9c8;
   --accent: #6d8ef5;
   --accent-hover: #8ba8f8;
   --danger: #ef4444;
@@ -120,6 +120,11 @@ html, body {
 
 .login-input:focus {
   border-color: var(--accent);
+}
+
+.login-input::placeholder {
+  opacity: 1;
+  color: var(--text-muted);
 }
 
 .login-hint {

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -7,7 +7,7 @@
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
-      --text-muted:    #6b7194;
+      --text-muted:    #9499c0;
       --accent:        #6d8ef5;
       /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
       --accent-light:  #1e2a52;
@@ -135,7 +135,7 @@
       font-family: var(--font-sans);
       font-size: 0.71rem;
       font-weight: 500;
-      color: var(--text-muted);
+      color: var(--text);
       background: var(--surface-alt);
       padding: 3px 10px;
       border-radius: var(--radius-pill);
@@ -717,6 +717,7 @@
     /* ── Inline end-session button ─────────────────────────────────────────── */
     #btn-end-session-inline {
       height: 40px;
+      min-height: 44px;
       color: var(--danger);
       border-color: var(--border-bright);
       background: transparent;
@@ -809,10 +810,13 @@
       padding: 8px;
       width: 40px;
       height: 40px;
+      min-width: 44px;
+      min-height: 44px;
       font-size: 1rem;
     }
 
     #btn-attach, #btn-send { height: 40px; }
+    #btn-attach { min-width: 44px; min-height: 44px; }
     #btn-send { padding: 0 16px; }
 
     /* ── Modal backdrop ────────────────────────────────────────────────────── */

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -718,17 +718,15 @@
     #btn-end-session-inline {
       height: 40px;
       min-height: 44px;
-      color: var(--danger);
+      color: var(--text-muted);
       border-color: var(--border-bright);
       background: transparent;
-      opacity: 0.6;
       flex-shrink: 0;
     }
     #btn-end-session-inline:not(:disabled):hover {
       background: rgba(248, 113, 113, 0.1);
       border-color: var(--danger);
       color: var(--danger);
-      opacity: 1;
     }
     #btn-end-session-inline:disabled {
       opacity: 0.25;
@@ -816,7 +814,11 @@
     }
 
     #btn-attach, #btn-send { height: 40px; }
-    #btn-attach { min-width: 44px; min-height: 44px; }
+    #btn-attach {
+      min-width: 44px;
+      min-height: 44px;
+      border: 1px solid var(--border);
+    }
     #btn-send { padding: 0 16px; }
 
     /* ── Modal backdrop ────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Restyles #btn-end-session-inline as a ghost pill (base --text-muted, hover --danger) so it sits as a peer of #btn-attach and Send
- Adds a subtle border to #btn-attach so it matches the pill family; 44×44 min-dimensions preserved from #175
- Introduces updateSendState() as the single source of truth for Send enablement
  - Disables when input + attachments are both empty, while streaming, or when session is locked
  - Wired to textarea input, attachment add/remove via renderStrip, setInputDisabled, resetSessionState, lockSession
  - Full-file audit: every prior direct btnSend.disabled assignment now routes through this helper

Closes #176

Stacked on top of #186 (feature/175-contrast-fix). Merge after #186.

## Test plan
- [ ] Empty input → Send is disabled
- [ ] Type text → Send enables
- [ ] Attach a file with empty input → Send enables
- [ ] Remove the only attachment with empty input → Send disables
- [ ] Press Enter → streams; Send stays disabled during stream; re-enables after
- [ ] End session → Send and End Session both disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)