### PR TITLE
feat(web): show logged-in user identity in header (#182)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -176,12 +176,20 @@
         promptBadge.classList.add('admin-visible');
         thinkingBadge.classList.add('admin-visible');
       }
-      const displayName = userMeta.name || user.email || '';
-      if (displayName) {
-        userDisplayName.textContent = displayName;
+
+      // Always show the account trigger for authenticated users. Fall back
+      // down the chain: explicit name → email local-part → "Account".
+      // Only the first word of the name appears in the trigger so the pill
+      // stays compact; the full email still shows in the dropdown info row.
+      if (user && (user.id || user.email)) {
+        const fullName = (userMeta.name || '').trim();
+        const emailPrefix = user.email ? String(user.email).split('@')[0] : '';
+        const displayName = fullName || emailPrefix || 'Account';
+        const firstName = displayName.split(/\s+/)[0] || 'Account';
+        userDisplayName.textContent = firstName;
         accountTrigger.style.display = '';
+        accountDropdownInfo.textContent = user.email || displayName;
       }
-      accountDropdownInfo.textContent = user.email || displayName;
     } catch {
       // Leave badges hidden on failure.
     }

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -178,11 +178,11 @@
       align-items: center;
       gap: 4px;
       background: none;
-      border: 1px solid var(--border);
+      border: 1px solid var(--border-bright);
       border-radius: var(--radius-md);
       padding: 4px 10px;
       cursor: pointer;
-      color: var(--text-muted);
+      color: var(--text);
       font-family: var(--font-sans);
       font-size: 0.75rem;
       transition: color 0.15s, border-color 0.15s;
@@ -200,7 +200,6 @@
       width: 16px;
       height: 16px;
       flex-shrink: 0;
-      opacity: 0.7;
     }
     .user-display-name {
       white-space: nowrap;

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- Promotes .account-trigger from muted to full-strength (border --border-bright, color --text) for a confident identity chip
- Removes opacity: 0.7 on the avatar icon
- fetchUserInfo always shows the account trigger for authenticated users
  - Fallback chain: name → email local-part → "Account"
  - Only the first word of the name appears in the trigger (compact on mobile)
  - Full email still appears in the dropdown info row

Closes #182

Stacked on top of #185 (feature/173-warm-color-system). Merge after #185.

## Test plan
- [ ] Log in as a user whose name is set → header shows first name only
- [ ] Log in as a user with no name but an email → header shows email local-part
- [ ] Edge case: user with only user.id → header shows "Account"
- [ ] Open dropdown → full email still shown in info row

🤖 Generated with [Claude Code](https://claude.com/claude-code)