### PR TITLE
chore(eval): switch evaluator model to haiku

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `PARENT_EMAIL` is absent, emails are silently skipped.
 
-The evaluation model (`claude-sonnet-4-6`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
+The evaluation model (`claude-haiku-4-5-20251001`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
 
 ---
 

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -49,7 +49,7 @@ export async function evaluateTranscript(
   transcript: Array<{ role: string; text: string }>,
   config?: { model?: string }
 ): Promise<EvaluationResult> {
-  const model = config?.model ?? "claude-sonnet-4-6";
+  const model = config?.model ?? "claude-haiku-4-5-20251001";
 
   const formattedTranscript = transcript
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)


### PR DESCRIPTION
## Summary
- Switch hardcoded default evaluator model from `claude-sonnet-4-6` to `claude-haiku-4-5-20251001` in `packages/core/src/evaluate-transcript.ts`
- Update corresponding note in CLAUDE.md

Closes #183

## Test plan
- [x] `npm run build` passes
- [ ] Backfill or new session evaluation runs successfully with haiku model

🤖 Generated with [Claude Code](https://claude.com/claude-code)