### PR TITLE
feat(web): replace placeholder logo with lightbulb-atom SVG mark

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -40,14 +40,17 @@
       <span class="header-logo">
         <svg class="logo-mark" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <defs>
-            <linearGradient id="logo-grad" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
-              <stop offset="0%" stop-color="#7c6af7"/>
-              <stop offset="100%" stop-color="#22d3ee"/>
+            <linearGradient id="logo-grad-hdr" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#6d8ef5"/>
+              <stop offset="100%" stop-color="#f59e0b"/>
             </linearGradient>
           </defs>
-          <line x1="4" y1="28" x2="16" y2="4" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
-          <line x1="28" y1="28" x2="16" y2="4" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
-          <line x1="9" y1="19" x2="23" y2="19" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
+          <g stroke="url(#logo-grad-hdr)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+            <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+            <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+            <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+          </g>
         </svg>
         <span class="logo-wordmark">
           <span class="logo-company">Axiom</span>
@@ -92,7 +95,20 @@
       <div id="chat-area">
         <div id="empty-state">
           <div class="empty-icon-wrap">
-            <div class="empty-icon">✦</div>
+            <svg class="empty-icon" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Axiom logo">
+              <defs>
+                <linearGradient id="logo-grad-es" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+                  <stop offset="0%" stop-color="#6d8ef5"/>
+                  <stop offset="100%" stop-color="#f59e0b"/>
+                </linearGradient>
+              </defs>
+              <g stroke="url(#logo-grad-es)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+                <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+                <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+                <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+              </g>
+            </svg>
           </div>
           <p class="empty-heading">What are you stuck on?</p>
           <p class="empty-sub">Drop a question or upload a photo of your homework.</p>

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -53,6 +53,42 @@ html, body {
   font-weight: 700;
 }
 
+.login-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.login-logo-mark {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.login-logo-text {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.1;
+  gap: 2px;
+}
+
+.login-logo-company {
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6d8ef5, #f59e0b);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.login-logo-product {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .login-subtitle {
   margin: 0 0 1.25rem 0;
   color: var(--text-muted);

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -13,7 +13,28 @@
 <body>
   <main class="login-shell">
     <div class="login-card">
-      <h1 class="login-title">Axiom AI Tutor</h1>
+      <h1 class="login-title">
+        <span class="login-logo">
+          <svg class="login-logo-mark" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="logo-grad-login" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+                <stop offset="0%" stop-color="#6d8ef5"/>
+                <stop offset="100%" stop-color="#f59e0b"/>
+              </linearGradient>
+            </defs>
+            <g stroke="url(#logo-grad-login)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+              <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+              <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+              <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+            </g>
+          </svg>
+          <span class="login-logo-text">
+            <span class="login-logo-company">Axiom</span>
+            <span class="login-logo-product">AI Tutor</span>
+          </span>
+        </span>
+      </h1>
       <p class="login-subtitle">Sign in or create an account</p>
 
       <div class="login-tabs" role="tablist">

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -983,14 +983,12 @@
       align-items: center;
       justify-content: center;
       animation: float 4s ease-in-out infinite;
+      box-shadow: 0 0 24px var(--accent-glow);
     }
     .empty-icon {
-      font-size: 2rem;
+      width: 48px;
+      height: 48px;
       opacity: 1;
-      background: linear-gradient(135deg, var(--accent), var(--tutor-accent));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
     }
     .empty-heading {
       font-family: var(--font-heading);


### PR DESCRIPTION
## Summary
- Replace the placeholder A-letterform SVG and sparkle emoji with a new lightbulb-atom inline SVG mark
- Applied at three locations: app header (28px), empty state (48px), and login card header
- Each SVG instance uses a unique gradient id (`logo-grad-hdr`, `logo-grad-es`, `logo-grad-login`) with periwinkle → amber stops (`#6d8ef5` → `#f59e0b`)
- `.empty-icon` CSS updated to drop the emoji gradient hack; `.empty-icon-wrap` gains a subtle accent glow
- Login card `<h1>` now wraps a `.login-logo` lockup with matching wordmark typography

Closes #177

## Test plan
- [ ] Header mark renders cleanly at 28px with periwinkle→amber gradient
- [ ] Empty state shows the 48px mark inside the circle with glow
- [ ] Login page shows the same mark beside the Axiom / AI TUTOR wordmark
- [ ] No duplicate gradient ids across SVG instances
- [ ] Mobile layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)