### PR TITLE
feat(web): improve empty state with Socratic tutoring expectations

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -95,12 +95,13 @@
             <div class="empty-icon">✦</div>
           </div>
           <p class="empty-heading">What are you stuck on?</p>
-          <p class="empty-sub">Drop a question or upload a photo of your homework.</p>
+          <p class="empty-sub">I'll help you work through it — not just give you the answer.</p>
           <div class="empty-chips">
             <button class="empty-chip" data-fill="Can you help me understand this problem?">🧭 Help me understand</button>
             <button class="empty-chip" data-fill="Check my work: ">✅ Check my work</button>
             <button class="empty-chip" data-fill="Explain ">💡 Explain a concept</button>
           </div>
+          <p class="empty-hint">Pick a mode, then describe what you're stuck on — or just start typing.</p>
         </div>
         <div id="messages"></div>
       </div>

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -385,6 +385,7 @@
       gap: 16px;
       color: var(--text-muted);
       text-align: center;
+      padding-bottom: 15vh;
     }
 
     /* ── Messages list ─────────────────────────────────────────────────────── */
@@ -1010,6 +1011,15 @@
       flex-wrap: wrap;
       gap: 8px;
       justify-content: center;
+      margin-top: 4px;
+    }
+    .empty-hint {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      max-width: 320px;
+      text-align: center;
+      line-height: 1.5;
+      opacity: 0.85;
       margin-top: 4px;
     }
     .empty-chip {


### PR DESCRIPTION
## Summary
- Update empty-state subtitle to set Socratic tutoring expectations
- Add an `.empty-hint` paragraph under the mode chips to guide students
- Shift the empty-state content cluster above dead center with `padding-bottom: 15vh`

Closes #180

## Test plan
- [ ] Empty state shows the new subtitle and hint copy
- [ ] Hint renders at ~0.8rem, muted, centered
- [ ] Content cluster sits above dead center

🤖 Generated with [Claude Code](https://claude.com/claude-code)