### PR TITLE
feat(web): align login page visual identity with main app brand

### DIFF
--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -7,14 +7,18 @@
 
 :root {
   --bg: #0e0f1a;
+  --surface: #181a2e;
   --card: #181a2e;
-  --border: #2a2e3a;
+  --border: #2e3247;
   --text: #e7e9ee;
   --text-muted: #b4b9c8;
   --accent: #6d8ef5;
   --accent-hover: #8ba8f8;
+  --accent-light: #1e2a52;
+  --tutor-accent: #f59e0b;
   --danger: #ef4444;
   --success: #22c55e;
+  --font-heading: 'Nunito', sans-serif;
 }
 
 * { box-sizing: border-box; }
@@ -35,13 +39,18 @@ html, body {
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
+  background: radial-gradient(ellipse 80% 60% at 50% 40%, #1a1f3a 0%, var(--bg) 100%);
 }
 
 .login-card {
   width: 100%;
   max-width: 420px;
   background: var(--card);
-  border: 1px solid var(--border);
+  border-top: 2px solid transparent;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+  border-image: linear-gradient(90deg, var(--accent), var(--tutor-accent)) 1;
   border-radius: 12px;
   padding: 1.75rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
@@ -73,9 +82,11 @@ html, body {
 }
 
 .login-logo-company {
-  font-size: 1.4rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, #6d8ef5, #f59e0b);
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  background: linear-gradient(135deg, var(--accent), var(--tutor-accent));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -143,7 +154,7 @@ html, body {
 }
 
 .login-input {
-  background: #11131b;
+  background: #0d0f1c;
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.6rem 0.75rem;
@@ -186,7 +197,7 @@ html, body {
 }
 
 .login-btn {
-  background: #2a2e3a;
+  background: #252845;
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -199,7 +210,7 @@ html, body {
 }
 
 .login-btn:hover {
-  background: #323745;
+  background: #2e3256;
 }
 
 .login-btn-primary {
@@ -256,7 +267,7 @@ html, body {
 }
 
 .login-status-note code {
-  background: #11131b;
+  background: #0d0f1c;
   padding: 0.05rem 0.35rem;
   border-radius: 4px;
   font-size: 0.75rem;
@@ -271,7 +282,7 @@ html, body {
 .login-status-output {
   margin: 0.75rem 0 0;
   padding: 0.6rem 0.75rem;
-  background: #11131b;
+  background: #0d0f1c;
   border: 1px solid var(--border);
   border-radius: 8px;
   color: var(--text-muted);

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Sign in — Axiom AI Tutor</title>
-  <meta name="theme-color" content="#0f1117">
+  <meta name="theme-color" content="#0e0f1a">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/login.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Align `login.css` tokens with `styles.css` palette (`--border`, add `--tutor-accent`, `--accent-light`, `--surface`, `--font-heading`)
- Load Nunito via Google Fonts so the login wordmark uses the same heading typeface as the main app
- Add a gradient top-border to `.login-card` (periwinkle → amber) mirroring the app header
- Add a subtle radial background behind the card on `.login-shell`
- Apply Nunito + var tokens to the `.login-logo-company` gradient wordmark
- Swap the warmer surface values into `.login-input` and `.login-btn`

Stacked on #177 (which establishes the canonical logo SVG). Merge #177 first; this PR will then auto-narrow to the login-specific deltas.

Closes #179

## Test plan
- [ ] `/login.html` card shows gradient top-border (periwinkle → amber)
- [ ] Wordmark renders in Nunito, visually matches main app header
- [ ] Radial background visible behind card
- [ ] Focus rings on inputs are warm periwinkle
- [ ] Mobile (375px) still centers card cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)