### PR TITLE
Release 2026-04-18 Socratic UX + Brand Refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,7 @@ Get session metadata.
   "id": "uuid",
   "started_at": "2024-01-01T00:00:00Z",
   "last_activity_at": "2024-01-01T00:10:00Z",
+  "ended_at": null,
   "client_ip": "1.2.3.4",
   "client_geo": { "city": "...", "country": "..." },
   "client_user_agent": "Mozilla/...",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,25 @@ Get conversation transcript.  Prefers in-memory session; falls back to DB.
 
 ---
 
+### POST /api/transcript/:sessionId/email
+
+Email a copy of the session transcript to the authenticated user's registered address via Resend.  Auth-gated; the session must belong to the caller.  Rate-limited to 3 requests per 15 minutes per IP.
+
+**Response**: `application/json`
+
+```json
+{ "ok": true }
+```
+
+Error responses:
+- `400 { "ok": false, "error": "invalid_session_id" | "empty_transcript" | "no_user_email" }`
+- `404 { "ok": false, "error": "not_found" }` — session missing or not owned by caller
+- `429 { "ok": false, "error": "too_many_requests" }`
+- `500 { "ok": false, "error": "failed" }` — Resend error
+- `503 { "ok": false, "error": "email_not_configured" }` — `RESEND_API_KEY` is not set
+
+---
+
 ### POST /api/feedback
 
 Submit end-of-session feedback.  Saves one row to `session_feedback`.  No email is sent on submission — feedback is included in the transcript email sent when the session ends.
@@ -481,6 +500,7 @@ These apply to every Claude Code session in this repo.
 | `apps/api/src/routes/chat.ts` | `POST /api/chat` — streaming chat with file upload |
 | `apps/api/src/routes/sessions.ts` | `GET/DELETE /api/sessions/:id` |
 | `apps/api/src/routes/transcript.ts` | `GET /api/transcript/:id` |
+| `apps/api/src/routes/transcript-email.ts` | `POST /api/transcript/:id/email` — rate-limited, auth-gated, ownership-checked. Sends the transcript to the caller's registered email via `sendUserTranscript`. |
 | `apps/api/src/routes/feedback.ts` | `POST /api/feedback` — saves one `session_feedback` row (requires auth + ownership) |
 | `apps/api/src/routes/auth.ts` | `createAuthRouter(db, anonDb)` — rate-limited proxies for `POST /register`, `/login`, `/forgot-password`. All other auth operations are client-side via supabase-js. Registered only if `SUPABASE_ANON_KEY` is set. |
 | `apps/api/src/middleware/require-auth.ts` | `createRequireAuth(db)` — verifies `Authorization: Bearer <token>` via `db.auth.getUser(token)` and sets `req.userId`, `req.userEmail`, `req.userName`, `req.isAdmin` (from `app_metadata.is_admin` JWT claim). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ Get non-secret runtime config.
   "model": "claude-sonnet-4-6",
   "extendedThinking": true,
   "inactivityMs": 600000,
-  "contactEmail": "wax.spirits8d@icloud.com",
+  "contactEmail": "",
   "availableModels": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"],
   "availablePrompts": ["tutor-prompt-v7", "tutor-prompt-v6"],
   "defaultPrompt": "tutor-prompt-v7",
@@ -409,7 +409,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
-| CONTACT_EMAIL | no | wax.spirits8d@icloud.com | api | Contact email returned by GET /api/config and shown on the login page |
+| CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
 | ALLOW_PROMPT_SELECTION | no | — (locked) | api | Set `"true"` to allow users to switch prompt versions via the header badge; omitting locks the picker (fail-closed). Surfaced as `promptSelectionEnabled` in `GET /api/config`. |
 | SUPABASE_ANON_KEY | **yes (API)** | — | db, api | Supabase anon/public key. Required for the `/api/auth/*` endpoints that back the login flow at `/login.html`. Still held server-side only — never exposed via `/api/config`. When unset, the auth router is not registered and the app will be inaccessible (the login page cannot authenticate). |
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import { errorHandler } from "./middleware/errors.js";
 import { createChatRouter } from "./routes/chat.js";
 import { createSessionsRouter } from "./routes/sessions.js";
 import { createTranscriptRouter } from "./routes/transcript.js";
+import { createTranscriptEmailRouter } from "./routes/transcript-email.js";
 import { createFeedbackRouter } from "./routes/feedback.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createAuthRouter } from "./routes/auth.js";
@@ -123,6 +124,7 @@ app.use(express.static(path.join(__dirname, "../../web/public")));
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db, promptMap, defaultPromptName, config.model, config.extendedThinking));
 app.use("/api/sessions", createSessionsRouter(db, emailConfig, config.model, defaultPromptName, config.extendedThinking));
+app.use("/api/transcript", createTranscriptEmailRouter(db, { apiKey: emailConfig.apiKey, from: emailConfig.from }));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -42,7 +42,7 @@ export function createConfigRouter(
       model: config.model,
       extendedThinking: config.extendedThinking,
       inactivityMs,
-      contactEmail: process.env.CONTACT_EMAIL ?? "wax.spirits8d@icloud.com",
+      contactEmail: process.env.CONTACT_EMAIL ?? "",
       availableModels: [...ALLOWED_MODELS],
       availablePrompts: [...promptMap.keys()],
       defaultPrompt: defaultPromptName,

--- a/apps/api/src/routes/transcript-email.ts
+++ b/apps/api/src/routes/transcript-email.ts
@@ -1,0 +1,107 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import {
+  getMessagesBySession,
+  getSession as getDbSession,
+} from "@ai-tutor/db";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { sendUserTranscript } from "@ai-tutor/email";
+import type { UserTranscriptPayload } from "@ai-tutor/email";
+import { UUID_RE } from "../lib/validation.js";
+import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
+
+export interface TranscriptEmailRouteConfig {
+  apiKey: string | undefined;
+  from: string;
+}
+
+/**
+ * POST /api/transcript/:sessionId/email
+ *
+ * Sends a copy of the session transcript to the authenticated user's
+ * registered email via Resend. Auth-gated; the session must belong to the
+ * caller. Rate-limited to 3 requests per 15 minutes per IP.
+ *
+ * Response:
+ *   { ok: true }                                on success
+ *   { ok: false, error: "email_not_configured" } 503 — Resend not set up
+ *   { ok: false, error: "failed" }              500 — Resend error
+ */
+export function createTranscriptEmailRouter(
+  db: SupabaseClient,
+  emailConfig: TranscriptEmailRouteConfig,
+): Router {
+  const router = Router();
+  const requireAuth = createRequireAuth(db);
+
+  const rateLimitHandler = (
+    _req: unknown,
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+  ) => {
+    res.status(429).json({ ok: false, error: "too_many_requests" });
+  };
+
+  const emailLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: rateLimitHandler,
+  });
+
+  router.post("/:sessionId/email", emailLimiter, requireAuth, async (req, res, next) => {
+    try {
+      const { sessionId } = req.params;
+      if (!UUID_RE.test(sessionId)) {
+        res.status(400).json({ ok: false, error: "invalid_session_id" });
+        return;
+      }
+
+      const authedReq = req as AuthedRequest;
+      const row = await getDbSession(db, sessionId);
+      if (!row || row.user_id !== authedReq.userId) {
+        res.status(404).json({ ok: false, error: "not_found" });
+        return;
+      }
+
+      if (!emailConfig.apiKey) {
+        res.status(503).json({ ok: false, error: "email_not_configured" });
+        return;
+      }
+      if (!authedReq.userEmail) {
+        res.status(400).json({ ok: false, error: "no_user_email" });
+        return;
+      }
+
+      const messages = await getMessagesBySession(db, sessionId);
+      if (messages.length === 0) {
+        res.status(400).json({ ok: false, error: "empty_transcript" });
+        return;
+      }
+
+      const transcript = messages.map((m) => ({
+        role: (m.role === "user" ? "Student" : "Tutor") as "Student" | "Tutor",
+        text: m.content,
+      }));
+      const startedAt = new Date(row.started_at);
+      const endedAt = row.ended_at ? new Date(row.ended_at) : new Date(row.last_activity_at);
+      const durationMs = Math.max(0, endedAt.getTime() - startedAt.getTime());
+
+      const payload: UserTranscriptPayload = { transcript, startedAt, durationMs };
+
+      try {
+        await sendUserTranscript(authedReq.userEmail, emailConfig, payload);
+      } catch (err) {
+        console.error(`[transcript-email] Send failed for ${sessionId}:`, err);
+        res.status(500).json({ ok: false, error: "failed" });
+        return;
+      }
+
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -348,6 +348,64 @@
     scrollBottom();
   }
 
+  function appendTutorRestored(text) {
+    hideEmpty();
+    const id = `m${++msgCounter}`;
+    const div = document.createElement('div');
+    div.className = 'msg tutor';
+    div.id = id;
+
+    const label = document.createElement('div');
+    label.className = 'msg-label';
+    label.textContent = 'Tutor';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'msg-bubble';
+
+    div.appendChild(label);
+    div.appendChild(bubble);
+    messagesEl.appendChild(div);
+
+    const entry = { id, role: 'tutor', dbId: null, bubbleEl: bubble };
+    msgList.push(entry);
+    finalizeTutor(entry, text);
+    updateHeaderButtons();
+    return entry;
+  }
+
+  /**
+   * Restore a previously active session after returning from another page.
+   * Verifies the session is still open server-side and replays its messages
+   * from the DB. All failure paths silently fall back to a fresh session.
+   */
+  async function restoreSession(savedId) {
+    try {
+      const sessionRes = await window.auth.authedFetch(`/api/sessions/${savedId}`);
+      if (!sessionRes.ok) return;
+      const meta = await sessionRes.json();
+      if (meta.ended_at) return;
+
+      const txRes = await window.auth.authedFetch(`/api/transcript/${savedId}`);
+      if (!txRes.ok) return;
+      const { transcript } = await txRes.json();
+      if (!transcript || transcript.length === 0) return;
+
+      sessionId = savedId;
+      for (const entry of transcript) {
+        if (entry.role === 'Student') {
+          appendUserMsg(entry.text, []);
+        } else {
+          appendTutorRestored(entry.text);
+        }
+      }
+      resetInactivityTimer();
+    } catch {
+      /* silently fall through — start fresh */
+    } finally {
+      sessionStorage.removeItem('resumeSessionId');
+    }
+  }
+
   function scrollBottom() {
     chatArea.scrollTop = chatArea.scrollHeight;
   }
@@ -585,6 +643,7 @@
     if (activeAbortController) { activeAbortController.abort(); activeAbortController = null; }
     if (inactivityTimer) { clearTimeout(inactivityTimer); inactivityTimer = null; }
     stopCountdownDisplay();
+    sessionStorage.removeItem('resumeSessionId');
     sessionId       = crypto.randomUUID();
     msgList         = [];
     for (const u of sessionUploads) {
@@ -1012,12 +1071,20 @@
     }
   });
 
+  function saveResumeIfActive() {
+    if (msgList.length > 0 && !sessionEnded) {
+      sessionStorage.setItem('resumeSessionId', sessionId);
+    }
+  }
+
   menuSettings.addEventListener('click', () => {
     closeAccountDropdown();
+    saveResumeIfActive();
     window.location.href = '/settings.html';
   });
   menuHistory.addEventListener('click', () => {
     closeAccountDropdown();
+    saveResumeIfActive();
     window.location.href = '/history.html';
   });
   menuLogout.addEventListener('click', () => {
@@ -1043,7 +1110,7 @@
   // Redirect to /login.html if no valid session exists. supabase-js handles
   // token storage, refresh, and cross-tab sync; we just check for a session
   // and listen for sign-out events.
-  window.auth.requireSession().then(function () {
+  window.auth.requireSession().then(async function () {
     window.auth.init().then(function () {
       window.auth.getClient().auth.onAuthStateChange(function (event) {
         if (event === 'SIGNED_OUT') {
@@ -1051,8 +1118,10 @@
         }
       });
     });
-    fetchConfig();
+    await fetchConfig();
     fetchUserInfo();
+    const savedId = sessionStorage.getItem('resumeSessionId');
+    if (savedId) await restoreSession(savedId);
   });
 
   // ── Init ──────────────────────────────────────────────────────────────────

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -548,11 +548,23 @@
   }
 
   function setInputDisabled(disabled) {
-    btnSend.disabled          = disabled;
     msgInput.disabled         = disabled;
     btnAttach.disabled        = disabled;
+    updateSendState();
     // When re-enabling after streaming, respect the "has messages" gate
     btnEndSessionInline.disabled = disabled || msgList.length === 0;
+  }
+
+  /**
+   * Single source of truth for Send button state.
+   *
+   * Disables Send when the input is empty or we're mid-stream or session is
+   * ended / otherwise locked. All callers that previously wrote directly to
+   * btnSend.disabled should go through this instead.
+   */
+  function updateSendState() {
+    const empty = !msgInput.value.trim() && attachments.length === 0;
+    btnSend.disabled = empty || isStreaming || sessionEnded || msgInput.disabled;
   }
 
   // ── Session DELETE helpers ────────────────────────────────────────────────
@@ -683,8 +695,8 @@
     msgInput.value = '';
     msgInput.placeholder = 'What are you stuck on?';
     msgInput.disabled = false;
-    btnSend.disabled = false;
     btnAttach.disabled = false;
+    updateSendState();
     updateHeaderButtons();
     resizeInput();
   }
@@ -799,9 +811,9 @@
 
   function lockSession(message) {
     msgInput.disabled = true;
-    btnSend.disabled  = true;
     btnAttach.disabled = true;
     btnEndSessionInline.disabled = true;
+    updateSendState();
     btnEndSessionInline.classList.remove('end-ready');
     msgInput.placeholder = 'Session ended.';
     showToast(message, 5000);
@@ -935,9 +947,13 @@
 
   function renderStrip() {
     fileStrip.innerHTML = '';
-    if (!attachments.length) { fileStrip.classList.remove('active'); return; }
-    fileStrip.classList.add('active');
-    for (const a of attachments) fileStrip.appendChild(a.chipEl);
+    if (!attachments.length) {
+      fileStrip.classList.remove('active');
+    } else {
+      fileStrip.classList.add('active');
+      for (const a of attachments) fileStrip.appendChild(a.chipEl);
+    }
+    updateSendState();
   }
 
   // ── Drag and drop ─────────────────────────────────────────────────────────
@@ -986,7 +1002,8 @@
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
   });
 
-  msgInput.addEventListener('input', resizeInput);
+  msgInput.addEventListener('input', () => { resizeInput(); updateSendState(); });
+  updateSendState();
 
   btnAttach.addEventListener('click', () => {
     if (!sessionEnded) fileInput.click();

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -176,12 +176,20 @@
         promptBadge.classList.add('admin-visible');
         thinkingBadge.classList.add('admin-visible');
       }
-      const displayName = userMeta.name || user.email || '';
-      if (displayName) {
-        userDisplayName.textContent = displayName;
+
+      // Always show the account trigger for authenticated users. Fall back
+      // down the chain: explicit name → email local-part → "Account".
+      // Only the first word of the name appears in the trigger so the pill
+      // stays compact; the full email still shows in the dropdown info row.
+      if (user && (user.id || user.email)) {
+        const fullName = (userMeta.name || '').trim();
+        const emailPrefix = user.email ? String(user.email).split('@')[0] : '';
+        const displayName = fullName || emailPrefix || 'Account';
+        const firstName = displayName.split(/\s+/)[0] || 'Account';
+        userDisplayName.textContent = firstName;
         accountTrigger.style.display = '';
+        accountDropdownInfo.textContent = user.email || displayName;
       }
-      accountDropdownInfo.textContent = user.email || displayName;
     } catch {
       // Leave badges hidden on failure.
     }

--- a/apps/web/public/history.css
+++ b/apps/web/public/history.css
@@ -204,6 +204,60 @@ html, body {
   background: #323745;
 }
 
+.transcript-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex: 1;
+  justify-content: flex-end;
+  margin-right: 0.5rem;
+}
+
+.transcript-action-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.transcript-action-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.transcript-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.transcript-action-status {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-align: center;
+  padding: 0.4rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.transcript-action-status.success {
+  color: var(--success);
+}
+
+.transcript-action-status.error {
+  color: var(--danger);
+}
+
+@media (max-width: 480px) {
+  .transcript-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
 .transcript-messages {
   flex: 1;
   overflow-y: auto;

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -29,8 +29,14 @@
         <div class="transcript-panel">
           <div class="transcript-panel-header">
             <h2 class="transcript-panel-title" id="transcript-title">Transcript</h2>
+            <div class="transcript-actions" id="transcript-actions" style="display:none">
+              <button type="button" class="transcript-action-btn" id="transcript-email-btn">Email me this</button>
+              <button type="button" class="transcript-action-btn" id="transcript-pdf-btn">Download PDF</button>
+              <button type="button" class="transcript-action-btn" id="transcript-xlsx-btn">Download Excel</button>
+            </div>
             <button type="button" class="transcript-close-btn" id="transcript-close">Close</button>
           </div>
+          <div class="transcript-action-status" id="transcript-action-status" style="display:none"></div>
           <div class="transcript-messages" id="transcript-messages"></div>
         </div>
       </div>
@@ -38,6 +44,8 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="/history.js"></script>
 </body>
 </html>

--- a/apps/web/public/history.js
+++ b/apps/web/public/history.js
@@ -15,6 +15,16 @@
   var messagesEl = document.getElementById("transcript-messages");
   var titleEl = document.getElementById("transcript-title");
   var closeBtn = document.getElementById("transcript-close");
+  var actionsEl = document.getElementById("transcript-actions");
+  var statusEl = document.getElementById("transcript-action-status");
+  var emailBtn = document.getElementById("transcript-email-btn");
+  var pdfBtn = document.getElementById("transcript-pdf-btn");
+  var xlsxBtn = document.getElementById("transcript-xlsx-btn");
+
+  // ── Module state ──────────────────────────────────────────────────────────
+  var currentSessionId = null;
+  var currentTranscriptData = null;
+  var currentStartedAt = null;
 
   // ── Formatting helpers ────────────────────────────────────────────────────
   function formatPromptName(name) {
@@ -142,6 +152,11 @@
     titleEl.textContent = "Transcript — " + formatDate(startedAt);
     messagesEl.innerHTML = "<div class=\"history-loading\">Loading transcript...</div>";
     overlayEl.style.display = "";
+    currentSessionId = sessionId;
+    currentTranscriptData = null;
+    currentStartedAt = startedAt;
+    actionsEl.style.display = "none";
+    clearStatus();
 
     window.auth.authedFetch("/api/transcript/" + sessionId)
       .then(function (res) {
@@ -157,6 +172,9 @@
           messagesEl.innerHTML = "<div class=\"history-empty\">No messages in this session.</div>";
           return;
         }
+
+        currentTranscriptData = data.transcript;
+        actionsEl.style.display = "";
 
         data.transcript.forEach(function (msg) {
           var div = document.createElement("div");
@@ -187,7 +205,157 @@
   function closeTranscript() {
     overlayEl.style.display = "none";
     messagesEl.innerHTML = "";
+    currentSessionId = null;
+    currentTranscriptData = null;
+    currentStartedAt = null;
+    actionsEl.style.display = "none";
+    clearStatus();
   }
+
+  // ── Export actions ────────────────────────────────────────────────────────
+  function setActionsDisabled(disabled) {
+    emailBtn.disabled = disabled;
+    pdfBtn.disabled = disabled;
+    xlsxBtn.disabled = disabled;
+  }
+
+  function showStatus(text, kind) {
+    statusEl.textContent = text;
+    statusEl.className = "transcript-action-status" + (kind ? " " + kind : "");
+    statusEl.style.display = "";
+  }
+
+  function clearStatus() {
+    statusEl.textContent = "";
+    statusEl.style.display = "none";
+    statusEl.className = "transcript-action-status";
+  }
+
+  function filenameBase() {
+    var prefix = currentSessionId ? currentSessionId.split("-")[0] : "session";
+    var d = new Date();
+    var pad = function (n) { return n < 10 ? "0" + n : String(n); };
+    var stamp = d.getFullYear() + pad(d.getMonth() + 1) + pad(d.getDate());
+    return "transcript-" + prefix + "-" + stamp;
+  }
+
+  function emailTranscript() {
+    if (!currentSessionId) return;
+    setActionsDisabled(true);
+    showStatus("Sending…");
+
+    window.auth.authedFetch("/api/transcript/" + currentSessionId + "/email", {
+      method: "POST",
+    })
+      .then(function (res) {
+        return res.json().catch(function () { return { ok: false }; }).then(function (body) {
+          return { status: res.status, body: body };
+        });
+      })
+      .then(function (r) {
+        if (r.status === 200 && r.body && r.body.ok) {
+          showStatus("Sent!", "success");
+          return;
+        }
+        if (r.status === 429) {
+          showStatus("Too many requests. Try again in a few minutes.", "error");
+          return;
+        }
+        if (r.status === 503) {
+          showStatus("Email is not configured on this server.", "error");
+          return;
+        }
+        showStatus("Could not send. Try again later.", "error");
+      })
+      .catch(function () {
+        showStatus("Could not send. Try again later.", "error");
+      })
+      .then(function () {
+        setActionsDisabled(false);
+      });
+  }
+
+  function downloadPdf() {
+    if (!currentTranscriptData || !window.jspdf) {
+      showStatus("PDF library not loaded.", "error");
+      return;
+    }
+    setActionsDisabled(true);
+    try {
+      var doc = new window.jspdf.jsPDF({ unit: "pt", format: "letter" });
+      var margin = 48;
+      var pageHeight = doc.internal.pageSize.getHeight();
+      var pageWidth = doc.internal.pageSize.getWidth();
+      var maxWidth = pageWidth - margin * 2;
+      var y = margin;
+
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(14);
+      doc.text("Tutor session transcript", margin, y);
+      y += 20;
+      if (currentStartedAt) {
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(10);
+        doc.text(formatDate(currentStartedAt), margin, y);
+        y += 16;
+      }
+      y += 6;
+
+      currentTranscriptData.forEach(function (msg) {
+        doc.setFont("helvetica", "bold");
+        doc.setFontSize(11);
+        if (y > pageHeight - margin) { doc.addPage(); y = margin; }
+        doc.text(msg.role, margin, y);
+        y += 14;
+
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(10);
+        var lines = doc.splitTextToSize(msg.text || "", maxWidth);
+        for (var i = 0; i < lines.length; i++) {
+          if (y > pageHeight - margin) { doc.addPage(); y = margin; }
+          doc.text(lines[i], margin, y);
+          y += 13;
+        }
+        y += 8;
+      });
+
+      doc.save(filenameBase() + ".pdf");
+      showStatus("PDF downloaded.", "success");
+    } catch (err) {
+      showStatus("PDF generation failed.", "error");
+      console.error("[history] PDF error:", err);
+    } finally {
+      setActionsDisabled(false);
+    }
+  }
+
+  function downloadXlsx() {
+    if (!currentTranscriptData || !window.XLSX) {
+      showStatus("Excel library not loaded.", "error");
+      return;
+    }
+    setActionsDisabled(true);
+    try {
+      var rows = [["Role", "Message"]];
+      currentTranscriptData.forEach(function (msg) {
+        rows.push([msg.role, msg.text || ""]);
+      });
+      var ws = window.XLSX.utils.aoa_to_sheet(rows);
+      var wb = window.XLSX.utils.book_new();
+      window.XLSX.utils.book_append_sheet(wb, ws, "Transcript");
+      window.XLSX.writeFile(wb, filenameBase() + ".xlsx");
+      showStatus("Excel downloaded.", "success");
+    } catch (err) {
+      showStatus("Excel generation failed.", "error");
+      console.error("[history] XLSX error:", err);
+    } finally {
+      setActionsDisabled(false);
+    }
+  }
+
+  emailBtn.addEventListener("click", emailTranscript);
+  pdfBtn.addEventListener("click", downloadPdf);
+  xlsxBtn.addEventListener("click", downloadXlsx);
 
   closeBtn.addEventListener("click", closeTranscript);
 

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -97,9 +97,9 @@
           <p class="empty-heading">What are you stuck on?</p>
           <p class="empty-sub">Drop a question or upload a photo of your homework.</p>
           <div class="empty-chips">
-            <button class="empty-chip" data-fill="Can you help me understand this problem?">Help me understand</button>
-            <button class="empty-chip" data-fill="Check my work: ">Check my work</button>
-            <button class="empty-chip" data-fill="Explain ">Explain a concept</button>
+            <button class="empty-chip" data-fill="Can you help me understand this problem?">🧭 Help me understand</button>
+            <button class="empty-chip" data-fill="Check my work: ">✅ Check my work</button>
+            <button class="empty-chip" data-fill="Explain ">💡 Explain a concept</button>
           </div>
         </div>
         <div id="messages"></div>
@@ -141,7 +141,7 @@
         <button class="btn btn-icon" id="btn-attach" title="Attach files (images or PDF)">📎</button>
         <input type="file" id="file-input" multiple
                accept="image/jpeg,image/png,image/gif,image/webp,application/pdf" hidden>
-        <textarea id="msg-input" placeholder="What are you stuck on?" rows="1"></textarea>
+        <textarea id="msg-input" placeholder="Describe what you're working on, or drag in a photo…" rows="1"></textarea>
         <button class="btn btn-primary" id="btn-send">Send</button>
         <button class="btn" id="btn-end-session-inline" disabled title="End this session">End session</button>
       </div>

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -10,7 +10,7 @@
   --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
-  --text-muted: #9aa0ad;
+  --text-muted: #b4b9c8;
   --accent: #6d8ef5;
   --accent-hover: #8ba8f8;
   --danger: #ef4444;
@@ -120,6 +120,11 @@ html, body {
 
 .login-input:focus {
   border-color: var(--accent);
+}
+
+.login-input::placeholder {
+  opacity: 1;
+  color: var(--text-muted);
 }
 
 .login-hint {

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -6,13 +6,13 @@
  */
 
 :root {
-  --bg: #0f1117;
-  --card: #1a1d27;
+  --bg: #0e0f1a;
+  --card: #181a2e;
   --border: #2a2e3a;
   --text: #e7e9ee;
   --text-muted: #9aa0ad;
-  --accent: #7c6af7;
-  --accent-hover: #8d7dfa;
+  --accent: #6d8ef5;
+  --accent-hover: #8ba8f8;
   --danger: #ef4444;
   --success: #22c55e;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -7,7 +7,7 @@
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
-      --text-muted:    #6b7194;
+      --text-muted:    #9499c0;
       --accent:        #6d8ef5;
       /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
       --accent-light:  #1e2a52;
@@ -135,7 +135,7 @@
       font-family: var(--font-sans);
       font-size: 0.71rem;
       font-weight: 500;
-      color: var(--text-muted);
+      color: var(--text);
       background: var(--surface-alt);
       padding: 3px 10px;
       border-radius: var(--radius-pill);
@@ -717,6 +717,7 @@
     /* ── Inline end-session button ─────────────────────────────────────────── */
     #btn-end-session-inline {
       height: 40px;
+      min-height: 44px;
       color: var(--danger);
       border-color: var(--border-bright);
       background: transparent;
@@ -809,10 +810,13 @@
       padding: 8px;
       width: 40px;
       height: 40px;
+      min-width: 44px;
+      min-height: 44px;
       font-size: 1rem;
     }
 
     #btn-attach, #btn-send { height: 40px; }
+    #btn-attach { min-width: 44px; min-height: 44px; }
     #btn-send { padding: 0 16px; }
 
     /* ── Modal backdrop ────────────────────────────────────────────────────── */

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -717,17 +717,15 @@
     #btn-end-session-inline {
       height: 40px;
       min-height: 44px;
-      color: var(--danger);
+      color: var(--text-muted);
       border-color: var(--border-bright);
       background: transparent;
-      opacity: 0.6;
       flex-shrink: 0;
     }
     #btn-end-session-inline:not(:disabled):hover {
       background: rgba(248, 113, 113, 0.1);
       border-color: var(--danger);
       color: var(--danger);
-      opacity: 1;
     }
     #btn-end-session-inline:disabled {
       opacity: 0.25;
@@ -815,7 +813,11 @@
     }
 
     #btn-attach, #btn-send { height: 40px; }
-    #btn-attach { min-width: 44px; min-height: 44px; }
+    #btn-attach {
+      min-width: 44px;
+      min-height: 44px;
+      border: 1px solid var(--border);
+    }
     #btn-send { padding: 0 16px; }
 
     /* ── Modal backdrop ────────────────────────────────────────────────────── */

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -178,11 +178,11 @@
       align-items: center;
       gap: 4px;
       background: none;
-      border: 1px solid var(--border);
+      border: 1px solid var(--border-bright);
       border-radius: var(--radius-md);
       padding: 4px 10px;
       cursor: pointer;
-      color: var(--text-muted);
+      color: var(--text);
       font-family: var(--font-sans);
       font-size: 0.75rem;
       transition: color 0.15s, border-color 0.15s;
@@ -200,7 +200,6 @@
       width: 16px;
       height: 16px;
       flex-shrink: 0;
-      opacity: 0.7;
     }
     .user-display-name {
       white-space: nowrap;

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1019,14 +1019,15 @@
       font-family: var(--font-sans);
       font-size: 0.82rem;
       font-weight: 500;
-      padding: 6px 14px;
+      padding: 8px 16px;
       cursor: pointer;
-      transition: background 0.15s, color 0.15s, border-color 0.15s;
+      transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s;
     }
     .empty-chip:hover {
       background: var(--accent-light);
       border-color: var(--accent);
       color: var(--text);
+      box-shadow: 0 0 10px var(--accent-glow);
     }
     @keyframes float {
       0%, 100% { transform: translateY(0); }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,19 +1,20 @@
     /* ── CSS variables ─────────────────────────────────────────────────────── */
     :root {
-      --bg:            #0f1117;
-      --surface:       #1a1d27;
+      --bg:            #0e0f1a;
+      --surface:       #181a2e;
       --surface-alt:   #252836;
       --surface-raise: #2e3247;
       --border:        #2e3247;
       --border-bright: #4a4f6a;
       --text:          #e8eaf6;
       --text-muted:    #6b7194;
-      --accent:        #7c6af7;
-      --accent-light:  #2d2860;
+      --accent:        #6d8ef5;
+      /* Warm periwinkle tinted surface used for accent backgrounds (pills, chips, hover states). */
+      --accent-light:  #1e2a52;
       --accent-dark:   #5b4dd4;
-      --accent-glow:   rgba(124, 106, 247, 0.25);
-      --tutor-accent:  #22d3ee;
-      --tutor-bg:      #0e1e26;
+      --accent-glow:   rgba(109, 142, 245, 0.25);
+      --tutor-accent:  #f59e0b;
+      --tutor-bg:      #1a1600;
       --tutor-border:  #1a3a48;
       --user-bg:       #1e1a40;
       --user-border:   #3d3572;
@@ -787,7 +788,7 @@
     .btn:disabled { opacity: 0.35; cursor: not-allowed; transform: none; }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--accent) 0%, #9c6af7 100%);
+      background: linear-gradient(135deg, var(--accent) 0%, #8ba8f8 100%);
       border-color: transparent;
       color: #fff;
     }
@@ -971,7 +972,7 @@
       width: 72px;
       height: 72px;
       border-radius: 50%;
-      background: linear-gradient(135deg, var(--accent-light), #0e1e26);
+      background: linear-gradient(135deg, var(--accent-light), var(--tutor-bg));
       border: 2px solid var(--border-bright);
       display: flex;
       align-items: center;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `RESEND_API_KEY` | no | Resend dashboard → API Keys | **Yes** |
 | `PARENT_EMAIL` | no | Your email address (where transcripts will be sent) | No |
 | `EMAIL_FROM` | no | Your verified sending address (e.g., `tutor@yourdomain.com`) | No |
-| `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config | No |
+| `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config. Defaults to `""` — required before going public. The contact line is hidden when absent. | No |
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |


### PR DESCRIPTION
## Features in this release

- schmimran/ai-tutor-toolkit#192 — chore(eval): switch evaluator model from sonnet to haiku (closes #183)
- schmimran/ai-tutor-toolkit#193 — feat(web): replace placeholder logo with lightbulb-atom SVG mark (closes #177)
- schmimran/ai-tutor-toolkit#194 — feat(web): improve empty state with Socratic tutoring expectations (closes #180)
- schmimran/ai-tutor-toolkit#195 — feat(web): align login page visual identity with main app brand (closes #179)

Automated by feature-creator.
