### PR TITLE
chore: bring today's features into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `PARENT_EMAIL` is absent, emails are silently skipped.
 
-The evaluation model (`claude-sonnet-4-6`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
+The evaluation model (`claude-haiku-4-5-20251001`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
 
 ---
 

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -40,14 +40,17 @@
       <span class="header-logo">
         <svg class="logo-mark" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <defs>
-            <linearGradient id="logo-grad" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
-              <stop offset="0%" stop-color="#7c6af7"/>
-              <stop offset="100%" stop-color="#22d3ee"/>
+            <linearGradient id="logo-grad-hdr" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#6d8ef5"/>
+              <stop offset="100%" stop-color="#f59e0b"/>
             </linearGradient>
           </defs>
-          <line x1="4" y1="28" x2="16" y2="4" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
-          <line x1="28" y1="28" x2="16" y2="4" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
-          <line x1="9" y1="19" x2="23" y2="19" stroke="url(#logo-grad)" stroke-width="2.5" stroke-linecap="round"/>
+          <g stroke="url(#logo-grad-hdr)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+            <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+            <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+            <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+          </g>
         </svg>
         <span class="logo-wordmark">
           <span class="logo-company">Axiom</span>
@@ -92,15 +95,29 @@
       <div id="chat-area">
         <div id="empty-state">
           <div class="empty-icon-wrap">
-            <div class="empty-icon">✦</div>
+            <svg class="empty-icon" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Axiom logo">
+              <defs>
+                <linearGradient id="logo-grad-es" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+                  <stop offset="0%" stop-color="#6d8ef5"/>
+                  <stop offset="100%" stop-color="#f59e0b"/>
+                </linearGradient>
+              </defs>
+              <g stroke="url(#logo-grad-es)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+                <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+                <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+                <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+              </g>
+            </svg>
           </div>
           <p class="empty-heading">What are you stuck on?</p>
-          <p class="empty-sub">Drop a question or upload a photo of your homework.</p>
+          <p class="empty-sub">I'll help you work through it — not just give you the answer.</p>
           <div class="empty-chips">
             <button class="empty-chip" data-fill="Can you help me understand this problem?">🧭 Help me understand</button>
             <button class="empty-chip" data-fill="Check my work: ">✅ Check my work</button>
             <button class="empty-chip" data-fill="Explain ">💡 Explain a concept</button>
           </div>
+          <p class="empty-hint">Pick a mode, then describe what you're stuck on — or just start typing.</p>
         </div>
         <div id="messages"></div>
       </div>

--- a/apps/web/public/login.css
+++ b/apps/web/public/login.css
@@ -7,14 +7,18 @@
 
 :root {
   --bg: #0e0f1a;
+  --surface: #181a2e;
   --card: #181a2e;
-  --border: #2a2e3a;
+  --border: #2e3247;
   --text: #e7e9ee;
   --text-muted: #b4b9c8;
   --accent: #6d8ef5;
   --accent-hover: #8ba8f8;
+  --accent-light: #1e2a52;
+  --tutor-accent: #f59e0b;
   --danger: #ef4444;
   --success: #22c55e;
+  --font-heading: 'Nunito', sans-serif;
 }
 
 * { box-sizing: border-box; }
@@ -35,13 +39,18 @@ html, body {
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
+  background: radial-gradient(ellipse 80% 60% at 50% 40%, #1a1f3a 0%, var(--bg) 100%);
 }
 
 .login-card {
   width: 100%;
   max-width: 420px;
   background: var(--card);
-  border: 1px solid var(--border);
+  border-top: 2px solid transparent;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+  border-image: linear-gradient(90deg, var(--accent), var(--tutor-accent)) 1;
   border-radius: 12px;
   padding: 1.75rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
@@ -51,6 +60,44 @@ html, body {
   margin: 0 0 0.25rem 0;
   font-size: 1.4rem;
   font-weight: 700;
+}
+
+.login-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.login-logo-mark {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.login-logo-text {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.1;
+  gap: 2px;
+}
+
+.login-logo-company {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  background: linear-gradient(135deg, var(--accent), var(--tutor-accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.login-logo-product {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .login-subtitle {
@@ -107,7 +154,7 @@ html, body {
 }
 
 .login-input {
-  background: #11131b;
+  background: #0d0f1c;
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.6rem 0.75rem;
@@ -150,7 +197,7 @@ html, body {
 }
 
 .login-btn {
-  background: #2a2e3a;
+  background: #252845;
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -163,7 +210,7 @@ html, body {
 }
 
 .login-btn:hover {
-  background: #323745;
+  background: #2e3256;
 }
 
 .login-btn-primary {
@@ -220,7 +267,7 @@ html, body {
 }
 
 .login-status-note code {
-  background: #11131b;
+  background: #0d0f1c;
   padding: 0.05rem 0.35rem;
   border-radius: 4px;
   font-size: 0.75rem;
@@ -235,7 +282,7 @@ html, body {
 .login-status-output {
   margin: 0.75rem 0 0;
   padding: 0.6rem 0.75rem;
-  background: #11131b;
+  background: #0d0f1c;
   border: 1px solid var(--border);
   border-radius: 8px;
   color: var(--text-muted);

--- a/apps/web/public/login.html
+++ b/apps/web/public/login.html
@@ -4,16 +4,37 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Sign in — Axiom AI Tutor</title>
-  <meta name="theme-color" content="#0f1117">
+  <meta name="theme-color" content="#0e0f1a">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/login.css">
 </head>
 <body>
   <main class="login-shell">
     <div class="login-card">
-      <h1 class="login-title">Axiom AI Tutor</h1>
+      <h1 class="login-title">
+        <span class="login-logo">
+          <svg class="login-logo-mark" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="logo-grad-login" x1="0" y1="32" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+                <stop offset="0%" stop-color="#6d8ef5"/>
+                <stop offset="100%" stop-color="#f59e0b"/>
+              </linearGradient>
+            </defs>
+            <g stroke="url(#logo-grad-login)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M 10,16 Q 10,7 16,7 Q 22,7 22,16 Q 22,18.5 20,20 L 20,22 Q 20,23 19,23 L 13,23 Q 12,23 12,22 L 12,20 Q 10,18.5 10,16 Z" stroke-width="1.8"/>
+              <path d="M 13,25 L 19,25" stroke-width="1.8"/>
+              <path d="M 14,27 L 18,27" stroke-width="1.8"/>
+              <ellipse cx="16" cy="15" rx="11" ry="4.5" transform="rotate(-20 16 15)" stroke-width="1.1" opacity="0.85"/>
+            </g>
+          </svg>
+          <span class="login-logo-text">
+            <span class="login-logo-company">Axiom</span>
+            <span class="login-logo-product">AI Tutor</span>
+          </span>
+        </span>
+      </h1>
       <p class="login-subtitle">Sign in or create an account</p>
 
       <div class="login-tabs" role="tablist">

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -385,6 +385,7 @@
       gap: 16px;
       color: var(--text-muted);
       text-align: center;
+      padding-bottom: 15vh;
     }
 
     /* ── Messages list ─────────────────────────────────────────────────────── */
@@ -983,14 +984,12 @@
       align-items: center;
       justify-content: center;
       animation: float 4s ease-in-out infinite;
+      box-shadow: 0 0 24px var(--accent-glow);
     }
     .empty-icon {
-      font-size: 2rem;
+      width: 48px;
+      height: 48px;
       opacity: 1;
-      background: linear-gradient(135deg, var(--accent), var(--tutor-accent));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
     }
     .empty-heading {
       font-family: var(--font-heading);
@@ -1010,6 +1009,15 @@
       flex-wrap: wrap;
       gap: 8px;
       justify-content: center;
+      margin-top: 4px;
+    }
+    .empty-hint {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      max-width: 320px;
+      text-align: center;
+      line-height: 1.5;
+      opacity: 0.85;
       margin-top: 4px;
     }
     .empty-chip {

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -49,7 +49,7 @@ export async function evaluateTranscript(
   transcript: Array<{ role: string; text: string }>,
   config?: { model?: string }
 ): Promise<EvaluationResult> {
-  const model = config?.model ?? "claude-sonnet-4-6";
+  const model = config?.model ?? "claude-haiku-4-5-20251001";
 
   const formattedTranscript = transcript
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)


### PR DESCRIPTION
The release/2026-04-18 branch was cut from stage before these four PRs merged, so they landed on stage but not main:

- #192 chore(eval): switch evaluator model to haiku
- #193 feat(web): replace placeholder logo with lightbulb-atom SVG mark
- #194 feat(web): improve empty state with Socratic tutoring expectations
- #195 feat(web): align login page visual identity with main app brand

🤖 Generated with [Claude Code](https://claude.com/claude-code)