### PR TITLE
fix: handle email-change confirmation in settings (#201)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,7 +524,7 @@ These apply to every Claude Code session in this repo.
 | `apps/web/public/login.css` | Styles for `login.html`. Self-contained dark theme mirroring `styles.css` palette. |
 | `apps/web/public/login.js` | Tabbed login/register/forgot panels. Calls the three server-side proxy endpoints for rate-limited operations; delegates hash callbacks (signup, recovery) to supabase-js's `detectSessionInUrl`. Listens for `PASSWORD_RECOVERY` to redirect into the settings page. |
 | `apps/web/public/settings.html` | Settings page — account info, preferences, email change, password change. Loads supabase-js + auth.js. |
-| `apps/web/public/settings.js` | Uses supabase-js directly: `auth.updateUser` for password/email changes (with `currentPassword` verification when not in recovery), and direct `profiles` upsert under RLS for transcript preferences. |
+| `apps/web/public/settings.js` | Uses supabase-js directly: `auth.updateUser` for password/email changes (with `currentPassword` verification when not in recovery), and direct `profiles` upsert under RLS for transcript preferences. Email-change flow passes `emailRedirectTo: window.location.origin + "/settings.html"` and listens for `USER_UPDATED`/`EMAIL_CHANGE` events on `onAuthStateChange` to refresh the displayed email after confirmation. |
 | `apps/web/public/history.html` | Session history page. Loads supabase-js + auth.js. |
 | `apps/web/public/history.js` | Uses `authedFetch` to call `/api/history` and `/api/transcript/:id`. |
 | `apps/web/public/manifest.json` | PWA web app manifest — standalone display, theme colors, icon references |

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -85,8 +85,24 @@
 
       // PASSWORD_RECOVERY fires when supabase-js processes a recovery hash — set
       // isRecovery so the password-change path skips the current-password field.
-      client.auth.onAuthStateChange(function (event) {
-        if (event === "PASSWORD_RECOVERY") { isRecovery = true; applyRecoveryUI(); }
+      // USER_UPDATED fires after an email-change confirmation link is consumed;
+      // refresh the displayed email and show a success banner.
+      client.auth.onAuthStateChange(async function (event, sess) {
+        if (event === "PASSWORD_RECOVERY") { isRecovery = true; applyRecoveryUI(); return; }
+        if (event === "USER_UPDATED" || event === "EMAIL_CHANGE") {
+          var freshUser = sess && sess.user;
+          if (!freshUser) {
+            try {
+              var res = await client.auth.getUser();
+              freshUser = res && res.data && res.data.user;
+            } catch (e) { /* ignore */ }
+          }
+          if (freshUser && freshUser.email && freshUser.email !== original.email) {
+            emailEl.value = freshUser.email;
+            original.email = freshUser.email;
+            showSuccess("Email address updated successfully.");
+          }
+        }
       });
 
       var user = session.user;
@@ -169,7 +185,10 @@
     if (newEmail === original.email) { showSuccess("Email unchanged."); return; }
     changeEmailBtn.disabled = true;
     try {
-      var res = await client.auth.updateUser({ email: newEmail });
+      var res = await client.auth.updateUser(
+        { email: newEmail },
+        { emailRedirectTo: window.location.origin + "/settings.html" }
+      );
       if (res.error) throw res.error;
       showSuccess("A confirmation link has been sent to " + newEmail + ". Click it to complete the change.");
     } catch (err) {

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -85,8 +85,6 @@
 
       // PASSWORD_RECOVERY fires when supabase-js processes a recovery hash — set
       // isRecovery so the password-change path skips the current-password field.
-      // USER_UPDATED fires after an email-change confirmation link is consumed;
-      // refresh the displayed email and show a success banner.
       client.auth.onAuthStateChange(async function (event, sess) {
         if (event === "PASSWORD_RECOVERY") { isRecovery = true; applyRecoveryUI(); return; }
         if (event === "USER_UPDATED" || event === "EMAIL_CHANGE") {

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -4,8 +4,9 @@
  *   - user object (name/email/birthdate/grade_level/app_metadata) via auth.getUser()
  *   - email_transcripts_enabled via a RLS-protected select/update on profiles
  *   - password change via auth.updateUser({ password, currentPassword })
- *   - email change via auth.updateUser({ email }) — Supabase emails the new
- *     address to confirm the change.
+ *   - email change via auth.updateUser({ email }, { emailRedirectTo }) — Supabase
+ *     emails the new address to confirm; USER_UPDATED/EMAIL_CHANGE on
+ *     onAuthStateChange refreshes the displayed email after confirmation.
  *
  * Recovery detection: supabase-js fires PASSWORD_RECOVERY on the auth state
  * when a recovery hash is consumed. We show the recovery banner when


### PR DESCRIPTION
## Summary

Fixes #201 — the email-change confirmation link redirected to `/settings.html` but the page never reacted to the resulting auth state change, so users saw no confirmation and the displayed email remained stale.

- Extend the `onAuthStateChange` handler in `settings.js` to respond to `USER_UPDATED` / `EMAIL_CHANGE` events. When the fresh user object has a different email than the baseline, update the input, update `original.email`, and show a success banner.
- Pass `emailRedirectTo: <origin>/settings.html` on the `updateUser` call so the Supabase confirmation link lands back on the settings page regardless of the project's default site URL.

The `PASSWORD_RECOVERY` branch is unchanged.

## Test plan

- [ ] Log in as a test user; open `/settings.html`.
- [ ] Enter a new email address, click "Update email"; confirm the banner says a confirmation link was sent.
- [ ] Open the confirmation link in the same browser; verify redirect to `/settings.html`.
- [ ] Verify the email field shows the new address and a success banner appears.
- [ ] Verify a follow-up "Update email" click with the same address shows "Email unchanged."
- [ ] Regression: password-recovery flow still works end-to-end.
- [ ] Confirm the Supabase dashboard → Authentication → URL Configuration includes `<origin>/settings.html` in the allowed redirect URLs.

Closes #201

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
