### PR TITLE
refactor: rename PARENT_EMAIL to ADMIN_EMAIL (#204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,7 +402,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | SUPABASE_URL | **yes (API)** | — | db, api | Supabase project URL |
 | SUPABASE_SERVICE_ROLE_KEY | **yes (API)** | — | db, api | Supabase service role (bypasses RLS) |
 | RESEND_API_KEY | no | — | email, api | Resend API key (email skipped if absent) |
-| PARENT_EMAIL | no | — | api | Recipient for transcript/feedback emails |
+| ADMIN_EMAIL | no | — | api | Recipient address for admin transcript/evaluation emails. Renamed from `PARENT_EMAIL` — existing deployments must update the env var name. |
 | EMAIL_FROM | no | tutor@tutor.schmim.com | email, api | Sender address |
 | CORS_ORIGIN | no | false (fail-closed) | api | Allowed CORS origin. When unset, all cross-origin requests are rejected. Set explicitly for all deployments. |
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
@@ -413,7 +413,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | ALLOW_PROMPT_SELECTION | no | — (locked) | api | Set `"true"` to allow users to switch prompt versions via the header badge; omitting locks the picker (fail-closed). Surfaced as `promptSelectionEnabled` in `GET /api/config`. |
 | SUPABASE_ANON_KEY | **yes (API)** | — | db, api | Supabase anon/public key. Required for the `/api/auth/*` endpoints that back the login flow at `/login.html`. Still held server-side only — never exposed via `/api/config`. When unset, the auth router is not registered and the app will be inaccessible (the login page cannot authenticate). |
 
-`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `PARENT_EMAIL` is absent, emails are silently skipped.
+`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `ADMIN_EMAIL` is absent, emails are silently skipped.
 
 The evaluation model (`claude-haiku-4-5-20251001`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You need a domain you own to send from.  Resend can't send from Gmail, Yahoo, or
 
 ```bash
 export RESEND_API_KEY=re_...
-export PARENT_EMAIL=you@yourdomain.com       # where transcripts go
+export ADMIN_EMAIL=you@yourdomain.com        # where admin transcripts go
 export EMAIL_FROM=tutor@tutor.yourdomain.com # must match your verified domain
 ```
 
@@ -206,7 +206,7 @@ This table is a quick reference.  If you followed Option B above, you've already
 | `SUPABASE_SERVICE_ROLE_KEY` | **yes (web app)** | — | Supabase service role key.  Keep secret. |
 | `SUPABASE_ANON_KEY` | **yes (web app)** | — | Supabase anon/public key.  Required for the login flow. |
 | `RESEND_API_KEY` | no | — | Resend API key.  Emails skipped if absent. |
-| `PARENT_EMAIL` | no | — | Where transcript emails are sent. |
+| `ADMIN_EMAIL` | no | — | Where admin transcript emails are sent. Renamed from `PARENT_EMAIL`. |
 | `EMAIL_FROM` | no | `tutor@tutor.schmim.com` | Sender address.  Must match a verified Resend domain. |
 | `CONTACT_EMAIL` | no | `wax.spirits8d@icloud.com` | Contact email shown on the login page and returned by GET /api/config. |
 | `CORS_ORIGIN` | no | `*` | Allowed origin if you put the app behind a specific URL. |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -62,8 +62,8 @@ for (const file of fs.readdirSync(templatesDir)) {
   }
 }
 
-// Derive default prompt name from config.systemPromptPath (basename without extension).
-const defaultPromptName = path.basename(config.systemPromptPath, ".md");
+// Default prompt name derived from config.systemPromptPath in loadConfig().
+const defaultPromptName = config.defaultPromptName;
 
 // Fall back to loading via loadSystemPrompt if the default prompt wasn't found in templates/.
 if (!promptMap.has(defaultPromptName)) {
@@ -75,7 +75,7 @@ const tutorClient = createTutorClient(config, promptMap.get(defaultPromptName)!)
 
 const emailConfig = {
   apiKey: process.env.RESEND_API_KEY,
-  to: process.env.PARENT_EMAIL,
+  to: process.env.ADMIN_EMAIL,
   from: process.env.EMAIL_FROM ?? "tutor@tutor.schmim.com",
 };
 
@@ -123,7 +123,7 @@ app.use(express.static(path.join(__dirname, "../../web/public")));
 
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db, promptMap, defaultPromptName, config.model, config.extendedThinking));
-app.use("/api/sessions", createSessionsRouter(db, emailConfig, config.model, defaultPromptName, config.extendedThinking));
+app.use("/api/sessions", createSessionsRouter(db, emailConfig, config));
 app.use("/api/transcript", createTranscriptEmailRouter(db, { apiKey: emailConfig.apiKey, from: emailConfig.from }));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -5,6 +5,7 @@ import {
   getUserInfoForSession,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Config } from "@ai-tutor/core";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
@@ -20,9 +21,7 @@ export interface EmailConfig {
 export function createSessionsRouter(
   db: SupabaseClient,
   emailConfig: EmailConfig,
-  defaultModel: string,
-  defaultPromptName: string,
-  defaultExtendedThinking: boolean,
+  config: Config,
 ): Router {
   const router = Router();
   const requireAuth = createRequireAuth(db);
@@ -84,7 +83,7 @@ export function createSessionsRouter(
             getUserInfoForSession(db, sessionId).catch(() => null),
           ]);
           const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback,
-            { model: defaultModel, promptName: defaultPromptName, extendedThinking: defaultExtendedThinking },
+            { model: config.model, promptName: config.defaultPromptName, extendedThinking: config.extendedThinking },
             userInfo);
           try {
             await sendTranscript(emailConfig, payload);

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,7 +55,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `SUPABASE_SERVICE_ROLE_KEY` | **yes** | Supabase dashboard → Settings → API → service_role key | **Yes** |
 | `SUPABASE_ANON_KEY` | **yes** | Supabase dashboard → Settings → API → anon/public key. Required for the Supabase auth flow that gates the app at `/login.html`. If unset, the auth router is not registered and users cannot log in. | **Yes** |
 | `RESEND_API_KEY` | no | Resend dashboard → API Keys | **Yes** |
-| `PARENT_EMAIL` | no | Your email address (where transcripts will be sent) | No |
+| `ADMIN_EMAIL` | no | Your email address (where admin transcript/evaluation emails are sent). Renamed from `PARENT_EMAIL` — deployments using the old name must rename it. | No |
 | `EMAIL_FROM` | no | Your verified sending address (e.g., `tutor@yourdomain.com`) | No |
 | `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config. Defaults to `""` — required before going public. The contact line is hidden when absent. | No |
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
@@ -64,7 +64,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
 
-You can skip `RESEND_API_KEY`, `PARENT_EMAIL`, and `EMAIL_FROM` if you don't want email transcripts.  The app will work without them.
+You can skip `RESEND_API_KEY`, `ADMIN_EMAIL`, and `EMAIL_FROM` if you don't want email transcripts.  The app will work without them.
 
 `PORT` does not need to be set — Render sets it automatically.
 
@@ -140,7 +140,7 @@ export SUPABASE_ANON_KEY=eyJ...
 
 # Optional — emails are silently skipped if absent
 export RESEND_API_KEY=re_...
-export PARENT_EMAIL=you@yourdomain.com
+export ADMIN_EMAIL=you@yourdomain.com
 export EMAIL_FROM=tutor@tutor.yourdomain.com
 
 # Optional — set to "true" to allow users to switch prompt versions in the UI.
@@ -242,7 +242,7 @@ Understanding how a tutoring session moves through the system:
 
 ### Email transcripts not arriving
 
-- **Missing keys:** Both `RESEND_API_KEY` and `PARENT_EMAIL` must be set.  If either is absent, emails are silently skipped.
+- **Missing keys:** Both `RESEND_API_KEY` and `ADMIN_EMAIL` must be set.  If either is absent, emails are silently skipped.  (The variable was previously named `PARENT_EMAIL`.)
 - **Domain not verified:** The `EMAIL_FROM` address must match a domain verified in your Resend dashboard.  Check Resend → Domains for verification status.
 - **Session too short:** Emails are only sent when a session has at least one exchange (transcript length > 0).
 

--- a/env.sh.template
+++ b/env.sh.template
@@ -27,7 +27,7 @@ export SUPABASE_ANON_KEY=""           # Required. Anon/public key. Enables /api/
 # ---------------------------------------------------------------------------
 
 export RESEND_API_KEY=""              # Get from https://resend.com/api-keys
-export PARENT_EMAIL=""                # Recipient address for transcripts and feedback
+export ADMIN_EMAIL=""                 # Recipient address for transcript and evaluation emails (admin)
 export EMAIL_FROM="tutor@tutor.schmim.com"  # Sender address (default: tutor@tutor.schmim.com)
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -11,19 +11,24 @@
  *   SYSTEM_PROMPT_PATH  — path to prompt file, relative to repo root
  *   PORT                — HTTP port for the API server (default: 3000)
  */
+import path from "path";
+
 export interface Config {
   model: string;
   extendedThinking: boolean;
   systemPromptPath: string;
+  defaultPromptName: string;
   port: number;
 }
 
 export function loadConfig(): Config {
+  const systemPromptPath =
+    process.env.SYSTEM_PROMPT_PATH ?? "templates/tutor-prompt-v7.md";
   return {
     model: process.env.MODEL ?? "claude-sonnet-4-6",
     extendedThinking: process.env.EXTENDED_THINKING !== "false",
-    systemPromptPath:
-      process.env.SYSTEM_PROMPT_PATH ?? "templates/tutor-prompt-v7.md",
+    systemPromptPath,
+    defaultPromptName: path.basename(systemPromptPath, ".md"),
     port: parseInt(process.env.PORT ?? "3000", 10),
   };
 }

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -28,7 +28,7 @@ import { sendTranscript } from "@ai-tutor/email";
 await sendTranscript(
   {
     apiKey: process.env.RESEND_API_KEY,
-    to: process.env.PARENT_EMAIL,
+    to: process.env.ADMIN_EMAIL,
     from: process.env.EMAIL_FROM ?? "tutor@tutor.schmim.com",
   },
   {
@@ -125,7 +125,7 @@ type ClientInfo = { ip?: string; geo?: Record<string, unknown>; userAgent?: stri
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `RESEND_API_KEY` | no | Resend API key. Email is silently skipped if missing. |
-| `PARENT_EMAIL` | no | Recipient for transcripts. Skipped if missing. |
+| `ADMIN_EMAIL` | no | Recipient for admin transcripts. Skipped if missing. Renamed from `PARENT_EMAIL`. |
 | `EMAIL_FROM` | no | Sender address. Must match a verified Resend domain. |
 
 ## Setup

--- a/packages/email/src/transcript.ts
+++ b/packages/email/src/transcript.ts
@@ -284,7 +284,7 @@ export async function sendTranscript(
     return;
   }
   if (!config.to) {
-    console.warn("[email] PARENT_EMAIL not set — skipping transcript email.");
+    console.warn("[email] ADMIN_EMAIL not set — skipping transcript email.");
     return;
   }
   if (payload.transcript.length === 0) {

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
         sync: false
       - key: RESEND_API_KEY
         sync: false
-      - key: PARENT_EMAIL
+      - key: ADMIN_EMAIL
         sync: false
       - key: EMAIL_FROM
         sync: false


### PR DESCRIPTION
Closes #204.

## Summary
- Renames `PARENT_EMAIL` env var to `ADMIN_EMAIL` across runtime, env template, render.yaml, and documentation. The recipient is the administrator of a multi-user product, not a parent.
- Refactors `createSessionsRouter()` to accept the full `Config` object rather than three positional args (`defaultModel`, `defaultPromptName`, `defaultExtendedThinking`). Adds `defaultPromptName` to the `Config` interface as a single source of truth derived from `systemPromptPath`.
- Prepares the signature for #205 (`autoEvaluate`) and #206 (`evaluationModel`) to be read from `config` without further signature churn.

## Breaking change
Existing deployments that still set `PARENT_EMAIL` must rename the env var to `ADMIN_EMAIL`. Leaving the old name unset means admin transcript emails are silently skipped (same behaviour as when the variable was unset before the rename). Noted in `docs/deployment.md` and `CLAUDE.md`.

## Test plan
- [x] `npm run build` passes
- [x] `grep -r PARENT_EMAIL .` returns only intentional migration-note references in docs
- [ ] Manual: start server with `ADMIN_EMAIL` set and confirm admin transcript email arrives after ending a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)