### PR TITLE
feat: EVALUATION_MODEL env var for transcript evaluation (#206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | AUTO_EVALUATE | no | true | core, api | Set `"false"` to disable the automatic transcript evaluation that runs on session end (inactivity sweep + explicit DELETE). When disabled, `session_evaluations` rows are not created inline; use `scripts/backfill-evaluations.ts` to evaluate sessions out-of-band. |
+| EVALUATION_MODEL | no | claude-haiku-4-5-20251001 | core, api | Claude model ID used for automated transcript evaluation. Default matches the previously hardcoded value. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
 | CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
@@ -417,7 +418,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `ADMIN_EMAIL` is absent, emails are silently skipped.
 
-The evaluation model (`claude-haiku-4-5-20251001`) is hardcoded in `packages/core/src/evaluate-transcript.ts`, not configurable via environment variable.
+The evaluation model defaults to `claude-haiku-4-5-20251001` (exported as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`) and can be overridden via the `EVALUATION_MODEL` env var.
 
 ---
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -159,7 +159,7 @@ setInterval(() => {
           try {
             const [evalResult, feedback, userInfo] = await Promise.all([
               config.autoEvaluate
-                ? runSessionEvaluation(db, sessionId, session.transcript)
+                ? runSessionEvaluation(db, sessionId, session.transcript, config.evaluationModel)
                 : Promise.resolve(null),
               getOrCreateTimeoutFeedback(db, sessionId, "sweep"),
               getUserInfoForSession(db, sessionId).catch(() => null),

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -99,10 +99,11 @@ export async function getOrCreateTimeoutFeedback(
 export async function runSessionEvaluation(
   db: SupabaseClient,
   sessionId: string,
-  transcript: Array<{ role: string; text: string }>
+  transcript: Array<{ role: string; text: string }>,
+  evaluationModel?: string,
 ): Promise<EvaluationResult | null> {
   try {
-    const result = await evaluateTranscript(transcript);
+    const result = await evaluateTranscript(transcript, evaluationModel ? { model: evaluationModel } : undefined);
     await upsertSessionEvaluation(db, {
       session_id: sessionId,
       model: result.model,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -79,7 +79,7 @@ export function createSessionsRouter(
         if (!discard && session && !session.emailSent && session.transcript.length > 0) {
           const [evalResult, feedback, userInfo] = await Promise.all([
             config.autoEvaluate
-              ? runSessionEvaluation(db, sessionId, session.transcript)
+              ? runSessionEvaluation(db, sessionId, session.transcript, config.evaluationModel)
               : Promise.resolve(null),
             getOrCreateTimeoutFeedback(db, sessionId, "sessions"),
             getUserInfoForSession(db, sessionId).catch(() => null),

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `AUTO_EVALUATE` | no | Default: `true`; set `false` to disable the automatic transcript evaluation that runs on session end. When disabled, `session_evaluations` rows are not created inline — use `scripts/backfill-evaluations.ts` for out-of-band evaluation. | No |
+| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5-20251001`. Claude model ID used for automated transcript evaluation. | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
 | `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
@@ -251,7 +252,7 @@ Understanding how a tutoring session moves through the system:
 
 ### Evaluation fails
 
-- **Model access:** The evaluation uses `claude-sonnet-4-6` by default (hardcoded in `packages/core/src/evaluate-transcript.ts`).  Your API key must have access to that model.
+- **Model access:** The evaluation defaults to `claude-haiku-4-5-20251001` and can be overridden via the `EVALUATION_MODEL` env var.  Your API key must have access to the configured model.
 - **Check server logs:** Evaluation errors are logged as `[evaluation] Failed to evaluate session <id>`.  The session still ends normally — evaluation failure doesn't block cleanup.
 
 ### Session not found (404)

--- a/env.sh.template
+++ b/env.sh.template
@@ -32,6 +32,10 @@ export ADMIN_EMAIL=""                 # Recipient address for transcript and eva
 # Set to "false" to disable the automatic transcript evaluation that runs on
 # session end (inactivity sweep + explicit DELETE). Default enabled.
 export AUTO_EVALUATE="true"
+
+# Claude model ID used for automated transcript evaluation.
+# Default: claude-haiku-4-5-20251001 (fast, cheap). Override to use a different model.
+export EVALUATION_MODEL=""
 export EMAIL_FROM="tutor@tutor.schmim.com"  # Sender address (default: tutor@tutor.schmim.com)
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,6 +12,7 @@
  *   PORT                — HTTP port for the API server (default: 3000)
  */
 import path from "path";
+import { DEFAULT_EVALUATION_MODEL } from "./evaluate-transcript.js";
 
 export interface Config {
   model: string;
@@ -20,6 +21,7 @@ export interface Config {
   defaultPromptName: string;
   port: number;
   autoEvaluate: boolean;
+  evaluationModel: string;
 }
 
 export function loadConfig(): Config {
@@ -32,5 +34,6 @@ export function loadConfig(): Config {
     defaultPromptName: path.basename(systemPromptPath, ".md"),
     port: parseInt(process.env.PORT ?? "3000", 10),
     autoEvaluate: process.env.AUTO_EVALUATE !== "false",
+    evaluationModel: process.env.EVALUATION_MODEL ?? DEFAULT_EVALUATION_MODEL,
   };
 }

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -4,6 +4,9 @@ import { loadPromptFile } from "./prompt-loader.js";
 /** Load the evaluation prompt from the co-located .md file (single source of truth). */
 const EVALUATION_PROMPT = loadPromptFile("packages/core/src/evaluation-prompt.md");
 
+/** Default model for automated transcript evaluation. Overridable via EVALUATION_MODEL env var. */
+export const DEFAULT_EVALUATION_MODEL = "claude-haiku-4-5-20251001";
+
 export interface EvaluationResult {
   model: string;
   session_mode: string;
@@ -49,7 +52,7 @@ export async function evaluateTranscript(
   transcript: Array<{ role: string; text: string }>,
   config?: { model?: string }
 ): Promise<EvaluationResult> {
-  const model = config?.model ?? "claude-haiku-4-5-20251001";
+  const model = config?.model ?? DEFAULT_EVALUATION_MODEL;
 
   const formattedTranscript = transcript
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,5 +16,5 @@ export type {
 export { createTutorClient } from "./tutor-client.js";
 export type { TutorClient } from "./tutor-client.js";
 
-export { evaluateTranscript } from "./evaluate-transcript.js";
+export { evaluateTranscript, DEFAULT_EVALUATION_MODEL } from "./evaluate-transcript.js";
 export type { EvaluationResult } from "./evaluate-transcript.js";


### PR DESCRIPTION
Closes #206.

## Summary
- Extracts the previously hardcoded evaluation model string (`claude-haiku-4-5-20251001`) into an exported `DEFAULT_EVALUATION_MODEL` constant in `packages/core/src/evaluate-transcript.ts`.
- Adds `EVALUATION_MODEL` env var (`Config.evaluationModel`) that overrides the default. Defaults match the existing hardcoded value, so behaviour is unchanged for deployments that do not set the variable.
- Threads `config.evaluationModel` through `runSessionEvaluation()` into `evaluateTranscript()` from both the inactivity sweep and the `DELETE /api/sessions/:id` handler.

## Test plan
- [x] `npm run build` passes
- [ ] Manual: set `EVALUATION_MODEL=claude-sonnet-4-6`, end a session, confirm the `session_evaluations.model` row reflects the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)