### PR TITLE
feat: prompt caching, adaptive thinking, shared client, model alias fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ Get non-secret runtime config.
   "extendedThinking": true,
   "inactivityMs": 600000,
   "contactEmail": "",
-  "availableModels": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"],
+  "availableModels": ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"],
   "availablePrompts": ["tutor-prompt-v7", "tutor-prompt-v6"],
   "defaultPrompt": "tutor-prompt-v7",
   "buildVersion": "abc1234",
@@ -409,7 +409,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | AUTO_EVALUATE | no | true | core, api | Set `"false"` to disable the automatic transcript evaluation that runs on session end (inactivity sweep + explicit DELETE). When disabled, `session_evaluations` rows are not created inline; use `scripts/backfill-evaluations.ts` to evaluate sessions out-of-band. |
-| EVALUATION_MODEL | no | claude-haiku-4-5-20251001 | core, api | Claude model ID used for automated transcript evaluation. Default matches the previously hardcoded value. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
+| EVALUATION_MODEL | no | claude-haiku-4-5 | core, api | Claude model ID used for automated transcript evaluation. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
 | CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
@@ -418,7 +418,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `ADMIN_EMAIL` is absent, emails are silently skipped.
 
-The evaluation model defaults to `claude-haiku-4-5-20251001` (exported as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`) and can be overridden via the `EVALUATION_MODEL` env var.
+The evaluation model defaults to `claude-haiku-4-5` (exported as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`) and can be overridden via the `EVALUATION_MODEL` env var.
 
 ---
 

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -4,7 +4,7 @@ export const UUID_RE =
 
 /** Model IDs accepted by the chat and config routes. */
 export const ALLOWED_MODELS = new Set([
-  "claude-haiku-4-5-20251001",
+  "claude-haiku-4-5",
   "claude-sonnet-4-6",
   "claude-opus-4-6",
 ]);

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `AUTO_EVALUATE` | no | Default: `true`; set `false` to disable the automatic transcript evaluation that runs on session end. When disabled, `session_evaluations` rows are not created inline — use `scripts/backfill-evaluations.ts` for out-of-band evaluation. | No |
-| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5-20251001`. Claude model ID used for automated transcript evaluation. | No |
+| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5`. Claude model ID used for automated transcript evaluation. | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
 | `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
@@ -252,7 +252,7 @@ Understanding how a tutoring session moves through the system:
 
 ### Evaluation fails
 
-- **Model access:** The evaluation defaults to `claude-haiku-4-5-20251001` and can be overridden via the `EVALUATION_MODEL` env var.  Your API key must have access to the configured model.
+- **Model access:** The evaluation defaults to `claude-haiku-4-5` and can be overridden via the `EVALUATION_MODEL` env var.  Your API key must have access to the configured model.
 - **Check server logs:** Evaluation errors are logged as `[evaluation] Failed to evaluate session <id>`.  The session still ends normally — evaluation failure doesn't block cleanup.
 
 ### Session not found (404)

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,19 +119,13 @@
       "resolved": "apps/web",
       "link": true
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -357,16 +351,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
@@ -438,18 +422,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -461,18 +433,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -522,12 +482,6 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -667,18 +621,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -808,15 +750,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -1018,21 +951,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1046,15 +964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -1177,41 +1086,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -1356,21 +1230,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1445,15 +1304,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -1647,6 +1497,19 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lazy": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
@@ -1833,46 +1696,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/nopt": {
@@ -2483,10 +2306,10 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -2565,31 +2388,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -2745,10 +2543,30 @@
       "name": "@ai-tutor/core",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0"
+        "@anthropic-ai/sdk": "^0.90.0"
       },
       "devDependencies": {
         "typescript": "^5.4.0"
+      }
+    },
+    "packages/core/node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "packages/db": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0"
+    "@anthropic-ai/sdk": "^0.90.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -1,5 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
-import { anthropicClient } from "./tutor-client.js";
+import { anthropicClient, cachedSystem } from "./tutor-client.js";
 import { loadPromptFile } from "./prompt-loader.js";
 
 /** Load the evaluation prompt from the co-located .md file (single source of truth). */
@@ -62,7 +62,7 @@ export async function evaluateTranscript(
   const response = await anthropicClient.messages.create({
     model,
     max_tokens: 2000,
-    system: [{ type: "text", text: EVALUATION_PROMPT, cache_control: { type: "ephemeral" } }],
+    system: cachedSystem(EVALUATION_PROMPT),
     messages: [{ role: "user", content: formattedTranscript }],
   });
 

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -1,11 +1,12 @@
-import Anthropic from "@anthropic-ai/sdk";
+import type Anthropic from "@anthropic-ai/sdk";
+import { anthropicClient } from "./tutor-client.js";
 import { loadPromptFile } from "./prompt-loader.js";
 
 /** Load the evaluation prompt from the co-located .md file (single source of truth). */
 const EVALUATION_PROMPT = loadPromptFile("packages/core/src/evaluation-prompt.md");
 
 /** Default model for automated transcript evaluation. Overridable via EVALUATION_MODEL env var. */
-export const DEFAULT_EVALUATION_MODEL = "claude-haiku-4-5-20251001";
+export const DEFAULT_EVALUATION_MODEL = "claude-haiku-4-5";
 
 export interface EvaluationResult {
   model: string;
@@ -58,12 +59,10 @@ export async function evaluateTranscript(
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)
     .join("\n");
 
-  const client = new Anthropic();
-
-  const response = await client.messages.create({
+  const response = await anthropicClient.messages.create({
     model,
     max_tokens: 2000,
-    system: EVALUATION_PROMPT,
+    system: [{ type: "text", text: EVALUATION_PROMPT, cache_control: { type: "ephemeral" } }],
     messages: [{ role: "user", content: formattedTranscript }],
   });
 

--- a/packages/core/src/tutor-client.ts
+++ b/packages/core/src/tutor-client.ts
@@ -2,6 +2,9 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { Config } from "./config.js";
 import type { Session, TokenUsage } from "./session.js";
 
+/** Shared Anthropic client — one connection pool for all API calls. */
+export const anthropicClient = new Anthropic();
+
 type UserContent = string | Anthropic.ContentBlockParam[];
 
 export interface StreamOptions {
@@ -40,10 +43,10 @@ function buildParams(
   return {
     model,
     max_tokens: 16000,
-    system: prompt,
+    system: [{ type: "text" as const, text: prompt, cache_control: { type: "ephemeral" as const } }],
     messages: session.messages as Anthropic.MessageParam[],
     ...(extendedThinking && {
-      thinking: { type: "enabled" as const, budget_tokens: 10000 },
+      thinking: { type: "adaptive" as const },
     }),
   } satisfies Omit<Anthropic.MessageCreateParams, "stream">;
 }
@@ -58,7 +61,7 @@ function buildParams(
  *                     yielded.  The Session is updated after the stream ends.
  */
 export function createTutorClient(config: Config, systemPrompt: string) {
-  const client = new Anthropic();
+  const client = anthropicClient;
 
   /**
    * Send a message and wait for the complete response.

--- a/packages/core/src/tutor-client.ts
+++ b/packages/core/src/tutor-client.ts
@@ -5,6 +5,11 @@ import type { Session, TokenUsage } from "./session.js";
 /** Shared Anthropic client — one connection pool for all API calls. */
 export const anthropicClient = new Anthropic();
 
+/** Wraps a prompt string into the system array shape required for prompt caching. */
+export function cachedSystem(text: string): Anthropic.Messages.TextBlockParam[] {
+  return [{ type: "text", text, cache_control: { type: "ephemeral" } }];
+}
+
 type UserContent = string | Anthropic.ContentBlockParam[];
 
 export interface StreamOptions {
@@ -43,7 +48,7 @@ function buildParams(
   return {
     model,
     max_tokens: 16000,
-    system: [{ type: "text" as const, text: prompt, cache_control: { type: "ephemeral" as const } }],
+    system: cachedSystem(prompt),
     messages: session.messages as Anthropic.MessageParam[],
     ...(extendedThinking && {
       thinking: { type: "adaptive" as const },
@@ -61,8 +66,6 @@ function buildParams(
  *                     yielded.  The Session is updated after the stream ends.
  */
 export function createTutorClient(config: Config, systemPrompt: string) {
-  const client = anthropicClient;
-
   /**
    * Send a message and wait for the complete response.
    *
@@ -77,7 +80,7 @@ export function createTutorClient(config: Config, systemPrompt: string) {
     session.addUserMessage(userContent, transcriptText);
     session.touchActivity();
 
-    const response = await client.messages.create({
+    const response = await anthropicClient.messages.create({
       ...buildParams(config, systemPrompt, session, opts),
       stream: false,
     } as Anthropic.MessageCreateParamsNonStreaming);
@@ -108,7 +111,7 @@ export function createTutorClient(config: Config, systemPrompt: string) {
     session.addUserMessage(userContent, transcriptText);
     session.touchActivity();
 
-    const stream = client.messages.stream(
+    const stream = anthropicClient.messages.stream(
       buildParams(config, systemPrompt, session, opts) as Anthropic.MessageCreateParamsStreaming
     );
 


### PR DESCRIPTION
## Summary

- **Prompt caching**: adds `cache_control: { type: "ephemeral" }` to the system prompt in `tutor-client.ts` and to the evaluation prompt in `evaluate-transcript.ts`. After the first call in any 5-minute window, subsequent calls read both prompts from cache at ~0.1× input cost — roughly 50–80% savings on cached portions for multi-turn sessions.
- **Adaptive thinking**: replaces deprecated `{ type: "enabled", budget_tokens: 10000 }` with `{ type: "adaptive" }`, which is forward-compatible with Opus 4.7 (where `budget_tokens` is fully removed and returns HTTP 400).
- **Shared Anthropic client**: exports a single `anthropicClient` instance from `tutor-client.ts`; `evaluate-transcript.ts` now imports and reuses it instead of constructing its own.
- **Model alias fix**: changes `DEFAULT_EVALUATION_MODEL` from `claude-haiku-4-5-20251001` (full versioned ID) to `claude-haiku-4-5` (alias), consistent with how other models are referenced. Updated `ALLOWED_MODELS`, `CLAUDE.md`, and `docs/deployment.md`.
- **SDK upgrade**: `@anthropic-ai/sdk` `^0.39.0` → `^0.90.0` (required for the `ThinkingConfigAdaptive` TypeScript type — not present in the older SDK).

Closes #210

## Test plan

- [ ] Build passes: `npm run build` from repo root — all 5 packages compile cleanly ✅
- [ ] Start server: `npm run api` — confirm startup with no errors
- [ ] Send 3+ chat messages in a session; check server logs for `cache_read_input_tokens > 0` on turns 2+ (or add a temp `console.log` on `finalMessage.usage`)
- [ ] End a session normally — confirm evaluation still writes a row to `session_evaluations` and email is sent
- [ ] Verify Haiku model still works: send a chat with `model=claude-haiku-4-5` override (should be in `ALLOWED_MODELS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)