### PR TITLE
fix: make AUTO_EVALUATE check case-insensitive

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -33,7 +33,7 @@ export function loadConfig(): Config {
     systemPromptPath,
     defaultPromptName: path.basename(systemPromptPath, ".md"),
     port: parseInt(process.env.PORT ?? "3000", 10),
-    autoEvaluate: process.env.AUTO_EVALUATE !== "false",
+    autoEvaluate: process.env.AUTO_EVALUATE?.toLowerCase() !== "false",
     evaluationModel: process.env.EVALUATION_MODEL ?? DEFAULT_EVALUATION_MODEL,
   };
 }


### PR DESCRIPTION
## Summary

`process.env.AUTO_EVALUATE !== "false"` was case-sensitive — setting the env var to `"False"` or `"FALSE"` on Render would leave evaluation enabled. Changed to `.toLowerCase() !== "false"` so any casing works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)