### PR TITLE
debug: expose autoEvaluate in GET /api/config

### DIFF
--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -41,6 +41,7 @@ export function createConfigRouter(
     res.json({
       model: config.model,
       extendedThinking: config.extendedThinking,
+      autoEvaluate: config.autoEvaluate,
       inactivityMs,
       contactEmail: process.env.CONTACT_EMAIL ?? "",
       availableModels: [...ALLOWED_MODELS],


### PR DESCRIPTION
Exposes config.autoEvaluate in the /api/config response so we can verify the server is reading AUTO_EVALUATE correctly.