### PR TITLE
fix: revert Haiku model ID to full versioned form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ Get non-secret runtime config.
   "extendedThinking": true,
   "inactivityMs": 600000,
   "contactEmail": "",
-  "availableModels": ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"],
+  "availableModels": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"],
   "availablePrompts": ["tutor-prompt-v7", "tutor-prompt-v6"],
   "defaultPrompt": "tutor-prompt-v7",
   "buildVersion": "abc1234",
@@ -409,7 +409,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
 | AUTO_EVALUATE | no | true | core, api | Set `"false"` to disable the automatic transcript evaluation that runs on session end (inactivity sweep + explicit DELETE). When disabled, `session_evaluations` rows are not created inline; use `scripts/backfill-evaluations.ts` to evaluate sessions out-of-band. |
-| EVALUATION_MODEL | no | claude-haiku-4-5 | core, api | Claude model ID used for automated transcript evaluation. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
+| EVALUATION_MODEL | no | claude-haiku-4-5-20251001 | core, api | Claude model ID used for automated transcript evaluation. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
 | CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
@@ -418,7 +418,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 
 `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` are required for the API server.  If `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is absent, the server will not start.  If `SUPABASE_ANON_KEY` is absent, the auth router is not registered and the app will be inaccessible.  The CLI (`apps/cli`) does not use the database and runs without these variables.  If `RESEND_API_KEY` or `ADMIN_EMAIL` is absent, emails are silently skipped.
 
-The evaluation model defaults to `claude-haiku-4-5` (exported as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`) and can be overridden via the `EVALUATION_MODEL` env var.
+The evaluation model defaults to `claude-haiku-4-5-20251001` (exported as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`) and can be overridden via the `EVALUATION_MODEL` env var.
 
 ---
 

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -4,7 +4,7 @@ export const UUID_RE =
 
 /** Model IDs accepted by the chat and config routes. */
 export const ALLOWED_MODELS = new Set([
-  "claude-haiku-4-5",
+  "claude-haiku-4-5-20251001",
   "claude-sonnet-4-6",
   "claude-opus-4-6",
 ]);

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
 | `AUTO_EVALUATE` | no | Default: `true`; set `false` to disable the automatic transcript evaluation that runs on session end. When disabled, `session_evaluations` rows are not created inline — use `scripts/backfill-evaluations.ts` for out-of-band evaluation. | No |
-| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5`. Claude model ID used for automated transcript evaluation. | No |
+| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5-20251001`. Claude model ID used for automated transcript evaluation. | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
 | `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |
@@ -252,7 +252,7 @@ Understanding how a tutoring session moves through the system:
 
 ### Evaluation fails
 
-- **Model access:** The evaluation defaults to `claude-haiku-4-5` and can be overridden via the `EVALUATION_MODEL` env var.  Your API key must have access to the configured model.
+- **Model access:** The evaluation defaults to `claude-haiku-4-5-20251001` and can be overridden via the `EVALUATION_MODEL` env var.  Your API key must have access to the configured model.
 - **Check server logs:** Evaluation errors are logged as `[evaluation] Failed to evaluate session <id>`.  The session still ends normally — evaluation failure doesn't block cleanup.
 
 ### Session not found (404)

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -6,7 +6,7 @@ import { loadPromptFile } from "./prompt-loader.js";
 const EVALUATION_PROMPT = loadPromptFile("packages/core/src/evaluation-prompt.md");
 
 /** Default model for automated transcript evaluation. Overridable via EVALUATION_MODEL env var. */
-export const DEFAULT_EVALUATION_MODEL = "claude-haiku-4-5";
+export const DEFAULT_EVALUATION_MODEL = "claude-haiku-4-5-20251001";
 
 export interface EvaluationResult {
   model: string;


### PR DESCRIPTION
## Summary

PR #211 changed `claude-haiku-4-5-20251001` → `claude-haiku-4-5` assuming it was a valid alias like Sonnet/Opus. It isn't — Haiku requires the full versioned ID. Every evaluation call was silently failing (API model-not-found error caught by the try/catch in `runSessionEvaluation`), returning `null`, and writing no rows to `session_evaluations`. This explained why no Haiku entries appeared in the Claude Console even with `AUTO_EVALUATE=true`.

Reverts the model ID in `DEFAULT_EVALUATION_MODEL`, `ALLOWED_MODELS`, and all docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)