### PR TITLE
fix: rename evaluateTranscript param to remove Config footgun

### DIFF
--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -103,7 +103,7 @@ export async function runSessionEvaluation(
   evaluationModel?: string,
 ): Promise<EvaluationResult | null> {
   try {
-    const result = await evaluateTranscript(transcript, evaluationModel ? { model: evaluationModel } : undefined);
+    const result = await evaluateTranscript(transcript, evaluationModel ? { evaluationModel } : undefined);
     await upsertSessionEvaluation(db, {
       session_id: sessionId,
       model: result.model,

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -51,9 +51,9 @@ const ALL_DIMENSION_KEYS: (keyof EvaluationResult)[] = [
 
 export async function evaluateTranscript(
   transcript: Array<{ role: string; text: string }>,
-  config?: { model?: string }
+  opts?: { evaluationModel?: string }
 ): Promise<EvaluationResult> {
-  const model = config?.model ?? DEFAULT_EVALUATION_MODEL;
+  const model = opts?.evaluationModel ?? DEFAULT_EVALUATION_MODEL;
 
   const formattedTranscript = transcript
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)


### PR DESCRIPTION
## Summary

`evaluateTranscript(transcript, config?: { model?: string })` was structurally compatible with the application `Config` object (which also has `model: string`). A future caller could accidentally pass `config` and silently use Sonnet for evaluations instead of Haiku.

Renamed to `opts?: { evaluationModel?: string }` — now TypeScript would reject an accidental `Config` argument at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)