### PR TITLE
refactor: simplify evaluateTranscript signature

### DIFF
--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -103,7 +103,7 @@ export async function runSessionEvaluation(
   evaluationModel?: string,
 ): Promise<EvaluationResult | null> {
   try {
-    const result = await evaluateTranscript(transcript, evaluationModel ? { evaluationModel } : undefined);
+    const result = await evaluateTranscript(transcript, evaluationModel);
     await upsertSessionEvaluation(db, {
       session_id: sessionId,
       model: result.model,

--- a/packages/core/src/evaluate-transcript.ts
+++ b/packages/core/src/evaluate-transcript.ts
@@ -51,9 +51,9 @@ const ALL_DIMENSION_KEYS: (keyof EvaluationResult)[] = [
 
 export async function evaluateTranscript(
   transcript: Array<{ role: string; text: string }>,
-  opts?: { evaluationModel?: string }
+  evaluationModel?: string
 ): Promise<EvaluationResult> {
-  const model = opts?.evaluationModel ?? DEFAULT_EVALUATION_MODEL;
+  const model = evaluationModel ?? DEFAULT_EVALUATION_MODEL;
 
   const formattedTranscript = transcript
     .map((entry, i) => `${i + 1}. [${entry.role}] ${entry.text}`)


### PR DESCRIPTION
Drop the opts wrapper — the parameter is just a plain string.