### PR TITLE
fix: guard rationale[key] against undefined in buildEvaluationPayload

### DIFF
--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -28,7 +28,7 @@ export function buildEvaluationPayload(result: EvaluationResult) {
     dimensions: DIMENSION_KEYS.map(key => ({
       label: DIMENSION_LABELS[key],
       score: result[key as keyof EvaluationResult] as string,
-      rationale: result.rationale[key],
+      rationale: result.rationale[key] ?? "",
     })),
     hasFailures: result.has_failures,
   };


### PR DESCRIPTION
## Summary

`result.rationale[key]` returns `undefined` when the evaluation model omits a rationale for a dimension. This is typed as `Record<string, string>` but not enforced at runtime. `escapeHtml` then crashes on `.replace()` with `TypeError: Cannot read properties of undefined`.

Added `?? ""` fallback in `buildEvaluationPayload` so the value is always a string before reaching the email template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)