### PR TITLE
fix: batch eval always sends admin email; guard concurrent processing

### DIFF
--- a/apps/api/src/lib/batch-evaluation.ts
+++ b/apps/api/src/lib/batch-evaluation.ts
@@ -266,11 +266,6 @@ export async function processBatchResults(
         continue;
       }
 
-      if (dbSession.email_sent) {
-        outcome.skipped += 1;
-        continue;
-      }
-
       const [messages, userProfile, feedback] = await Promise.all([
         getMessagesBySession(db, sessionId),
         getUserProfileForSession(db, sessionId).catch(() => null),
@@ -285,14 +280,16 @@ export async function processBatchResults(
         userProfile,
       );
 
-      try {
-        await sendTranscript(opts.emailConfig, payload);
-        if (opts.emailConfig.apiKey && opts.emailConfig.to) {
+      if (opts.emailConfig.apiKey && opts.emailConfig.to) {
+        try {
+          await sendTranscript(opts.emailConfig, payload);
           await updateSession(db, sessionId, { email_sent: true });
           outcome.emailsSent += 1;
+        } catch (err) {
+          console.error(`[batch-eval] Failed to send admin transcript for ${sessionId}:`, err);
         }
-      } catch (err) {
-        console.error(`[batch-eval] Failed to send admin transcript for ${sessionId}:`, err);
+      } else {
+        outcome.skipped += 1;
       }
 
       // Fire-and-forget student copy. Never throws.

--- a/apps/api/src/routes/admin-evaluations.ts
+++ b/apps/api/src/routes/admin-evaluations.ts
@@ -16,6 +16,9 @@ import {
   MAX_BATCH_SIZE,
 } from "../lib/batch-evaluation.js";
 
+/** Tracks batch IDs currently being processed to prevent concurrent re-entry. */
+const processingBatchIds = new Set<string>();
+
 export function createAdminEvaluationsRouter(
   db: SupabaseClient,
   config: Config,
@@ -102,12 +105,21 @@ export function createAdminEvaluationsRouter(
       }
 
       if (batch.status === "ended") {
-        const outcome = await processBatchResults(db, batch, {
-          emailConfig,
-          evaluationModel: config.evaluationModel,
-        });
-        const processed = await getEvaluationBatch(db, id);
-        res.json({ ok: true, batch: processed ?? batch, outcome });
+        if (processingBatchIds.has(batch.id)) {
+          res.json({ ok: true, batch });
+          return;
+        }
+        processingBatchIds.add(batch.id);
+        try {
+          const outcome = await processBatchResults(db, batch, {
+            emailConfig,
+            evaluationModel: config.evaluationModel,
+          });
+          const processed = await getEvaluationBatch(db, id);
+          res.json({ ok: true, batch: processed ?? batch, outcome });
+        } finally {
+          processingBatchIds.delete(batch.id);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

- **0 emails sent bug**: `processBatchResults` was skipping the admin transcript email when `email_sent=true` on the session. This fires when `AUTO_EVALUATE=false`: the inactivity sweep sends a no-evaluation email at session-end (setting `email_sent=true`), then the batch evaluator computes the evaluation but skips the email because the flag is already set. Fix: remove the `email_sent` check from the batch path — the batch's whole purpose is to send the email *with* evaluation. `skipped` is repurposed to count sessions where `emailConfig.apiKey`/`to` are missing (no-op).

- **3x processing log**: `GET /batches/:id` had no concurrency guard. Simultaneous poll requests all saw `status=ended` and each ran `processBatchResults` to completion. Fix: module-level `processingBatchIds` Set prevents concurrent re-entry for the same batch ID on a single-process server.

## For the 6 already-processed sessions

Those sessions now have `evaluated=true` and `email_sent=true` (set by the sweep, not the batch). They won't appear in future batch runs. To get evaluation emails for them, reset both flags in the DB:
```sql
UPDATE sessions SET evaluated = false, email_sent = false WHERE id IN (...);
```
Then re-run the batch via the admin page.

## Test plan
- [ ] Deploy and run a new batch against sessions that had `email_sent=true` — confirm emails arrive with evaluation results
- [ ] Open the admin batch detail page and click poll rapidly — confirm log shows "Processed batch..." only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)