### PR TITLE
Remove automated transcript evaluator (#228)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ The model appends `[END_SESSION_AVAILABLE]` on its own line when a conversation 
 
 ### In-memory session store + database
 
-Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — running an automated evaluation, recording a `source: 'timeout'` feedback row if none exists, sending an email transcript (including evaluation and feedback), and marking the session ended in the DB.  When a session is explicitly ended via `DELETE /api/sessions/:id`, the same evaluation + feedback fetch happens before the transcript email is sent.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.
+Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — recording a `source: 'timeout'` feedback row if none exists, sending an email transcript (including feedback), and marking the session ended in the DB.  When a session is explicitly ended via `DELETE /api/sessions/:id`, the same feedback fetch happens before the transcript email is sent.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.  Transcript evaluation runs out-of-band via the admin-gated batch evaluator (see `apps/api/src/routes/admin-evaluations.ts`).
 
 The inactivity timeout (`INACTIVITY_MS`) is defined as a constant in `apps/api/src/index.ts` and served via `GET /api/config` as `inactivityMs` so the frontend stays in sync with the server-side sweep.  The frontend uses the same value to trigger its own auto-end flow after the same duration of client-side inactivity.
 
@@ -145,7 +145,7 @@ Managed via `supabase/migrations/*.sql`. RLS is enabled on all user-facing table
 | prompt_name | text | null | Tutor prompt filename stem used for this session (e.g. "tutor-prompt-v7"). Set on first message. |
 | extended_thinking | boolean | true | Whether extended thinking was enabled for this session. Set on first message; user-controllable via the header thinking badge. |
 | user_id | uuid | null | FK → auth.users(id) ON DELETE SET NULL. Populated for sessions initiated by authenticated users via the Supabase auth flow. Partial index `sessions_user_id` on non-null values. |
-| evaluated | boolean | false | Set to true after `runSessionEvaluation()` successfully writes a `session_evaluations` row, or after `processBatchResults()` persists a batched evaluation. Used by out-of-band evaluation jobs (including the admin batch endpoints) to skip already-evaluated sessions. Migration 006 added the column; migration 007 back-filled it for sessions with pre-existing evaluation rows. |
+| evaluated | boolean | false | Set to true after `processBatchResults()` persists a batched evaluation. Used by the batched evaluation subsystem to skip already-evaluated sessions. Migration 006 added the column; migration 007 back-filled it for sessions with pre-existing evaluation rows. |
 
 ### messages
 
@@ -282,7 +282,6 @@ Get non-secret runtime config.
 {
   "model": "claude-sonnet-4-6",
   "extendedThinking": true,
-  "autoEvaluate": true,
   "inactivityMs": 600000,
   "contactEmail": "",
   "availableModels": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"],
@@ -445,8 +444,7 @@ All configuration comes from environment variables.  No `.env` files are committ
 | CORS_ORIGIN | no | false (fail-closed) | api | Allowed CORS origin. When unset, all cross-origin requests are rejected. Set explicitly for all deployments. |
 | MODEL | no | claude-sonnet-4-6 | core | Claude model ID |
 | EXTENDED_THINKING | no | true | core | Set "false" to disable |
-| AUTO_EVALUATE | no | true | core, api | Set `"false"` to disable the automatic transcript evaluation that runs on session end (inactivity sweep + explicit DELETE). When disabled, `session_evaluations` rows are not created inline; use `scripts/backfill-evaluations.ts` to evaluate sessions out-of-band. |
-| EVALUATION_MODEL | no | claude-haiku-4-5-20251001 | core, api | Claude model ID used for automated transcript evaluation. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
+| EVALUATION_MODEL | no | claude-haiku-4-5-20251001 | core, api | Claude model ID used by the admin-gated batch transcript evaluator. Exposed as `DEFAULT_EVALUATION_MODEL` from `@ai-tutor/core`. |
 | SYSTEM_PROMPT_PATH | no | templates/tutor-prompt-v7.md | core | Path from repo root |
 | PORT | no | 3000 | api | HTTP listen port |
 | CONTACT_EMAIL | no | `""` | api | Contact email returned by GET /api/config and shown on the login page. Defaults to empty string — required before going public. The login page hides the contact line when this value is empty. |
@@ -510,7 +508,7 @@ These apply to every Claude Code session in this repo.
 | `supabase/migrations/20260412192232_003_profiles.sql` | Creates `profiles` table with `is_admin` column. `is_admin` is dropped by migration 005 (moves to `auth.users.app_metadata`). |
 | `supabase/migrations/20260418025953_004_profile_settings.sql` | Adds `email_transcripts_enabled boolean NOT NULL DEFAULT true` to profiles |
 | `supabase/migrations/20260418072330_005_auth_redesign.sql` | Full auth redesign: truncates all data, drops `disclaimer_acceptances`, drops `profiles.is_admin`, installs `on_auth_user_created` trigger, makes `sessions.user_id NOT NULL`, enables RLS with `auth.uid()` policies on all user-facing tables. |
-| `supabase/migrations/20260421215914_006_auto_evaluate.sql` | Adds `evaluated boolean NOT NULL DEFAULT false` to sessions. Populated by `runSessionEvaluation()` after a successful evaluation; used to skip already-evaluated sessions in out-of-band jobs when `AUTO_EVALUATE` is disabled. |
+| `supabase/migrations/20260421215914_006_auto_evaluate.sql` | Adds `evaluated boolean NOT NULL DEFAULT false` to sessions. Populated by the batched evaluation subsystem after a successful evaluation; used to skip already-evaluated sessions. |
 | `supabase/migrations/20260421221547_007_evaluation_batches.sql` | Creates the `evaluation_batches` table used by the admin-gated batched evaluation subsystem. Also runs a one-time `UPDATE` to reconcile `sessions.evaluated` with pre-existing `session_evaluations` rows so the first batch run doesn't resubmit already-evaluated sessions. |
 | `supabase/migrations/20260422010105_008_policy_fixes.sql` | Updates RLS policies on profiles, sessions, messages, session_feedback, and session_evaluations to use `(SELECT auth.uid())` subquery form. |
 | `templates/tutor-prompt-v7.md` | Production tutor prompt — current version; loaded at runtime via `SYSTEM_PROMPT_PATH` |
@@ -556,7 +554,7 @@ These apply to every Claude Code session in this repo.
 | `apps/api/scripts/gen-build-info.js` | Generates `build-info.json` (commit SHA + timestamp) at build time; called by the API `build` script |
 | `apps/api/build-info.json` | Generated build metadata (gitignored); read at startup by the config route |
 | `apps/api/src/routes/config.ts` | `GET /api/config` |
-| `apps/api/src/lib/evaluation.ts` | `runSessionEvaluation()` — calls `evaluateTranscript`, saves to DB, returns result; `buildEvaluationPayload()` — maps result to email shape; `buildTranscriptEmailPayload()` — assembles full email payload from session data |
+| `apps/api/src/lib/evaluation.ts` | `buildEvaluationPayload()` — maps result to email shape; `buildTranscriptEmailPayload()` — assembles full email payload from session data; helpers for timeout-feedback, marking emails sent, and student-facing transcript dispatch |
 | `apps/api/src/lib/session-store.ts` | In-memory session cache (`Map<id, Session>`) |
 | `apps/api/src/lib/stream.ts` | SSE helpers (`initSSE`, `sendEvent`, `sendHeartbeat`) |
 | `apps/api/src/lib/geo.ts` | `extractClientInfo()` — IP, geolocation, user-agent extraction |

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -37,7 +37,7 @@ For full endpoint reference (request/response schemas, auth requirements, error 
 The API binary reads the following environment variables:
 
 - **Required:** `ANTHROPIC_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`.
-- **Optional:** `RESEND_API_KEY`, `ADMIN_EMAIL`, `EMAIL_FROM`, `CORS_ORIGIN`, `CONTACT_EMAIL`, `ALLOW_PROMPT_SELECTION`, `MODEL`, `EXTENDED_THINKING`, `AUTO_EVALUATE`, `EVALUATION_MODEL`, `SYSTEM_PROMPT_PATH`, `PORT`.
+- **Optional:** `RESEND_API_KEY`, `ADMIN_EMAIL`, `EMAIL_FROM`, `CORS_ORIGIN`, `CONTACT_EMAIL`, `ALLOW_PROMPT_SELECTION`, `MODEL`, `EXTENDED_THINKING`, `EVALUATION_MODEL`, `SYSTEM_PROMPT_PATH`, `PORT`.
 
 For defaults and full descriptions, see [CLAUDE.md](../../CLAUDE.md#configsecrets-management).
 
@@ -84,7 +84,7 @@ apps/api/src/
 │   ├── require-auth.ts     ← Bearer token verification middleware
 │   └── require-admin.ts    ← Admin-only gating (chains after require-auth)
 └── lib/
-    ├── evaluation.ts       ← runSessionEvaluation(), buildEvaluationPayload(), buildTranscriptEmailPayload()
+    ├── evaluation.ts       ← buildEvaluationPayload(), buildTranscriptEmailPayload(), timeout-feedback + email helpers
     ├── batch-evaluation.ts ← findPendingEvaluations(), createEvaluationBatchForPending(), processBatchResults()
     ├── session-store.ts    ← In-memory Map<sessionId, Session>
     ├── stream.ts           ← SSE helpers (initSSE, sendEvent, sendHeartbeat)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,7 +27,7 @@ import { createHistoryRouter } from "./routes/history.js";
 import { createAdminEvaluationsRouter } from "./routes/admin-evaluations.js";
 import { getAllSessions, removeSession } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
+import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -145,8 +145,8 @@ setInterval(() => {
       removeSession(sessionId);
 
       // Shared teardown: mark ended_at in DB and log. Called both from the async
-      // eval/email path (in finally, after the evaluation row is written) and from
-      // the no-email path (immediately, since there is no evaluation to wait for).
+      // email path (in finally, after the transcript email completes) and from
+      // the no-email path (immediately).
       const finishReap = async () => {
         try {
           await markSessionEnded(db, sessionId);
@@ -159,16 +159,13 @@ setInterval(() => {
       if (!session.emailSent && session.transcript.length > 0) {
         void (async () => {
           try {
-            const [evalResult, feedback, userInfo] = await Promise.all([
-              config.autoEvaluate
-                ? runSessionEvaluation(db, sessionId, session.transcript, config.evaluationModel)
-                : Promise.resolve(null),
+            const [feedback, userInfo] = await Promise.all([
               getOrCreateTimeoutFeedback(db, sessionId, "sweep"),
               getUserInfoForSession(db, sessionId).catch(() => null),
             ]);
 
             const payload = buildTranscriptEmailPayload(
-              session, sessionId, evalResult, feedback,
+              session, sessionId, null, feedback,
               { model: config.model, promptName: defaultPromptName, extendedThinking: config.extendedThinking },
               userInfo,
             );
@@ -185,8 +182,7 @@ setInterval(() => {
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
           } finally {
-            // Mark ended_at only after evaluation and email have completed (or failed),
-            // so session_evaluations is always written before ended_at is set.
+            // Mark ended_at only after the email has completed (or failed).
             await finishReap();
           }
         })();

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -1,8 +1,7 @@
-import { evaluateTranscript } from "@ai-tutor/core";
 import type { EvaluationResult, Session } from "@ai-tutor/core";
 import type { TranscriptEmailPayload } from "@ai-tutor/email";
 import { sendUserTranscript } from "@ai-tutor/email";
-import { upsertSessionEvaluation, updateSession, getSessionFeedback, createSessionFeedback, getUserProfileForSession } from "@ai-tutor/db";
+import { updateSession, getSessionFeedback, createSessionFeedback, getUserProfileForSession } from "@ai-tutor/db";
 import type { DbSessionFeedback, UserSessionInfo } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -94,43 +93,6 @@ export async function getOrCreateTimeoutFeedback(
     }
   }
   return feedback;
-}
-
-export async function runSessionEvaluation(
-  db: SupabaseClient,
-  sessionId: string,
-  transcript: Array<{ role: string; text: string }>,
-  evaluationModel?: string,
-): Promise<EvaluationResult | null> {
-  try {
-    const result = await evaluateTranscript(transcript, evaluationModel);
-    await upsertSessionEvaluation(db, {
-      session_id: sessionId,
-      model: result.model,
-      mode_handling: result.mode_handling,
-      problem_confirmation: result.problem_confirmation,
-      never_gave_answer: result.never_gave_answer,
-      probe_reasoning: result.probe_reasoning,
-      understood_where_student_was: result.understood_where_student_was,
-      one_question: result.one_question,
-      worked_at_edge: result.worked_at_edge,
-      followed_student_lead: result.followed_student_lead,
-      adaptive_tone: result.adaptive_tone,
-      parallel_problems: result.parallel_problems,
-      step_feedback: result.step_feedback,
-      resolution: result.resolution,
-      has_failures: result.has_failures,
-      rationale: result.rationale,
-    });
-    // Mark the session as evaluated so out-of-band evaluation jobs can skip it.
-    await updateSession(db, sessionId, { evaluated: true }).catch(err =>
-      console.error(`[evaluation] Could not persist evaluated=true for ${sessionId}:`, err)
-    );
-    return result;
-  } catch (err) {
-    console.error(`[evaluation] Failed to evaluate session ${sessionId}:`, err);
-    return null;
-  }
 }
 
 /**

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -41,7 +41,6 @@ export function createConfigRouter(
     res.json({
       model: config.model,
       extendedThinking: config.extendedThinking,
-      autoEvaluate: config.autoEvaluate,
       inactivityMs,
       contactEmail: process.env.CONTACT_EMAIL ?? "",
       availableModels: [...ALLOWED_MODELS],

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -8,7 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Config } from "@ai-tutor/core";
 import { getSession, removeSession } from "../lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
-import { runSessionEvaluation, buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
+import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
@@ -53,12 +53,12 @@ export function createSessionsRouter(
   /**
    * DELETE /api/sessions/:sessionId
    *
-   * Normal flow: runs evaluation, sends the transcript email (if not already
-   * sent), removes the in-memory session, and marks ended_at in the database.
+   * Normal flow: sends the transcript email (if not already sent), removes the
+   * in-memory session, and marks ended_at in the database.
    *
-   * With ?discard=true: skips evaluation and email entirely — just removes
-   * from memory and marks ended_at.  Used when the user switches model/prompt
-   * mid-session and the transcript should be discarded.
+   * With ?discard=true: skips the email entirely — just removes from memory
+   * and marks ended_at.  Used when the user switches model/prompt mid-session
+   * and the transcript should be discarded.
    */
   router.delete("/:sessionId", requireAuth, async (req, res, next) => {
     try {
@@ -77,14 +77,11 @@ export function createSessionsRouter(
 
       try {
         if (!discard && session && !session.emailSent && session.transcript.length > 0) {
-          const [evalResult, feedback, userInfo] = await Promise.all([
-            config.autoEvaluate
-              ? runSessionEvaluation(db, sessionId, session.transcript, config.evaluationModel)
-              : Promise.resolve(null),
+          const [feedback, userInfo] = await Promise.all([
             getOrCreateTimeoutFeedback(db, sessionId, "sessions"),
             getUserInfoForSession(db, sessionId).catch(() => null),
           ]);
-          const payload = buildTranscriptEmailPayload(session, sessionId, evalResult, feedback,
+          const payload = buildTranscriptEmailPayload(session, sessionId, null, feedback,
             { model: config.model, promptName: config.defaultPromptName, extendedThinking: config.extendedThinking },
             userInfo);
           try {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,8 +60,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 | `CONTACT_EMAIL` | no | Contact email shown on the login page and returned by GET /api/config. Defaults to `""` — required before going public. The contact line is hidden when absent. | No |
 | `MODEL` | no | Default: `claude-sonnet-4-6` | No |
 | `EXTENDED_THINKING` | no | Default: `true`; set `false` to disable | No |
-| `AUTO_EVALUATE` | no | Default: `true`; set `false` to disable the automatic transcript evaluation that runs on session end. When disabled, `session_evaluations` rows are not created inline — use `scripts/backfill-evaluations.ts` for out-of-band evaluation. | No |
-| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5-20251001`. Claude model ID used for automated transcript evaluation. | No |
+| `EVALUATION_MODEL` | no | Default: `claude-haiku-4-5-20251001`. Claude model ID used by the admin-gated batch transcript evaluator. | No |
 | `SYSTEM_PROMPT_PATH` | no | Default: `templates/tutor-prompt-v7.md` | No |
 | `CORS_ORIGIN` | no | Default: `false` (fail-closed). When unset, all cross-origin requests are rejected. Set explicitly to your Render app URL once deployed (e.g., `https://ai-tutor.onrender.com`). Required for every deployment that serves cross-origin traffic. | No |
 | `ALLOW_PROMPT_SELECTION` | no | Set to `true` to enable the in-app prompt-version picker. Omit (or set to anything else) to lock the picker. Defaults fail-closed. | No |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ Scroll down to the **Environment Variables** section.  Add each variable below a
 
 You can skip `RESEND_API_KEY`, `ADMIN_EMAIL`, and `EMAIL_FROM` if you don't want email transcripts.  The app will work without them.
 
-> **Migration ordering:** migration `006_auto_evaluate.sql` adds the `evaluated` column used by the post-evaluation write. Migration `007_evaluation_batches.sql` adds the `evaluation_batches` table used by the admin-gated batched evaluation subsystem and runs a one-time `UPDATE` to reconcile `sessions.evaluated` with existing `session_evaluations` rows. Apply Supabase migrations **before** deploying the matching API binary — otherwise inline writes (`updateSession({ evaluated: true })`) and the admin batch endpoints will fail against the old schema.
+> **Migration ordering:** migration `006_auto_evaluate.sql` adds the `evaluated` column used by the batch evaluator to skip already-evaluated sessions. Migration `007_evaluation_batches.sql` adds the `evaluation_batches` table used by the admin-gated batched evaluation subsystem and runs a one-time `UPDATE` to reconcile `sessions.evaluated` with existing `session_evaluations` rows. Apply Supabase migrations **before** deploying the matching API binary — otherwise the admin batch endpoints will fail against the old schema.
 
 `PORT` does not need to be set — Render sets it automatically.
 

--- a/env.sh.template
+++ b/env.sh.template
@@ -29,11 +29,7 @@ export SUPABASE_ANON_KEY=""           # Required. Anon/public key. Enables /api/
 export RESEND_API_KEY=""              # Get from https://resend.com/api-keys
 export ADMIN_EMAIL=""                 # Recipient address for transcript and evaluation emails (admin)
 
-# Set to "false" to disable the automatic transcript evaluation that runs on
-# session end (inactivity sweep + explicit DELETE). Default enabled.
-export AUTO_EVALUATE="false"
-
-# Claude model ID used for automated transcript evaluation.
+# Claude model ID used by the admin-gated batch transcript evaluator.
 # Default: claude-haiku-4-5-20251001 (fast, cheap). Override to use a different model.
 export EVALUATION_MODEL=""
 export EMAIL_FROM="tutor@tutor.schmim.com"  # Sender address (default: tutor@tutor.schmim.com)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,7 +32,6 @@ Reads environment variables and returns a typed config object.
   systemPromptPath: string;  // SYSTEM_PROMPT_PATH env var, default "templates/tutor-prompt-v7.md"
   defaultPromptName: string; // basename of systemPromptPath without extension (e.g. "tutor-prompt-v7")
   port: number;              // PORT env var, default 3000
-  autoEvaluate: boolean;     // AUTO_EVALUATE env var, default true
   evaluationModel: string;   // EVALUATION_MODEL env var, default "claude-haiku-4-5-20251001"
 }
 ```
@@ -172,7 +171,7 @@ import type {
 
 ## Configuration
 
-This package reads `ANTHROPIC_API_KEY` (required), `MODEL`, `EXTENDED_THINKING`, `SYSTEM_PROMPT_PATH`, `AUTO_EVALUATE`, and `EVALUATION_MODEL` from environment variables.  (`PORT` is consumed by `apps/api`, not this package directly.)  For the full table with defaults and descriptions, see [CLAUDE.md](../../CLAUDE.md#configsecrets-management).
+This package reads `ANTHROPIC_API_KEY` (required), `MODEL`, `EXTENDED_THINKING`, `SYSTEM_PROMPT_PATH`, and `EVALUATION_MODEL` from environment variables.  (`PORT` is consumed by `apps/api`, not this package directly.)  For the full table with defaults and descriptions, see [CLAUDE.md](../../CLAUDE.md#configsecrets-management).
 
 ## Setup
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -20,7 +20,6 @@ export interface Config {
   systemPromptPath: string;
   defaultPromptName: string;
   port: number;
-  autoEvaluate: boolean;
   evaluationModel: string;
 }
 
@@ -33,7 +32,6 @@ export function loadConfig(): Config {
     systemPromptPath,
     defaultPromptName: path.basename(systemPromptPath, ".md"),
     port: parseInt(process.env.PORT ?? "3000", 10),
-    autoEvaluate: process.env.AUTO_EVALUATE?.toLowerCase() !== "false",
     evaluationModel: process.env.EVALUATION_MODEL ?? DEFAULT_EVALUATION_MODEL,
   };
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ Out-of-band maintenance scripts for the AI Tutor.
 
 ## backfill-evaluations.ts
 
-Runs the automated transcript evaluation against sessions that ended without a `session_evaluations` row. Use this after running with `AUTO_EVALUATE=false`, or to fill gaps caused by transient evaluation failures.
+Runs the automated transcript evaluation against sessions that ended without a `session_evaluations` row. Use this to fill gaps left by the admin-gated batch evaluator (e.g. transient failures, or sessions that ended before the batch evaluator existed).
 
 ### What it writes
 


### PR DESCRIPTION
## Summary

- Retire the inline automated transcript evaluator that fired at session end (inactivity sweep + explicit `DELETE /api/sessions/:id`). Transcript evaluation now runs exclusively through the admin-gated batch subsystem shipped earlier this week.
- Drop `runSessionEvaluation()`, the `AUTO_EVALUATE` env var, and `Config.autoEvaluate`. Retain `Config.evaluationModel` because `apps/api/src/routes/admin-evaluations.ts` still consumes it.
- Transcript emails still send on session end; the `evaluation` block is simply `null` and the rest of the payload (feedback, token usage, transcript) is unchanged.

Closes #228.

## Test plan

- [x] `npm run build` (worktree) — clean compile across all workspaces
- [ ] Verify a session ended via `DELETE /api/sessions/:id` still produces a transcript email without an evaluation block
- [ ] Verify the inactivity sweep still reaps + emails idle sessions without invoking the evaluator
- [ ] Confirm `GET /api/config` no longer returns `autoEvaluate`
- [ ] Confirm `POST /api/admin/evaluations/batches` still picks up sessions and runs evaluation via the batch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)