### PR TITLE
feat(#232): add admin nav link to sidebar

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -182,6 +182,8 @@
         modelBadge.classList.add('admin-visible');
         promptBadge.classList.add('admin-visible');
         thinkingBadge.classList.add('admin-visible');
+        const adminNavGroup = document.getElementById('admin-nav-group');
+        if (adminNavGroup) adminNavGroup.style.display = '';
       }
 
       // Always show the account trigger for authenticated users. Fall back

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -70,6 +70,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-user-row" id="sidebar-user-row" style="display:none">
           <div class="s-avatar" id="sidebar-avatar-initials">?</div>
@@ -133,6 +140,17 @@
         var c = sidebar.classList.toggle('collapsed');
         localStorage.setItem(KEY, c);
       });
+    })();
+    // Reveal Admin nav group for admin users (app_metadata.is_admin === true).
+    (function() {
+      if (!window.auth || typeof window.auth.getSession !== 'function') return;
+      window.auth.getSession().then(function(session) {
+        var appMeta = (session && session.user && session.user.app_metadata) || {};
+        if (appMeta.is_admin === true) {
+          var group = document.getElementById('admin-nav-group');
+          if (group) group.style.display = '';
+        }
+      }).catch(function() { /* ignore */ });
     })();
   </script>
 </body>

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -109,6 +109,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-footer-badges">
           <span id="build-info" class="build-info"></span>

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -70,6 +70,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-user-row" id="sidebar-user-row" style="display:none">
           <div class="s-avatar" id="sidebar-avatar-initials">?</div>
@@ -184,6 +191,17 @@
         var c = sidebar.classList.toggle('collapsed');
         localStorage.setItem(KEY, c);
       });
+    })();
+    // Reveal Admin nav group for admin users (app_metadata.is_admin === true).
+    (function() {
+      if (!window.auth || typeof window.auth.getSession !== 'function') return;
+      window.auth.getSession().then(function(session) {
+        var appMeta = (session && session.user && session.user.app_metadata) || {};
+        if (appMeta.is_admin === true) {
+          var group = document.getElementById('admin-nav-group');
+          if (group) group.style.display = '';
+        }
+      }).catch(function() { /* ignore */ });
     })();
   </script>
 </body>


### PR DESCRIPTION
Closes #232.

## Summary
- Adds a hidden `div#admin-nav-group` (shield-check icon + "Admin" label linking to `/admin.html`) to the sidebars in `index.html`, `settings.html`, and `history.html`.
- The group is revealed only for users whose Supabase JWT `app_metadata.is_admin === true`.
- `app.js` reveals it inside the existing `fetchUserInfo()` block (same place the model/prompt/thinking badges are revealed).
- `settings.html` and `history.html` reveal it via a small inline script using `window.auth.getSession()`.

## Files changed
- `apps/web/public/index.html` — new nav group below "Account"
- `apps/web/public/app.js` — reveal logic inside `fetchUserInfo()`
- `apps/web/public/settings.html` — nav group + inline reveal script
- `apps/web/public/history.html` — nav group + inline reveal script

No changes to `styles.css`. No new npm deps. Follows the existing `admin-visible` / display-toggle pattern already used in this codebase.

## Test plan
- [ ] Sign in as a non-admin — confirm no "Admin" nav group appears on `/`, `/settings.html`, or `/history.html`.
- [ ] Sign in as an admin — confirm "Admin" group appears on all three pages and clicking the link navigates to `/admin.html`.
- [ ] Collapse the sidebar (hamburger toggle) — confirm the admin shield icon is still visible in the icon rail.
- [ ] Check browser console for JS errors on all three pages.

## Notes
- This is the dependency-root for issues #233 and #234. Both must merge after this PR.
- `/simplify` and `/code-review` should be run on the changed files before merging per CLAUDE.md.
- Known acceptable gap: no mobile breakpoint for settings/history sidebars (pre-existing; not scoped here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)