### PR TITLE
feat(#233): reskin admin.html with shared warm-red layout

### DIFF
--- a/apps/web/public/admin.css
+++ b/apps/web/public/admin.css
@@ -1,0 +1,330 @@
+/* admin.css — standalone styles for /admin.html.
+ *
+ * Mirrors the settings.css pattern: warm-red palette, shared layout shell
+ * (.app-header / .app-body / .page-sidebar / .page-content), plus admin-
+ * specific component styles (cards, table, status badges, inputs).
+ *
+ * Note: the :root token block and layout shell rules are duplicated from
+ * settings.css / history.css. A shared layout.css is filed as follow-on
+ * work — intentionally not extracted in this PR.
+ */
+
+:root {
+  --bg:           #fffdf7;
+  --surface:      #ffffff;
+  --surface-alt:  #fffbf7;
+  --card:         #ffffff;
+  --border:       #e2e8f0;
+  --border-bright:#d1d5db;
+  --text:         #1e293b;
+  --text-muted:   #64748b;
+  --accent:       #e8392a;
+  --accent-light: #fee2e2;
+  --accent-dark:  #c42d1e;
+  --accent-hover: #c42d1e;
+  --tutor-accent: #f97316;
+  --header-bg:    #b91c1c;
+  --danger:       #ef4444;
+  --success:      #22c55e;
+  --font-heading: 'Nunito', sans-serif;
+  --font-sans:    'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── App shell (shared with settings.css / history.css) ── */
+.app-header {
+  height: 64px;
+  background: var(--header-bg);
+  display: flex; align-items: center;
+  padding: 0 20px; gap: 14px; flex-shrink: 0;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.app-header .logo-box {
+  width: 36px; height: 36px; background: #e8392a;
+  border-radius: 10px; display: flex; align-items: center;
+  justify-content: center; flex-shrink: 0;
+  box-shadow: 0 4px 14px rgba(232,57,42,0.45);
+}
+.app-header .brand-name {
+  font-family: var(--font-heading); font-weight: 900;
+  font-size: 20px; color: #fff; line-height: 1;
+}
+.app-header .brand-sub {
+  font-size: 9px; font-weight: 600; letter-spacing: 2.5px;
+  text-transform: uppercase; color: rgba(255,255,255,0.35);
+}
+.app-header .header-wordmark { display: flex; flex-direction: column; gap: 1px; }
+.app-header .header-divider {
+  width: 1px; height: 28px; background: rgba(255,255,255,0.1);
+}
+.app-header .page-title {
+  font-family: var(--font-heading); font-weight: 700;
+  font-size: 15px; color: rgba(255,255,255,0.7);
+}
+.app-header .header-spacer { flex: 1; }
+
+.app-body {
+  display: flex; flex: 1; min-height: 0;
+  height: calc(100vh - 64px); overflow: hidden;
+}
+
+/* ── Sidebar ── */
+.page-sidebar {
+  width: 220px; flex-shrink: 0;
+  background: #fffbf7; border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; overflow: hidden;
+  transition: width .2s ease;
+}
+.page-sidebar.collapsed { width: 60px; }
+.page-sidebar .nav-group { padding: 20px 12px 8px; }
+.page-sidebar .nav-group-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 1.8px;
+  text-transform: uppercase; color: #94a3b8;
+  padding: 0 8px; margin-bottom: 6px; white-space: nowrap; overflow: hidden;
+}
+.page-sidebar .nav-link {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 10px; border-radius: 9px;
+  font-size: 13.5px; font-weight: 500; color: #475569;
+  cursor: pointer; margin-bottom: 2px; white-space: nowrap;
+  transition: background .12s, color .12s; text-decoration: none;
+}
+.page-sidebar .nav-link:hover { background: #fff5f5; color: #1e293b; }
+.page-sidebar .nav-link.active {
+  background: var(--accent-light); color: var(--accent-dark); font-weight: 700;
+}
+.page-sidebar .nav-link.active .nl-icon { color: var(--accent); }
+.page-sidebar .nav-link.nav-disabled {
+  pointer-events: none; opacity: 0.5;
+}
+.page-sidebar .nl-icon { width: 17px; height: 17px; flex-shrink: 0; color: #94a3b8; }
+.page-sidebar .nl-soon {
+  margin-left: auto; font-size: 10px; color: #cbd5e1; font-style: italic;
+}
+.page-sidebar .sidebar-footer {
+  margin-top: auto; border-top: 1px solid var(--border); padding: 14px 12px;
+}
+.page-sidebar .sidebar-user-row {
+  display: flex; align-items: center; gap: 9px;
+  padding: 8px 10px; border-radius: 9px; cursor: pointer;
+}
+.page-sidebar .sidebar-user-row:hover { background: #fff5f5; }
+.page-sidebar .s-avatar {
+  width: 32px; height: 32px; background: #e8392a; border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-heading); font-weight: 800; font-size: 12px;
+  color: #fff; flex-shrink: 0;
+}
+.page-sidebar .s-user-info { flex: 1; min-width: 0; }
+.page-sidebar .s-name {
+  font-size: 13px; font-weight: 600; color: #1e293b;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.page-sidebar .s-grade { font-size: 11px; color: #94a3b8; margin-top: 1px; }
+
+.page-sidebar.collapsed .nav-group-label,
+.page-sidebar.collapsed .nav-link-text,
+.page-sidebar.collapsed .nl-soon,
+.page-sidebar.collapsed .s-user-info { display: none; }
+.page-sidebar.collapsed .nav-link {
+  width: 42px; height: 42px; padding: 0;
+  justify-content: center; border-radius: 10px; margin: 2px auto;
+}
+.page-sidebar.collapsed .nav-group { padding: 12px 9px; }
+
+/* ── Page content area ── */
+.page-content {
+  flex: 1; overflow-y: auto; background: var(--bg);
+}
+
+/* ── Admin-specific layout ── */
+.admin-shell {
+  min-height: 100%;
+  padding: 2rem 2.5rem;
+}
+
+.admin-heading {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.4rem;
+  font-weight: 800;
+  font-family: var(--font-heading);
+  color: var(--text);
+}
+
+#user-info {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+#user-info span {
+  color: var(--text);
+  font-weight: 600;
+}
+#user-info .access-denied {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+/* ── Cards ── */
+.admin-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+}
+
+.admin-section-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.85rem 0;
+}
+
+.admin-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.admin-row-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* ── Inputs ── */
+.admin-card input[type="number"],
+.admin-card input[type="text"] {
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  font-size: 0.9rem;
+  width: 140px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.admin-card input[type="text"].admin-input-wide { width: 320px; }
+.admin-card input:focus { border-color: var(--accent); }
+
+/* ── Buttons ── */
+.admin-card button {
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.admin-card button:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+.admin-card button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.admin-card button.secondary {
+  background: var(--surface-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.admin-card button.secondary:hover:not(:disabled) {
+  background: #f1f5f9;
+  border-color: var(--border-bright);
+}
+
+/* ── Status output ── */
+.admin-status {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.85rem;
+  margin-top: 0.85rem;
+  white-space: pre-wrap;
+  min-height: 1.5em;
+}
+.admin-status:empty { display: none; }
+.admin-status.error { color: var(--danger); }
+.admin-status.success { color: var(--success); }
+
+/* ── Badges (status-semantic colors over light surface) ── */
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+.badge.submitted { background: #dbeafe; color: #1d4ed8; }
+.badge.ended     { background: #f3e8ff; color: #7c3aed; }
+.badge.processed { background: #dcfce7; color: #16a34a; }
+.badge.failed    { background: var(--accent-light); color: var(--accent-dark); }
+
+/* ── Table ── */
+.admin-card table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.admin-card th {
+  text-align: left;
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-alt);
+}
+.admin-card td {
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+  color: var(--text);
+}
+.admin-card td.mono {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.admin-card .poll-btn {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+}
+
+.admin-card .table-empty,
+.admin-card .table-loading {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -2,85 +2,147 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Admin — Evaluation Batches</title>
-  <style>
-    * { box-sizing: border-box; }
-    body { font-family: system-ui, sans-serif; background: #0f0f13; color: #e0e0e0; margin: 0; padding: 24px; }
-    h1 { font-size: 1.2rem; margin: 0 0 24px; color: #fff; }
-    h2 { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 24px 0 12px; }
-    .card { background: #1a1a22; border: 1px solid #2a2a38; border-radius: 8px; padding: 16px; margin-bottom: 12px; }
-    .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-    input[type="number"], input[type="text"] {
-      background: #111; border: 1px solid #333; border-radius: 6px;
-      color: #e0e0e0; padding: 8px 12px; font-size: 0.9rem; width: 140px;
-    }
-    button {
-      background: #4f6ef7; color: #fff; border: none; border-radius: 6px;
-      padding: 8px 16px; font-size: 0.9rem; cursor: pointer;
-    }
-    button:disabled { opacity: 0.5; cursor: default; }
-    button.secondary { background: #2a2a38; }
-    .status { font-size: 0.85rem; color: #aaa; margin-top: 10px; white-space: pre-wrap; font-family: monospace; }
-    .badge {
-      display: inline-block; padding: 2px 8px; border-radius: 10px;
-      font-size: 0.75rem; font-weight: 600;
-    }
-    .badge.submitted { background: #2a3a6a; color: #7aacff; }
-    .badge.ended     { background: #3a2a6a; color: #c07aff; }
-    .badge.processed { background: #1a3a2a; color: #5adf8a; }
-    .badge.failed    { background: #3a1a1a; color: #ff7a7a; }
-    table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-    th { text-align: left; color: #888; font-weight: 500; padding: 6px 8px; border-bottom: 1px solid #2a2a38; }
-    td { padding: 8px; border-bottom: 1px solid #1e1e28; vertical-align: top; }
-    td.mono { font-family: monospace; font-size: 0.8rem; color: #aaa; }
-    .poll-btn { font-size: 0.78rem; padding: 4px 10px; }
-    #user-info { font-size: 0.8rem; color: #888; margin-bottom: 20px; }
-    #user-info span { color: #e0e0e0; }
-  </style>
+  <meta name="theme-color" content="#b91c1c">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/admin.css">
 </head>
 <body>
-  <h1>Evaluation Batches — Admin</h1>
-  <div id="user-info">Checking auth…</div>
 
-  <div class="card">
-    <h2 style="margin-top:0">Submit New Batch</h2>
-    <div class="row">
-      <label style="font-size:0.85rem;color:#aaa">Limit</label>
-      <input type="number" id="limit" value="50" min="1" max="100" />
-      <button id="submit-btn">Submit Batch</button>
+  <!-- ── Header ─────────────────────────────────────────────────────────── -->
+  <div class="app-header">
+    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation"
+            style="width:36px;height:36px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;cursor:pointer;flex-shrink:0;border-radius:8px;border:none;background:transparent;padding:0;">
+      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+    </button>
+    <div class="logo-box">
+      <svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <path d="M16 4C10.477 4 6 8.477 6 14C6 17.5 7.9 20.58 10.75 22.35L10.75 25.5Q10.75 26.5 11.75 26.5L20.25 26.5Q21.25 26.5 21.25 25.5L21.25 22.35C24.1 20.58 26 17.5 26 14C26 8.477 21.523 4 16 4Z" fill="white" opacity=".88"/>
+        <rect x="12.5" y="27.5" width="7" height="1.5" rx=".75" fill="white" opacity=".6"/>
+        <rect x="14" y="29.5" width="4" height="1.5" rx=".75" fill="white" opacity=".35"/>
+        <path d="M18 11.5L13.5 17H16.5L13.5 22L20 15.5H17L19.5 11.5Z" fill="rgba(255,220,60,.9)"/>
+      </svg>
     </div>
-    <div class="status" id="submit-status"></div>
-  </div>
-
-  <div class="card">
-    <h2 style="margin-top:0">Poll / Finalize Batch</h2>
-    <div class="row">
-      <input type="text" id="poll-id" placeholder="Batch UUID" style="width:300px" />
-      <button id="poll-btn">Poll</button>
+    <div class="header-wordmark">
+      <span class="brand-name">Axiom</span>
+      <span class="brand-sub">AI Tutor</span>
     </div>
-    <div class="status" id="poll-status"></div>
+    <div class="header-divider"></div>
+    <span class="page-title">Admin</span>
+    <div class="header-spacer"></div>
   </div>
 
-  <div class="card">
-    <h2 style="margin-top:0">Recent Batches</h2>
-    <button id="refresh-btn" class="secondary" style="margin-bottom:12px">Refresh</button>
-    <div id="batches-table"><div style="color:#888;font-size:0.85rem">Loading…</div></div>
-  </div>
+  <!-- ── App body ───────────────────────────────────────────────────────── -->
+  <div class="app-body">
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+    <!-- ── Sidebar ──────────────────────────────────────────────────────── -->
+    <nav class="page-sidebar" id="page-sidebar" aria-label="Main navigation">
+      <div class="nav-group">
+        <div class="nav-group-label">Learn</div>
+        <a href="/" class="nav-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/><path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/></svg>
+          <span class="nav-link-text">Tutor</span>
+        </a>
+        <a href="/history.html" class="nav-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Session History</span>
+        </a>
+        <div class="nav-link nav-disabled">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM14 11a1 1 0 011 1v1h1a1 1 0 110 2h-1v1a1 1 0 11-2 0v-1h-1a1 1 0 110-2h1v-1a1 1 0 011-1z"/></svg>
+          <span class="nav-link-text">Practice Sets</span>
+          <span class="nl-soon">soon</span>
+        </div>
+        <div class="nav-link nav-disabled">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/></svg>
+          <span class="nav-link-text">My Progress</span>
+          <span class="nl-soon">soon</span>
+        </div>
+      </div>
+      <div class="nav-group">
+        <div class="nav-group-label">Account</div>
+        <a href="/settings.html" class="nav-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Settings</span>
+        </a>
+      </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link active" aria-current="page" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
+      <div class="sidebar-footer">
+        <!-- #sidebar-user-row is present but not populated on admin.html; the
+             admin init() script does not wire up the name/grade display. This
+             is a known acceptable gap (admin-only page). -->
+        <div class="sidebar-user-row" id="sidebar-user-row" style="display:none">
+          <div class="s-avatar" id="sidebar-avatar-initials">?</div>
+          <div class="s-user-info">
+            <div class="s-name" id="sidebar-display-name"></div>
+            <div class="s-grade" id="sidebar-grade"></div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- ── Page content ────────────────────────────────────────────────── -->
+    <div class="page-content">
+      <main class="admin-shell">
+        <h1 class="admin-heading">Evaluation Batches</h1>
+        <div id="user-info">Checking auth…</div>
+
+        <div class="admin-card">
+          <h2 class="admin-section-title">Submit New Batch</h2>
+          <div class="admin-row">
+            <label class="admin-row-label" for="limit">Limit</label>
+            <input type="number" id="limit" value="50" min="1" max="100" />
+            <button id="submit-btn">Submit Batch</button>
+          </div>
+          <div class="admin-status" id="submit-status"></div>
+        </div>
+
+        <div class="admin-card">
+          <h2 class="admin-section-title">Poll / Finalize Batch</h2>
+          <div class="admin-row">
+            <input type="text" id="poll-id" class="admin-input-wide" placeholder="Batch UUID" />
+            <button id="poll-btn">Poll</button>
+          </div>
+          <div class="admin-status" id="poll-status"></div>
+        </div>
+
+        <div class="admin-card">
+          <h2 class="admin-section-title">Recent Batches</h2>
+          <button id="refresh-btn" class="secondary" style="margin-bottom:12px">Refresh</button>
+          <div id="batches-table"><div class="table-loading">Loading…</div></div>
+        </div>
+      </main>
+    </div>
+
+  </div><!-- /.app-body -->
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
   <script>
-    function setStatus(id, text, color) {
+    // Helper: write text to a status region and apply a semantic class.
+    // `tone` is one of "info" (default), "error", "success".
+    function setStatus(id, text, tone) {
       const el = document.getElementById(id);
       el.textContent = text;
-      el.style.color = color || "#aaa";
+      el.classList.remove('error', 'success');
+      if (tone === 'error')   el.classList.add('error');
+      if (tone === 'success') el.classList.add('success');
     }
 
     async function submitBatch() {
       const limit = parseInt(document.getElementById("limit").value, 10) || 50;
       document.getElementById("submit-btn").disabled = true;
-      setStatus("submit-status", "Submitting…", "#aaa");
+      setStatus("submit-status", "Submitting…", "info");
       try {
         const res = await window.auth.authedFetch("/api/admin/evaluations/batches", {
           method: "POST",
@@ -89,18 +151,18 @@
         });
         const data = await res.json();
         if (!res.ok) {
-          setStatus("submit-status", JSON.stringify(data, null, 2), "#ff7a7a");
+          setStatus("submit-status", JSON.stringify(data, null, 2), "error");
         } else if (data.sessionCount === 0) {
-          setStatus("submit-status", "No sessions pending evaluation.", "#5adf8a");
+          setStatus("submit-status", "No sessions pending evaluation.", "success");
         } else {
           setStatus("submit-status",
             `Submitted — ${data.sessionCount} sessions\nBatch ID: ${data.id}\nAnthropic ID: ${data.anthropicBatchId}`,
-            "#5adf8a");
+            "success");
           document.getElementById("poll-id").value = data.id;
           loadBatches();
         }
       } catch (e) {
-        setStatus("submit-status", "Error: " + e.message, "#ff7a7a");
+        setStatus("submit-status", "Error: " + e.message, "error");
       } finally {
         document.getElementById("submit-btn").disabled = false;
       }
@@ -108,25 +170,25 @@
 
     async function pollBatch(id) {
       const batchId = id || document.getElementById("poll-id").value.trim();
-      if (!batchId) { setStatus("poll-status", "Enter a batch UUID.", "#ff7a7a"); return; }
-      setStatus("poll-status", "Polling…", "#aaa");
+      if (!batchId) { setStatus("poll-status", "Enter a batch UUID.", "error"); return; }
+      setStatus("poll-status", "Polling…", "info");
       try {
         const res = await window.auth.authedFetch(`/api/admin/evaluations/batches/${batchId}`);
         const data = await res.json();
         if (!res.ok) {
-          setStatus("poll-status", JSON.stringify(data, null, 2), "#ff7a7a");
+          setStatus("poll-status", JSON.stringify(data, null, 2), "error");
         } else {
           const b = data.batch;
           let msg = `Status: ${b.status}`;
           if (b.request_counts) msg += `\nCounts: ${JSON.stringify(b.request_counts)}`;
           if (data.outcome)     msg += `\nOutcome: ${JSON.stringify(data.outcome)}`;
           if (b.error_message)  msg += `\nError: ${b.error_message}`;
-          setStatus("poll-status", msg, "#e0e0e0");
+          setStatus("poll-status", msg, "info");
           if (id) document.getElementById("poll-id").value = batchId;
           loadBatches();
         }
       } catch (e) {
-        setStatus("poll-status", "Error: " + e.message, "#ff7a7a");
+        setStatus("poll-status", "Error: " + e.message, "error");
       }
     }
 
@@ -136,11 +198,11 @@
         const res = await window.auth.authedFetch("/api/admin/evaluations/batches");
         const data = await res.json();
         if (!res.ok || !data.ok) {
-          container.innerHTML = `<div style="color:#ff7a7a">${JSON.stringify(data)}</div>`;
+          container.innerHTML = `<div class="table-empty" style="color:var(--danger)">${JSON.stringify(data)}</div>`;
           return;
         }
         if (!data.batches.length) {
-          container.innerHTML = `<div style="color:#888;font-size:0.85rem">No batches yet.</div>`;
+          container.innerHTML = `<div class="table-empty">No batches yet.</div>`;
           return;
         }
         const tbody = document.createElement("tbody");
@@ -169,7 +231,7 @@
         table.appendChild(tbody);
         container.replaceChildren(table);
       } catch (e) {
-        container.innerHTML = `<div style="color:#ff7a7a">Error: ${e.message}</div>`;
+        container.innerHTML = `<div class="table-empty" style="color:var(--danger)">Error: ${e.message}</div>`;
       }
     }
 
@@ -178,9 +240,18 @@
       const session = await window.auth.requireSession();
       const email = session.user?.email ?? "unknown";
       const isAdmin = session.user?.app_metadata?.is_admin;
+
+      // Reveal Admin nav group for consistency with other pages.
+      if (isAdmin === true) {
+        const group = document.getElementById("admin-nav-group");
+        if (group) group.style.display = "";
+      }
+
+      // Admin auth gate — preserve the behavior from the pre-reskin version:
+      // non-admins see an access-denied message and every button is disabled.
       if (!isAdmin) {
         document.getElementById("user-info").innerHTML =
-          '<span style="color:#ff7a7a">Not an admin account. Access denied.</span>';
+          '<span class="access-denied">Not an admin account. Access denied.</span>';
         document.querySelectorAll("button").forEach(b => b.disabled = true);
         return;
       }
@@ -195,6 +266,19 @@
     }
 
     init();
+  </script>
+  <script>
+    // Sidebar toggle for this page
+    (function() {
+      var sidebar = document.getElementById('page-sidebar');
+      var toggle  = document.getElementById('btn-sidebar-toggle');
+      var KEY     = 'sidebar-collapsed';
+      if (localStorage.getItem(KEY) === 'true') sidebar.classList.add('collapsed');
+      toggle.addEventListener('click', function() {
+        var c = sidebar.classList.toggle('collapsed');
+        localStorage.setItem(KEY, c);
+      });
+    })();
   </script>
 </body>
 </html>

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -182,6 +182,8 @@
         modelBadge.classList.add('admin-visible');
         promptBadge.classList.add('admin-visible');
         thinkingBadge.classList.add('admin-visible');
+        const adminNavGroup = document.getElementById('admin-nav-group');
+        if (adminNavGroup) adminNavGroup.style.display = '';
       }
 
       // Always show the account trigger for authenticated users. Fall back

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -70,6 +70,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-user-row" id="sidebar-user-row" style="display:none">
           <div class="s-avatar" id="sidebar-avatar-initials">?</div>
@@ -133,6 +140,17 @@
         var c = sidebar.classList.toggle('collapsed');
         localStorage.setItem(KEY, c);
       });
+    })();
+    // Reveal Admin nav group for admin users (app_metadata.is_admin === true).
+    (function() {
+      if (!window.auth || typeof window.auth.getSession !== 'function') return;
+      window.auth.getSession().then(function(session) {
+        var appMeta = (session && session.user && session.user.app_metadata) || {};
+        if (appMeta.is_admin === true) {
+          var group = document.getElementById('admin-nav-group');
+          if (group) group.style.display = '';
+        }
+      }).catch(function() { /* ignore */ });
     })();
   </script>
 </body>

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -109,6 +109,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-footer-badges">
           <span id="build-info" class="build-info"></span>

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -70,6 +70,13 @@
           <span class="nav-link-text">Settings</span>
         </a>
       </div>
+      <div class="nav-group admin-nav-group" id="admin-nav-group" style="display:none">
+        <div class="nav-group-label">Admin</div>
+        <a href="/admin.html" class="nav-link" id="nav-admin-link">
+          <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.317 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/></svg>
+          <span class="nav-link-text">Admin</span>
+        </a>
+      </div>
       <div class="sidebar-footer">
         <div class="sidebar-user-row" id="sidebar-user-row" style="display:none">
           <div class="s-avatar" id="sidebar-avatar-initials">?</div>
@@ -184,6 +191,17 @@
         var c = sidebar.classList.toggle('collapsed');
         localStorage.setItem(KEY, c);
       });
+    })();
+    // Reveal Admin nav group for admin users (app_metadata.is_admin === true).
+    (function() {
+      if (!window.auth || typeof window.auth.getSession !== 'function') return;
+      window.auth.getSession().then(function(session) {
+        var appMeta = (session && session.user && session.user.app_metadata) || {};
+        if (appMeta.is_admin === true) {
+          var group = document.getElementById('admin-nav-group');
+          if (group) group.style.display = '';
+        }
+      }).catch(function() { /* ignore */ });
     })();
   </script>
 </body>


### PR DESCRIPTION
Closes #233. **Depends on #235** — base branch is `feature/232-admin-nav-link`; after that PR merges to `main`, rebase this one onto `main` (or retarget the base).

## Summary
- Replaces the dark self-contained admin theme (`#0f0f13` bg, `#4f6ef7` buttons, `system-ui` font) with the warm-red palette used across the rest of the app.
- Restructures `admin.html` to use the shared layout shell (`.app-header` / `.app-body` / `.page-sidebar` / `.page-content`).
- New file: `apps/web/public/admin.css` (warm-red `:root` tokens + shared layout shell + admin-specific component styles).
- All existing JS functionality and DOM IDs are preserved (`submit-btn`, `poll-btn`, `poll-id`, `refresh-btn`, `batches-table`, `user-info`, `submit-status`, `poll-status`, `limit`).
- **`is_admin` auth gate verified preserved** — `init()` still disables every button and shows the access-denied message when `session.user.app_metadata.is_admin` is not true.

## Files changed
- `apps/web/public/admin.html` — replaced inline `<style>` with link to `/admin.css`; restructured `<body>` to the shared layout shell; sidebar nav HTML copied from `settings.html`.
- `apps/web/public/admin.css` — new.

## Known acceptable gaps (called out in the review)
- `#sidebar-user-row` is present in the DOM but not populated (admin `init()` does not wire up name/grade). HTML comment marks this.
- `:root` tokens + layout shell CSS are now duplicated across `admin.css`, `settings.css`, `history.css`. A shared `layout.css` is follow-on work — intentionally not extracted here.
- No mobile breakpoint for the admin sidebar (pre-existing gap for all page-sidebar pages).

## Test plan
- [ ] Navigate to `/admin.html` as an admin. Confirm warm-red header, white content area, warm off-white sidebar, Nunito + Plus Jakarta Sans fonts.
- [ ] Confirm the Admin nav group appears in the sidebar and its entry is marked `.active`.
- [ ] Click "Submit Batch" with no pending sessions — confirm the "No sessions pending evaluation." status appears (success color).
- [ ] Click "Poll" with a known batch UUID — confirm the status area updates with counts/outcome.
- [ ] Click "Refresh" — confirm the Recent Batches table renders.
- [ ] Navigate to `/admin.html` as a non-admin. Confirm "Not an admin account. Access denied." appears and every button is disabled.
- [ ] Collapse the sidebar — confirm icons still visible and content pane adjusts.
- [ ] Check browser console for JS errors.

## Notes
- `styles.css` is not modified.
- No npm dependencies added.
- `/simplify` and `/code-review` should be run on the changed files before merging per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)