### PR TITLE
fix: four bug fixes from daily sweep (IDOR, sweep race, history gating, IP spoofing)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,7 +25,7 @@ import { createConfigRouter } from "./routes/config.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { createHistoryRouter } from "./routes/history.js";
 import { createAdminEvaluationsRouter } from "./routes/admin-evaluations.js";
-import { getAllSessions, removeSession } from "./lib/session-store.js";
+import { getAllSessions, removeSession, markReaping, unmarkReaping } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
@@ -130,9 +130,9 @@ app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));
 app.use("/api/admin/evaluations", createAdminEvaluationsRouter(db, config, emailConfig));
+app.use("/api/history", createHistoryRouter(db));
 if (anonDb) {
   app.use("/api/auth", createAuthRouter(db, anonDb));
-  app.use("/api/history", createHistoryRouter(db));
 }
 
 app.use(errorHandler);
@@ -141,19 +141,24 @@ setInterval(() => {
   const now = Date.now();
   for (const [sessionId, session] of getAllSessions()) {
     if (now - session.lastActivityAt.getTime() > INACTIVITY_MS) {
-      // Remove from memory first to prevent the next sweep tick from re-processing.
-      removeSession(sessionId);
+      // Mark as reaping to prevent the next sweep tick from re-processing and
+      // to block concurrent chat requests on this session during async teardown.
+      // The session stays in the store until finishReap removes it, so no
+      // concurrent chat request can silently resurrect an empty ghost session.
+      markReaping(sessionId);
 
-      // Shared teardown: mark ended_at in DB and log. Called both from the async
-      // email path (in finally, after the transcript email completes) and from
-      // the no-email path (immediately).
+      // Shared teardown: mark ended_at in DB, then remove from memory. Called
+      // both from the async email path (in finally) and the no-email path.
       const finishReap = async () => {
         try {
           await markSessionEnded(db, sessionId);
         } catch (err) {
           console.error(`[sweep] Could not mark session ${sessionId} as ended:`, err);
+        } finally {
+          removeSession(sessionId);
+          unmarkReaping(sessionId);
+          console.log(`[sweep] Reaped idle session ${sessionId}.`);
         }
-        console.log(`[sweep] Reaped idle session ${sessionId}.`);
       };
 
       if (!session.emailSent && session.transcript.length > 0) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,7 +25,7 @@ import { createConfigRouter } from "./routes/config.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { createHistoryRouter } from "./routes/history.js";
 import { createAdminEvaluationsRouter } from "./routes/admin-evaluations.js";
-import { getAllSessions, removeSession, markReaping, unmarkReaping } from "./lib/session-store.js";
+import { getAllSessions, removeSession, markReaping, unmarkReaping, isReaping } from "./lib/session-store.js";
 import { sendTranscript } from "@ai-tutor/email";
 import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
@@ -141,6 +141,8 @@ setInterval(() => {
   const now = Date.now();
   for (const [sessionId, session] of getAllSessions()) {
     if (now - session.lastActivityAt.getTime() > INACTIVITY_MS) {
+      if (isReaping(sessionId)) continue; // teardown already in progress
+
       // Mark as reaping to prevent the next sweep tick from re-processing and
       // to block concurrent chat requests on this session during async teardown.
       // The session stays in the store until finishReap removes it, so no

--- a/apps/api/src/lib/geo.ts
+++ b/apps/api/src/lib/geo.ts
@@ -8,10 +8,7 @@ import type { ClientInfo } from "@ai-tutor/core";
  * raw socket address.  Runs a geoip lookup and returns a ClientInfo object.
  */
 export function extractClientInfo(req: Request): ClientInfo {
-  const ip =
-    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ??
-    req.socket.remoteAddress ??
-    "";
+  const ip = req.ip ?? req.socket.remoteAddress ?? "";
   const geo = geoip.lookup(ip);
   return {
     ip,

--- a/apps/api/src/lib/session-store.ts
+++ b/apps/api/src/lib/session-store.ts
@@ -13,6 +13,11 @@ import { Session } from "@ai-tutor/core";
  */
 const store = new Map<string, Session>();
 
+// Sessions currently being torn down by the inactivity sweep. Kept in the
+// store until teardown finishes to prevent chat requests from re-creating them
+// as empty sessions against a DB row that is about to be marked ended.
+const reapingSet = new Set<string>();
+
 export function getOrCreateSession(id: string): Session {
   if (!store.has(id)) {
     store.set(id, new Session());
@@ -30,4 +35,16 @@ export function removeSession(id: string): void {
 
 export function getAllSessions(): IterableIterator<[string, Session]> {
   return store.entries();
+}
+
+export function markReaping(id: string): void {
+  reapingSet.add(id);
+}
+
+export function unmarkReaping(id: string): void {
+  reapingSet.delete(id);
+}
+
+export function isReaping(id: string): boolean {
+  return reapingSet.has(id);
 }

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -177,6 +177,7 @@ export function createChatRouter(
             console.error("[chat] Could not create DB session row:", err);
           }
         } else if (session.ownerId !== null && session.ownerId !== userId) {
+          // ownerId null = session predates this guard; allow through for migration safety.
           res.status(403).json({ error: "Forbidden." });
           return;
         }

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -7,7 +7,7 @@ import {
   updateSession,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { getOrCreateSession } from "../lib/session-store.js";
+import { getOrCreateSession, isReaping } from "../lib/session-store.js";
 import { initSSE, sendEvent } from "../lib/stream.js";
 import { extractClientInfo } from "../lib/geo.js";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
@@ -126,10 +126,18 @@ export function createChatRouter(
         }
 
         const files = (req.files as Express.Multer.File[]) ?? [];
-        const session = getOrCreateSession(sessionId);
 
-        // Capture client info and model/prompt on the first message of the session.
-        if (session.transcript.length === 0) {
+        if (isReaping(sessionId)) {
+          res.status(409).json({ error: "Session is ending. Please start a new session." });
+          return;
+        }
+
+        const session = getOrCreateSession(sessionId);
+        const isFirstMessage = session.transcript.length === 0;
+
+        if (isFirstMessage) {
+          // Bind this session to the calling user and capture client metadata.
+          session.ownerId = userId;
           session.setClientInfo(extractClientInfo(req));
 
           // Validate and set model for this session.
@@ -168,6 +176,9 @@ export function createChatRouter(
           } catch (err) {
             console.error("[chat] Could not create DB session row:", err);
           }
+        } else if (session.ownerId !== null && session.ownerId !== userId) {
+          res.status(403).json({ error: "Forbidden." });
+          return;
         }
 
         // Store uploaded files on the session for later email attachment.

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -79,6 +79,8 @@ export class Session {
   promptName: string | null = null;
   /** Whether extended thinking is enabled for this session. Null until set on the first message. */
   extendedThinking: boolean | null = null;
+  /** Authenticated user ID that owns this session. Set on the first message; subsequent callers must match. */
+  ownerId: string | null = null;
 
   /**
    * Record a user message.
@@ -173,5 +175,6 @@ export class Session {
     this.model = null;
     this.promptName = null;
     this.extendedThinking = null;
+    this.ownerId = null;
   }
 }


### PR DESCRIPTION
## Summary

Daily automated bug sweep found four confirmed bugs. All fixes verified by `npm run build`.

---

## Confirmed bugs fixed

### BUG-1 [HIGH] — IDOR: no session ownership check in `POST /api/chat`

**File:** `apps/api/src/routes/chat.ts`

Any authenticated user who knew or guessed another user's `sessionId` UUID could inject messages into their active tutoring session. The `userId` from the Bearer token was stored to the DB on the first message but was never written to the in-memory `Session`, so subsequent chat requests had no way to verify ownership.

**Fix:** Added `ownerId: string | null` to the `Session` class (`packages/core/src/session.ts`). On the first message the route sets `session.ownerId = userId`. On subsequent messages, if `ownerId` is set and doesn't match the caller, the route returns `403 Forbidden`.

---

### BUG-2 [HIGH] — Race: `removeSession` before async teardown allows ghost session resurrection

**File:** `apps/api/src/index.ts`, `apps/api/src/lib/session-store.ts`, `apps/api/src/routes/chat.ts`

The inactivity sweep called `removeSession(sessionId)` at the top of its teardown loop — before any async I/O (two DB reads + Resend API call + two DB writes). During that async window, a concurrent `POST /api/chat` with the same `sessionId` would call `getOrCreateSession`, find nothing in the store, and create a fresh empty `Session`. That fresh session's `createSession(db, ...)` would then fail silently with a PK conflict, and any subsequent messages would be persisted against a DB session already being marked `ended_at`.

**Fix:** Replaced `removeSession` at the top of the sweep body with `markReaping(sessionId)`. The session stays in the store until `finishReap` completes; `finishReap` now calls `removeSession` + `unmarkReaping` in a `finally` block. `chat.ts` returns `409` if `isReaping(sessionId)` is true, preventing ghost session creation. Three new exports added to `session-store.ts`: `markReaping`, `unmarkReaping`, `isReaping`.

---

### BUG-3 [MEDIUM] — `/api/history` silently disabled when `SUPABASE_ANON_KEY` is absent

**File:** `apps/api/src/index.ts`

The history router was nested inside `if (anonDb)` alongside the auth router. `createHistoryRouter(db)` only uses the service-role `db` client — it has no dependency on the anon client. When `SUPABASE_ANON_KEY` is absent (or the anon client fails to initialize), authenticated users would receive `404` on all `/api/history` requests.

**Fix:** Moved `app.use("/api/history", createHistoryRouter(db))` outside the `if (anonDb)` block.

---

### BUG-4 [LOW] — IP extraction bypasses Express trust-proxy logic

**File:** `apps/api/src/lib/geo.ts`

`extractClientInfo` manually parsed the raw `x-forwarded-for` header instead of using Express's `req.ip`, which respects the `app.set("trust proxy", 1)` setting already in place. In multi-proxy or local-dev environments this allowed attacker-controlled values to spoof `client_ip` and geolocation in the `sessions` table.

**Fix:** Replaced the manual header extraction with `req.ip ?? req.socket.remoteAddress ?? ""`. Functionally identical in production (Render, single trusted proxy); more correct everywhere else.

---

## False positives discarded

| Claim | Ruled out |
|-------|-----------|
| `void finishReap()` swallows errors | Has explicit try/catch; `void` is correct for fire-and-forget with internal error handling |
| `authedFetch` retries consumed `FormData` | `FormData` is not single-use; each `fetch` call re-serializes it independently |
| `markEmailSentPersisted` mutates removed session | DB `email_sent=true` is the real guard; in-memory mutation is secondary |
| `touchActivity` before DB write divergence | In-memory `lastActivityAt` is what the sweep reads; DB column is analytics-only |
| Map iterator + `store.delete` safety | Per ES2015 spec, safe for already-visited entries |
| `history.js` Escape listener leak | Cleaned up on full-page navigation |
| `settings.js` onAuthStateChange accumulation | One subscription per full page load; not an accumulation issue |
| `resetSessionState` writes to detached element | Harmless; `finally` re-enables input correctly |

---

## Open GitHub issues

No open issues labeled `bug` at sweep time.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code) — daily bug sweep