### PR TITLE
feat: extract shared layout CSS and add mobile sidebar breakpoints (#238, #239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,10 +569,13 @@ These apply to every Claude Code session in this repo.
 | `apps/web/public/login.html` | Login/register/forgot-password page. Unauthenticated users are redirected here. |
 | `apps/web/public/login.css` | Styles for `login.html`. Self-contained dark theme mirroring `styles.css` palette. |
 | `apps/web/public/login.js` | Tabbed login/register/forgot panels. Calls the three server-side proxy endpoints for rate-limited operations; delegates hash callbacks (signup, recovery) to supabase-js's `detectSessionInUrl`. Listens for `PASSWORD_RECOVERY` to redirect into the settings page. |
-| `apps/web/public/settings.html` | Settings page — account info, preferences, email change, password change. Loads supabase-js + auth.js. |
+| `apps/web/public/layout.css` | Shared design tokens (`:root` variables), base resets, app-shell layout (`.app-header`, `.app-body`, `.page-sidebar`, `.page-content`), and mobile breakpoints (≤768px). Loaded before per-page stylesheets by admin.html, settings.html, and history.html. |
+| `apps/web/public/settings.html` | Settings page — account info, preferences, email change, password change. Loads layout.css, settings.css, supabase-js, auth.js. |
 | `apps/web/public/settings.js` | Uses supabase-js directly: `auth.updateUser` for password/email changes (with `currentPassword` verification when not in recovery), and direct `profiles` upsert under RLS for transcript preferences. Email-change flow passes `emailRedirectTo: window.location.origin + "/settings.html"` and listens for `USER_UPDATED`/`EMAIL_CHANGE` events on `onAuthStateChange` to refresh the displayed email after confirmation. |
-| `apps/web/public/history.html` | Session history page. Loads supabase-js + auth.js. |
+| `apps/web/public/history.html` | Session history page. Loads layout.css, history.css, supabase-js, auth.js. |
 | `apps/web/public/history.js` | Uses `authedFetch` to call `/api/history` and `/api/transcript/:id`. |
+| `apps/web/public/admin.html` | Admin panel (evaluation batch management). Loads layout.css, admin.css, supabase-js, auth.js. |
+| `apps/web/public/admin.css` | Admin-specific styles — cards, table, status badges, inputs, buttons. Page-specific only; shared tokens and shell live in layout.css. |
 | `apps/web/public/manifest.json` | PWA web app manifest — standalone display, theme colors, icon references |
 | `apps/web/public/icons/` | PWA app icons (192×192 and 512×512 PNGs) for home-screen and manifest |
 | `apps/cli/src/index.ts` | Terminal REPL — readline loop, `sendMessage()`, transcript export |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -27,6 +27,8 @@ apps/web/
 │   ├── history.css    ← Session history page styles
 │   ├── history.js     ← Session history logic
 │   ├── admin.html     ← Admin panel (evaluation batch management)
+│   ├── admin.css      ← Admin page styles (page-specific; layout.css loaded first)
+│   ├── layout.css     ← Shared tokens and app-shell layout (loaded by admin, settings, history)
 │   ├── mockup.html    ← Static UI reference implementation (docs/ui-style-guide.md)
 │   ├── manifest.json  ← PWA web app manifest
 │   └── icons/         ← PWA app icons (192×192 and 512×512 PNGs)
@@ -34,7 +36,7 @@ apps/web/
 └── README.md
 ```
 
-Each page has a matching CSS file (`page.html` + `page.css`) and, where needed, a page JS module (`page.js`). `styles.css` and `auth.js` are shared.
+Each page has a matching CSS file (`page.html` + `page.css`) and, where needed, a page JS module (`page.js`). `styles.css` and `auth.js` are shared across the main chat page. `layout.css` is shared across the admin, settings, and history pages, which all load it before their own per-page stylesheet.
 
 ## Usage
 

--- a/apps/web/public/admin.css
+++ b/apps/web/public/admin.css
@@ -1,153 +1,6 @@
-/* admin.css — standalone styles for /admin.html.
- *
- * Mirrors the settings.css pattern: warm-red palette, shared layout shell
- * (.app-header / .app-body / .page-sidebar / .page-content), plus admin-
- * specific component styles (cards, table, status badges, inputs).
- *
- * Note: the :root token block and layout shell rules are duplicated from
- * settings.css / history.css. A shared layout.css is filed as follow-on
- * work — intentionally not extracted in this PR.
+/* admin.css — page-specific styles for /admin.html.
+ * Shared tokens and app-shell layout live in layout.css (loaded first).
  */
-
-:root {
-  --bg:           #fffdf7;
-  --surface:      #ffffff;
-  --surface-alt:  #fffbf7;
-  --card:         #ffffff;
-  --border:       #e2e8f0;
-  --border-bright:#d1d5db;
-  --text:         #1e293b;
-  --text-muted:   #64748b;
-  --accent:       #e8392a;
-  --accent-light: #fee2e2;
-  --accent-dark:  #c42d1e;
-  --accent-hover: #c42d1e;
-  --tutor-accent: #f97316;
-  --header-bg:    #b91c1c;
-  --danger:       #ef4444;
-  --success:      #22c55e;
-  --font-heading: 'Nunito', sans-serif;
-  --font-sans:    'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-* { box-sizing: border-box; }
-
-html, body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-sans);
-  -webkit-font-smoothing: antialiased;
-}
-
-/* ── App shell (shared with settings.css / history.css) ── */
-.app-header {
-  height: 64px;
-  background: var(--header-bg);
-  display: flex; align-items: center;
-  padding: 0 20px; gap: 14px; flex-shrink: 0;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
-}
-.app-header .logo-box {
-  width: 36px; height: 36px; background: #e8392a;
-  border-radius: 10px; display: flex; align-items: center;
-  justify-content: center; flex-shrink: 0;
-  box-shadow: 0 4px 14px rgba(232,57,42,0.45);
-}
-.app-header .brand-name {
-  font-family: var(--font-heading); font-weight: 900;
-  font-size: 20px; color: #fff; line-height: 1;
-}
-.app-header .brand-sub {
-  font-size: 9px; font-weight: 600; letter-spacing: 2.5px;
-  text-transform: uppercase; color: rgba(255,255,255,0.35);
-}
-.app-header .header-wordmark { display: flex; flex-direction: column; gap: 1px; }
-.app-header .header-divider {
-  width: 1px; height: 28px; background: rgba(255,255,255,0.1);
-}
-.app-header .page-title {
-  font-family: var(--font-heading); font-weight: 700;
-  font-size: 15px; color: rgba(255,255,255,0.7);
-}
-.app-header .header-spacer { flex: 1; }
-
-.app-body {
-  display: flex; flex: 1; min-height: 0;
-  height: calc(100vh - 64px); overflow: hidden;
-}
-
-/* ── Sidebar ── */
-.page-sidebar {
-  width: 220px; flex-shrink: 0;
-  background: #fffbf7; border-right: 1px solid var(--border);
-  display: flex; flex-direction: column; overflow: hidden;
-  transition: width .2s ease;
-}
-.page-sidebar.collapsed { width: 60px; }
-.page-sidebar .nav-group { padding: 20px 12px 8px; }
-.page-sidebar .nav-group-label {
-  font-size: 10px; font-weight: 700; letter-spacing: 1.8px;
-  text-transform: uppercase; color: #94a3b8;
-  padding: 0 8px; margin-bottom: 6px; white-space: nowrap; overflow: hidden;
-}
-.page-sidebar .nav-link {
-  display: flex; align-items: center; gap: 10px;
-  padding: 9px 10px; border-radius: 9px;
-  font-size: 13.5px; font-weight: 500; color: #475569;
-  cursor: pointer; margin-bottom: 2px; white-space: nowrap;
-  transition: background .12s, color .12s; text-decoration: none;
-}
-.page-sidebar .nav-link:hover { background: #fff5f5; color: #1e293b; }
-.page-sidebar .nav-link.active {
-  background: var(--accent-light); color: var(--accent-dark); font-weight: 700;
-}
-.page-sidebar .nav-link.active .nl-icon { color: var(--accent); }
-.page-sidebar .nav-link.nav-disabled {
-  pointer-events: none; opacity: 0.5;
-}
-.page-sidebar .nl-icon { width: 17px; height: 17px; flex-shrink: 0; color: #94a3b8; }
-.page-sidebar .nl-soon {
-  margin-left: auto; font-size: 10px; color: #cbd5e1; font-style: italic;
-}
-.page-sidebar .sidebar-footer {
-  margin-top: auto; border-top: 1px solid var(--border); padding: 14px 12px;
-}
-.page-sidebar .sidebar-user-row {
-  display: flex; align-items: center; gap: 9px;
-  padding: 8px 10px; border-radius: 9px; cursor: pointer;
-}
-.page-sidebar .sidebar-user-row:hover { background: #fff5f5; }
-.page-sidebar .s-avatar {
-  width: 32px; height: 32px; background: #e8392a; border-radius: 8px;
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-heading); font-weight: 800; font-size: 12px;
-  color: #fff; flex-shrink: 0;
-}
-.page-sidebar .s-user-info { flex: 1; min-width: 0; }
-.page-sidebar .s-name {
-  font-size: 13px; font-weight: 600; color: #1e293b;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.page-sidebar .s-grade { font-size: 11px; color: #94a3b8; margin-top: 1px; }
-
-.page-sidebar.collapsed .nav-group-label,
-.page-sidebar.collapsed .nav-link-text,
-.page-sidebar.collapsed .nl-soon,
-.page-sidebar.collapsed .s-user-info { display: none; }
-.page-sidebar.collapsed .nav-link {
-  width: 42px; height: 42px; padding: 0;
-  justify-content: center; border-radius: 10px; margin: 2px auto;
-}
-.page-sidebar.collapsed .nav-group { padding: 12px 9px; }
-
-/* ── Page content area ── */
-.page-content {
-  flex: 1; overflow-y: auto; background: var(--bg);
-}
 
 /* ── Admin-specific layout ── */
 .admin-shell {
@@ -327,4 +180,11 @@ html, body {
   color: var(--text-muted);
   font-size: 0.85rem;
   padding: 0.5rem 0;
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .admin-shell {
+    padding: 1.25rem 1rem;
+  }
 }

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/layout.css">
   <link rel="stylesheet" href="/admin.css">
 </head>
 <body>

--- a/apps/web/public/history.css
+++ b/apps/web/public/history.css
@@ -1,147 +1,6 @@
-/* history.css — standalone styles for /history.html.
- *
- * Mirrors the login.css dark theme palette and CSS variable approach.
- * Self-contained so the page can be tested in isolation.
+/* history.css — page-specific styles for /history.html.
+ * Shared tokens and app-shell layout live in layout.css (loaded first).
  */
-
-:root {
-  --bg:           #fffdf7;
-  --surface:      #ffffff;
-  --card:         #ffffff;
-  --border:       #e2e8f0;
-  --border-bright:#d1d5db;
-  --text:         #1e293b;
-  --text-muted:   #64748b;
-  --accent:       #e8392a;
-  --accent-light: #fee2e2;
-  --accent-dark:  #c42d1e;
-  --accent-hover: #c42d1e;
-  --tutor-accent: #f97316;
-  --header-bg:    #b91c1c;
-  --danger:       #ef4444;
-  --success:      #22c55e;
-  --font-heading: 'Nunito', sans-serif;
-}
-
-* { box-sizing: border-box; }
-
-html, body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, sans-serif;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* ── App shell ── */
-.app-header {
-  height: 64px;
-  background: var(--header-bg);
-  display: flex; align-items: center;
-  padding: 0 20px; gap: 14px; flex-shrink: 0;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
-}
-.app-header .logo-box {
-  width: 36px; height: 36px; background: #e8392a;
-  border-radius: 10px; display: flex; align-items: center;
-  justify-content: center; flex-shrink: 0;
-  box-shadow: 0 4px 14px rgba(232,57,42,0.45);
-}
-.app-header .brand-name {
-  font-family: var(--font-heading); font-weight: 900;
-  font-size: 20px; color: #fff; line-height: 1;
-}
-.app-header .brand-sub {
-  font-size: 9px; font-weight: 600; letter-spacing: 2.5px;
-  text-transform: uppercase; color: rgba(255,255,255,0.35);
-}
-.app-header .header-wordmark { display: flex; flex-direction: column; gap: 1px; }
-.app-header .header-divider {
-  width: 1px; height: 28px; background: rgba(255,255,255,0.1);
-}
-.app-header .page-title {
-  font-family: var(--font-heading); font-weight: 700;
-  font-size: 15px; color: rgba(255,255,255,0.7);
-}
-.app-header .header-spacer { flex: 1; }
-
-.app-body {
-  display: flex; flex: 1; min-height: 0;
-  height: calc(100vh - 64px); overflow: hidden;
-}
-
-/* ── Sidebar ── */
-.page-sidebar {
-  width: 220px; flex-shrink: 0;
-  background: #fffbf7; border-right: 1px solid var(--border);
-  display: flex; flex-direction: column; overflow: hidden;
-  transition: width .2s ease;
-}
-.page-sidebar.collapsed { width: 60px; }
-.page-sidebar .nav-group { padding: 20px 12px 8px; }
-.page-sidebar .nav-group-label {
-  font-size: 10px; font-weight: 700; letter-spacing: 1.8px;
-  text-transform: uppercase; color: #94a3b8;
-  padding: 0 8px; margin-bottom: 6px; white-space: nowrap; overflow: hidden;
-}
-.page-sidebar .nav-link {
-  display: flex; align-items: center; gap: 10px;
-  padding: 9px 10px; border-radius: 9px;
-  font-size: 13.5px; font-weight: 500; color: #475569;
-  cursor: pointer; margin-bottom: 2px; white-space: nowrap;
-  transition: background .12s, color .12s; text-decoration: none;
-}
-.page-sidebar .nav-link:hover { background: #fff5f5; color: #1e293b; }
-.page-sidebar .nav-link.active {
-  background: var(--accent-light); color: var(--accent-dark); font-weight: 700;
-}
-.page-sidebar .nav-link.active .nl-icon { color: var(--accent); }
-.page-sidebar .nav-link.nav-disabled {
-  pointer-events: none; opacity: 0.5;
-}
-.page-sidebar .nl-icon { width: 17px; height: 17px; flex-shrink: 0; color: #94a3b8; }
-.page-sidebar .nav-link-text { }
-.page-sidebar .nl-soon {
-  margin-left: auto; font-size: 10px; color: #cbd5e1; font-style: italic;
-}
-.page-sidebar .sidebar-footer {
-  margin-top: auto; border-top: 1px solid var(--border); padding: 14px 12px;
-}
-.page-sidebar .sidebar-user-row {
-  display: flex; align-items: center; gap: 9px;
-  padding: 8px 10px; border-radius: 9px; cursor: pointer;
-}
-.page-sidebar .sidebar-user-row:hover { background: #fff5f5; }
-.page-sidebar .s-avatar {
-  width: 32px; height: 32px; background: #e8392a; border-radius: 8px;
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-heading); font-weight: 800; font-size: 12px;
-  color: #fff; flex-shrink: 0;
-}
-.page-sidebar .s-user-info { flex: 1; min-width: 0; }
-.page-sidebar .s-name {
-  font-size: 13px; font-weight: 600; color: #1e293b;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.page-sidebar .s-grade { font-size: 11px; color: #94a3b8; margin-top: 1px; }
-
-/* Collapsed: hide text */
-.page-sidebar.collapsed .nav-group-label,
-.page-sidebar.collapsed .nav-link-text,
-.page-sidebar.collapsed .nl-soon,
-.page-sidebar.collapsed .s-user-info { display: none; }
-.page-sidebar.collapsed .nav-link {
-  width: 42px; height: 42px; padding: 0;
-  justify-content: center; border-radius: 10px; margin: 2px auto;
-}
-.page-sidebar.collapsed .nav-group { padding: 12px 9px; }
-
-/* ── Page content area ── */
-.page-content {
-  flex: 1; overflow-y: auto; background: var(--bg);
-}
 
 /* History is a real page, not a centered overlay. The session list
  * fills the content pane beside the sidebar. */
@@ -214,7 +73,7 @@ html, body {
 }
 
 .history-item {
-  background: #fffbf7;
+  background: var(--surface-alt);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.85rem 1rem;
@@ -434,3 +293,13 @@ html, body {
 .rating-pill.experience-positive { background: rgba(232,57,42,0.08); border-color: rgba(232,57,42,0.3); color: #c42d1e; }
 .rating-pill.experience-neutral  { background: rgba(100,116,139,0.1); border-color: rgba(100,116,139,0.3); color: #64748b; }
 .rating-pill.experience-negative { background: rgba(239,68,68,0.1);   border-color: rgba(239,68,68,0.3);   color: #ef4444; }
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .history-shell {
+    padding: 1.25rem 1rem;
+  }
+  .history-card {
+    padding: 1.25rem;
+  }
+}

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -7,7 +7,8 @@
   <meta name="theme-color" content="#b91c1c">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/layout.css">
   <link rel="stylesheet" href="/history.css">
 </head>
 <body>

--- a/apps/web/public/layout.css
+++ b/apps/web/public/layout.css
@@ -1,0 +1,168 @@
+/* layout.css — shared design tokens and app-shell layout for admin, settings,
+ * and history pages.  Load this before any per-page stylesheet.
+ *
+ * Contains: CSS variables, base resets, .app-header, .app-body, .page-sidebar,
+ * .page-content, and responsive mobile breakpoints (≤768px).
+ *
+ * Do NOT import this from index.html or login.html — those pages have their
+ * own self-contained stylesheets.
+ */
+
+:root {
+  --bg:           #fffdf7;
+  --surface:      #ffffff;
+  --surface-alt:  #fffbf7;
+  --card:         #ffffff;
+  --border:       #e2e8f0;
+  --border-bright:#d1d5db;
+  --text:         #1e293b;
+  --text-muted:   #64748b;
+  --accent:       #e8392a;
+  --accent-light: #fee2e2;
+  --accent-dark:  #c42d1e;
+  --accent-hover: #c42d1e;
+  --tutor-accent: #f97316;
+  --header-bg:    #b91c1c;
+  --danger:       #ef4444;
+  --success:      #22c55e;
+  --text-dim:     #94a3b8;
+  --font-heading: 'Nunito', sans-serif;
+  --font-sans:    'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── App header ── */
+.app-header {
+  height: 64px;
+  background: var(--header-bg);
+  display: flex; align-items: center;
+  padding: 0 20px; gap: 14px; flex-shrink: 0;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.app-header .logo-box {
+  width: 36px; height: 36px; background: var(--accent);
+  border-radius: 10px; display: flex; align-items: center;
+  justify-content: center; flex-shrink: 0;
+  box-shadow: 0 4px 14px rgba(232,57,42,0.45);
+}
+.app-header .brand-name {
+  font-family: var(--font-heading); font-weight: 900;
+  font-size: 20px; color: #fff; line-height: 1;
+}
+.app-header .brand-sub {
+  font-size: 9px; font-weight: 600; letter-spacing: 2.5px;
+  text-transform: uppercase; color: rgba(255,255,255,0.35);
+}
+.app-header .header-wordmark { display: flex; flex-direction: column; gap: 1px; }
+.app-header .header-divider {
+  width: 1px; height: 28px; background: rgba(255,255,255,0.1);
+}
+.app-header .page-title {
+  font-family: var(--font-heading); font-weight: 700;
+  font-size: 15px; color: rgba(255,255,255,0.7);
+}
+.app-header .header-spacer { flex: 1; }
+
+/* ── App body ── */
+.app-body {
+  display: flex; flex: 1; min-height: 0;
+  height: calc(100vh - 64px); overflow: hidden;
+}
+
+/* ── Sidebar ── */
+.page-sidebar {
+  width: 220px; flex-shrink: 0;
+  background: var(--surface-alt); border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; overflow: hidden;
+  transition: width .2s ease;
+}
+.page-sidebar.collapsed { width: 60px; }
+.page-sidebar .nav-group { padding: 20px 12px 8px; }
+.page-sidebar .nav-group-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 1.8px;
+  text-transform: uppercase; color: var(--text-dim);
+  padding: 0 8px; margin-bottom: 6px; white-space: nowrap; overflow: hidden;
+}
+.page-sidebar .nav-link {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 10px; border-radius: 9px;
+  font-size: 13.5px; font-weight: 500; color: #475569;
+  cursor: pointer; margin-bottom: 2px; white-space: nowrap;
+  transition: background .12s, color .12s; text-decoration: none;
+}
+.page-sidebar .nav-link:hover { background: #fff5f5; color: #1e293b; }
+.page-sidebar .nav-link.active {
+  background: var(--accent-light); color: var(--accent-dark); font-weight: 700;
+}
+.page-sidebar .nav-link.active .nl-icon { color: var(--accent); }
+.page-sidebar .nav-link.nav-disabled {
+  pointer-events: none; opacity: 0.5;
+}
+.page-sidebar .nl-icon { width: 17px; height: 17px; flex-shrink: 0; color: var(--text-dim); }
+.page-sidebar .nl-soon {
+  margin-left: auto; font-size: 10px; color: #cbd5e1; font-style: italic;
+}
+.page-sidebar .sidebar-footer {
+  margin-top: auto; border-top: 1px solid var(--border); padding: 14px 12px;
+}
+.page-sidebar .sidebar-user-row {
+  display: flex; align-items: center; gap: 9px;
+  padding: 8px 10px; border-radius: 9px; cursor: pointer;
+}
+.page-sidebar .sidebar-user-row:hover { background: #fff5f5; }
+.page-sidebar .s-avatar {
+  width: 32px; height: 32px; background: var(--accent); border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-heading); font-weight: 800; font-size: 12px;
+  color: #fff; flex-shrink: 0;
+}
+.page-sidebar .s-user-info { flex: 1; min-width: 0; }
+.page-sidebar .s-name {
+  font-size: 13px; font-weight: 600; color: #1e293b;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.page-sidebar .s-grade { font-size: 11px; color: var(--text-dim); margin-top: 1px; }
+
+.page-sidebar.collapsed .nav-group-label,
+.page-sidebar.collapsed .nav-link-text,
+.page-sidebar.collapsed .nl-soon,
+.page-sidebar.collapsed .s-user-info { display: none; }
+.page-sidebar.collapsed .nav-link {
+  width: 42px; height: 42px; padding: 0;
+  justify-content: center; border-radius: 10px; margin: 2px auto;
+}
+.page-sidebar.collapsed .nav-group { padding: 12px 9px; }
+
+/* ── Page content area ── */
+.page-content {
+  flex: 1; overflow-y: auto; background: var(--bg);
+}
+
+/* ── Mobile breakpoints ── */
+@media (max-width: 768px) {
+  .app-body {
+    flex-direction: column;
+    height: auto;
+    min-height: calc(100vh - 64px);
+    overflow-y: auto;
+  }
+  .page-sidebar {
+    display: none;
+  }
+  .page-content {
+    min-height: calc(100vh - 64px);
+    overflow-y: visible;
+  }
+}

--- a/apps/web/public/settings.css
+++ b/apps/web/public/settings.css
@@ -1,146 +1,6 @@
-/* settings.css — standalone styles for /settings.html.
- *
- * Mirrors the login.css dark theme palette and CSS variable approach.
- * Self-contained so the page can be tested in isolation.
+/* settings.css — page-specific styles for /settings.html.
+ * Shared tokens and app-shell layout live in layout.css (loaded first).
  */
-
-:root {
-  --bg:           #fffdf7;
-  --surface:      #ffffff;
-  --card:         #ffffff;
-  --border:       #e2e8f0;
-  --border-bright:#d1d5db;
-  --text:         #1e293b;
-  --text-muted:   #64748b;
-  --accent:       #e8392a;
-  --accent-light: #fee2e2;
-  --accent-dark:  #c42d1e;
-  --accent-hover: #c42d1e;
-  --tutor-accent: #f97316;
-  --header-bg:    #b91c1c;
-  --danger:       #ef4444;
-  --success:      #22c55e;
-  --font-heading: 'Nunito', sans-serif;
-}
-
-* { box-sizing: border-box; }
-
-html, body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, sans-serif;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* ── App shell (shared with history.css) ── */
-.app-header {
-  height: 64px;
-  background: var(--header-bg);
-  display: flex; align-items: center;
-  padding: 0 20px; gap: 14px; flex-shrink: 0;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
-}
-.app-header .logo-box {
-  width: 36px; height: 36px; background: #e8392a;
-  border-radius: 10px; display: flex; align-items: center;
-  justify-content: center; flex-shrink: 0;
-  box-shadow: 0 4px 14px rgba(232,57,42,0.45);
-}
-.app-header .brand-name {
-  font-family: var(--font-heading); font-weight: 900;
-  font-size: 20px; color: #fff; line-height: 1;
-}
-.app-header .brand-sub {
-  font-size: 9px; font-weight: 600; letter-spacing: 2.5px;
-  text-transform: uppercase; color: rgba(255,255,255,0.35);
-}
-.app-header .header-wordmark { display: flex; flex-direction: column; gap: 1px; }
-.app-header .header-divider {
-  width: 1px; height: 28px; background: rgba(255,255,255,0.1);
-}
-.app-header .page-title {
-  font-family: var(--font-heading); font-weight: 700;
-  font-size: 15px; color: rgba(255,255,255,0.7);
-}
-.app-header .header-spacer { flex: 1; }
-
-.app-body {
-  display: flex; flex: 1; min-height: 0;
-  height: calc(100vh - 64px); overflow: hidden;
-}
-
-/* ── Sidebar ── */
-.page-sidebar {
-  width: 220px; flex-shrink: 0;
-  background: #fffbf7; border-right: 1px solid var(--border);
-  display: flex; flex-direction: column; overflow: hidden;
-  transition: width .2s ease;
-}
-.page-sidebar.collapsed { width: 60px; }
-.page-sidebar .nav-group { padding: 20px 12px 8px; }
-.page-sidebar .nav-group-label {
-  font-size: 10px; font-weight: 700; letter-spacing: 1.8px;
-  text-transform: uppercase; color: #94a3b8;
-  padding: 0 8px; margin-bottom: 6px; white-space: nowrap; overflow: hidden;
-}
-.page-sidebar .nav-link {
-  display: flex; align-items: center; gap: 10px;
-  padding: 9px 10px; border-radius: 9px;
-  font-size: 13.5px; font-weight: 500; color: #475569;
-  cursor: pointer; margin-bottom: 2px; white-space: nowrap;
-  transition: background .12s, color .12s; text-decoration: none;
-}
-.page-sidebar .nav-link:hover { background: #fff5f5; color: #1e293b; }
-.page-sidebar .nav-link.active {
-  background: var(--accent-light); color: var(--accent-dark); font-weight: 700;
-}
-.page-sidebar .nav-link.active .nl-icon { color: var(--accent); }
-.page-sidebar .nav-link.nav-disabled {
-  pointer-events: none; opacity: 0.5;
-}
-.page-sidebar .nl-icon { width: 17px; height: 17px; flex-shrink: 0; color: #94a3b8; }
-.page-sidebar .nav-link-text { }
-.page-sidebar .nl-soon {
-  margin-left: auto; font-size: 10px; color: #cbd5e1; font-style: italic;
-}
-.page-sidebar .sidebar-footer {
-  margin-top: auto; border-top: 1px solid var(--border); padding: 14px 12px;
-}
-.page-sidebar .sidebar-user-row {
-  display: flex; align-items: center; gap: 9px;
-  padding: 8px 10px; border-radius: 9px; cursor: pointer;
-}
-.page-sidebar .sidebar-user-row:hover { background: #fff5f5; }
-.page-sidebar .s-avatar {
-  width: 32px; height: 32px; background: #e8392a; border-radius: 8px;
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-heading); font-weight: 800; font-size: 12px;
-  color: #fff; flex-shrink: 0;
-}
-.page-sidebar .s-user-info { flex: 1; min-width: 0; }
-.page-sidebar .s-name {
-  font-size: 13px; font-weight: 600; color: #1e293b;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.page-sidebar .s-grade { font-size: 11px; color: #94a3b8; margin-top: 1px; }
-
-.page-sidebar.collapsed .nav-group-label,
-.page-sidebar.collapsed .nav-link-text,
-.page-sidebar.collapsed .nl-soon,
-.page-sidebar.collapsed .s-user-info { display: none; }
-.page-sidebar.collapsed .nav-link {
-  width: 42px; height: 42px; padding: 0;
-  justify-content: center; border-radius: 10px; margin: 2px auto;
-}
-.page-sidebar.collapsed .nav-group { padding: 12px 9px; }
-
-/* ── Page content area ── */
-.page-content {
-  flex: 1; overflow-y: auto; background: var(--bg);
-}
 
 /* Settings is a real page, not a centered overlay. The form is
  * left-anchored in the content pane with a readable max-width. */
@@ -232,7 +92,7 @@ html, body {
 }
 
 .settings-input {
-  background: #fffbf7;
+  background: var(--surface-alt);
   border: 1.5px solid var(--border);
   border-radius: 8px;
   padding: 0.6rem 0.75rem;
@@ -333,4 +193,11 @@ html, body {
   font-size: 0.85rem;
   color: var(--text);
   margin-bottom: 0.85rem;
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .settings-shell {
+    padding: 1.25rem 1rem;
+  }
 }

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -7,7 +7,8 @@
   <meta name="theme-color" content="#b91c1c">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/layout.css">
   <link rel="stylesheet" href="/settings.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary

- **#238**: Creates `apps/web/public/layout.css` with shared design tokens (`:root` variables), base resets, and app-shell layout rules (`.app-header`, `.app-body`, `.page-sidebar`, `.page-content`). The three per-page stylesheets (`admin.css`, `settings.css`, `history.css`) now load `layout.css` first and contain only page-specific overrides, eliminating ~140 lines of duplicated CSS from each file.
- **#239**: Adds `@media (max-width: 768px)` to `layout.css` that stacks `.app-body` vertically and hides `.page-sidebar`; each per-page file adds a matching shell padding override.

Additional improvements from `/simplify` review:
- Added `--text-dim: #94a3b8` token to `:root` and replaced 3 hardcoded sidebar color values
- Tokenized hardcoded `#e8392a` logo/avatar backgrounds to `var(--accent)`
- Tokenized hardcoded `#fffbf7` values in settings/history to `var(--surface-alt)`
- Aligned JetBrains Mono font loading across all three pages (settings.html and history.html were missing it)

## Test plan

- [ ] Load `/settings.html` — page renders correctly with sidebar and content at desktop width
- [ ] Load `/history.html` — page renders correctly
- [ ] Load `/admin.html` — page renders correctly
- [ ] Resize to ≤768px — sidebar hides, content fills full width on all three pages
- [ ] Confirm fonts load correctly (Nunito, Plus Jakarta Sans, JetBrains Mono) in Network tab

Closes #238
Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)