### PR TITLE
feat: sidebar session resume + 60-min idle timeout (#241, #244)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -100,6 +100,8 @@
   const sidebarDisplayName = $('sidebar-display-name');
   const sidebarAvatarInitials = $('sidebar-avatar-initials');
   const sidebarGrade       = $('sidebar-grade');
+  const sidebarSettings    = $('sidebar-settings');
+  const sidebarHistory     = $('sidebar-history');
 
   // ── Config ────────────────────────────────────────────────────────────────
   async function fetchConfig() {
@@ -1130,6 +1132,22 @@
     saveResumeIfActive();
     window.location.href = '/history.html';
   });
+
+  // Sidebar nav links also need to preserve the session before navigating.
+  if (sidebarSettings) {
+    sidebarSettings.addEventListener('click', e => {
+      e.preventDefault();
+      saveResumeIfActive();
+      window.location.href = '/settings.html';
+    });
+  }
+  if (sidebarHistory) {
+    sidebarHistory.addEventListener('click', e => {
+      e.preventDefault();
+      saveResumeIfActive();
+      window.location.href = '/history.html';
+    });
+  }
   menuLogout.addEventListener('click', () => {
     closeAccountDropdown();
     handleLogout();

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1122,32 +1122,16 @@
     }
   }
 
-  menuSettings.addEventListener('click', () => {
-    closeAccountDropdown();
+  function navigateTo(url) {
     saveResumeIfActive();
-    window.location.href = '/settings.html';
-  });
-  menuHistory.addEventListener('click', () => {
-    closeAccountDropdown();
-    saveResumeIfActive();
-    window.location.href = '/history.html';
-  });
+    window.location.href = url;
+  }
 
-  // Sidebar nav links also need to preserve the session before navigating.
-  if (sidebarSettings) {
-    sidebarSettings.addEventListener('click', e => {
-      e.preventDefault();
-      saveResumeIfActive();
-      window.location.href = '/settings.html';
-    });
-  }
-  if (sidebarHistory) {
-    sidebarHistory.addEventListener('click', e => {
-      e.preventDefault();
-      saveResumeIfActive();
-      window.location.href = '/history.html';
-    });
-  }
+  menuSettings.addEventListener('click', () => { closeAccountDropdown(); navigateTo('/settings.html'); });
+  menuHistory.addEventListener('click',  () => { closeAccountDropdown(); navigateTo('/history.html'); });
+
+  if (sidebarSettings) sidebarSettings.addEventListener('click', e => { e.preventDefault(); navigateTo('/settings.html'); });
+  if (sidebarHistory)  sidebarHistory.addEventListener('click',  e => { e.preventDefault(); navigateTo('/history.html'); });
   menuLogout.addEventListener('click', () => {
     closeAccountDropdown();
     handleLogout();

--- a/apps/web/public/auth.js
+++ b/apps/web/public/auth.js
@@ -19,6 +19,33 @@
   let client = null;
   let initPromise = null;
 
+  // ── Idle-session enforcement ──────────────────────────────────────────────
+  // Re-require login if the user has been inactive for more than 60 minutes.
+  // "Activity" is any mouse move, key press, click, or touch. We track it in
+  // localStorage so the clock is shared across tabs.
+  const IDLE_KEY     = 'auth.lastActivityAt';
+  const IDLE_LIMIT   = 60 * 60 * 1000; // 60 minutes
+
+  function touchActivity() {
+    localStorage.setItem(IDLE_KEY, Date.now().toString());
+  }
+
+  function isIdleExpired() {
+    const raw = localStorage.getItem(IDLE_KEY);
+    if (!raw) return false; // no record → new session, not expired
+    return (Date.now() - parseInt(raw, 10)) > IDLE_LIMIT;
+  }
+
+  let trackingStarted = false;
+  function startActivityTracking() {
+    if (trackingStarted) return;
+    trackingStarted = true;
+    ['mousemove', 'keydown', 'click', 'touchstart', 'scroll'].forEach(evt =>
+      document.addEventListener(evt, touchActivity, { passive: true, capture: true })
+    );
+    touchActivity(); // record activity on page load
+  }
+
   async function loadConfig() {
     const res = await fetch("/api/config", { cache: "no-store" });
     if (!res.ok) throw new Error("config fetch failed: " + res.status);
@@ -67,6 +94,13 @@
       window.location.href = "/login.html";
       throw new Error("not_authenticated");
     }
+    if (isIdleExpired()) {
+      try { await client.auth.signOut(); } catch (_) { /* ignore */ }
+      localStorage.removeItem(IDLE_KEY);
+      window.location.href = "/login.html?reason=session_expired";
+      throw new Error("idle_timeout");
+    }
+    startActivityTracking();
     return session;
   }
 
@@ -100,6 +134,7 @@
 
   async function signOut() {
     await init();
+    localStorage.removeItem(IDLE_KEY);
     try { await client.auth.signOut(); } catch (e) { /* ignore */ }
     window.location.href = "/login.html";
   }

--- a/apps/web/public/auth.js
+++ b/apps/web/public/auth.js
@@ -19,20 +19,21 @@
   let client = null;
   let initPromise = null;
 
-  // ── Idle-session enforcement ──────────────────────────────────────────────
-  // Re-require login if the user has been inactive for more than 60 minutes.
-  // "Activity" is any mouse move, key press, click, or touch. We track it in
-  // localStorage so the clock is shared across tabs.
-  const IDLE_KEY     = 'auth.lastActivityAt';
-  const IDLE_LIMIT   = 60 * 60 * 1000; // 60 minutes
+  // ── Idle-session enforcement — re-login after 60 min of inactivity ──────────
+  const IDLE_KEY   = 'auth.lastActivityAt';
+  const IDLE_LIMIT = 60 * 60 * 1000; // 60 minutes; independent of server inactivity sweep (10 min)
 
+  let lastWrite = 0;
   function touchActivity() {
-    localStorage.setItem(IDLE_KEY, Date.now().toString());
+    const now = Date.now();
+    if (now - lastWrite < 10_000) return; // throttle: write at most once per 10 s
+    lastWrite = now;
+    localStorage.setItem(IDLE_KEY, now);
   }
 
   function isIdleExpired() {
     const raw = localStorage.getItem(IDLE_KEY);
-    if (!raw) return false; // no record → new session, not expired
+    if (!raw) return false; // absent → treat as just-active (first load or cleared storage)
     return (Date.now() - parseInt(raw, 10)) > IDLE_LIMIT;
   }
 
@@ -43,7 +44,7 @@
     ['mousemove', 'keydown', 'click', 'touchstart', 'scroll'].forEach(evt =>
       document.addEventListener(evt, touchActivity, { passive: true, capture: true })
     );
-    touchActivity(); // record activity on page load
+    touchActivity();
   }
 
   async function loadConfig() {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -87,7 +87,7 @@
           <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/><path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/></svg>
           <span class="nav-link-text">Tutor</span>
         </a>
-        <a href="/history.html" class="nav-link">
+        <a href="/history.html" class="nav-link" id="sidebar-history">
           <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
           <span class="nav-link-text">Session History</span>
         </a>
@@ -104,7 +104,7 @@
       </div>
       <div class="nav-group">
         <div class="nav-group-label">Account</div>
-        <a href="/settings.html" class="nav-link">
+        <a href="/settings.html" class="nav-link" id="sidebar-settings">
           <svg class="nl-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
           <span class="nav-link-text">Settings</span>
         </a>


### PR DESCRIPTION
## Summary
- **#241**: Sidebar nav links to Settings and History now call `saveResumeIfActive()` before navigating, so an in-progress tutor session can be restored on return. Previously only the account dropdown menu items did this.
- **#244**: `auth.js` now tracks user activity (mousemove, keydown, click, touch, scroll) in `localStorage` and rejects `requireSession()` with a redirect to `/login.html?reason=session_expired` after 60 minutes of inactivity. Activity writes are throttled to once per 10s.
- Unified all session-preserving navigation behind a single `navigateTo(url)` helper.

## Closes
- #241
- #244

## Test plan
- [ ] On `/`, start a tutor conversation, click Settings in the sidebar → return via sidebar Tutor link → session restored.
- [ ] Same flow via the account dropdown → session restored.
- [ ] Idle in another tab for 60+ minutes → on next action, redirected to `/login.html?reason=session_expired`.
- [ ] Verify `localStorage['auth.lastActivityAt']` updates at most once per ~10 seconds during heavy mouse activity.
- [ ] Sign out clears `auth.lastActivityAt` from localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)