### PR TITLE
feat: widen settings + admin console launchpad (#242, #243)

### DIFF
--- a/apps/web/public/admin.css
+++ b/apps/web/public/admin.css
@@ -30,6 +30,106 @@
   font-weight: 600;
 }
 
+/* ── Launchpad ── */
+.admin-launchpad {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.admin-tile {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  text-decoration: none;
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  position: relative;
+}
+
+.admin-tile:not(.admin-tile-soon):hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+.admin-tile-soon {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.admin-tile-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.admin-tile-icon svg {
+  width: 18px;
+  height: 18px;
+  color: var(--text-muted);
+}
+
+.admin-tile-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.admin-tile-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-bottom: 0.2rem;
+  color: var(--text);
+}
+
+.admin-tile-desc {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+.admin-tile-badge {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: 6px;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  align-self: flex-start;
+}
+
+.admin-tile-badge.live {
+  background: #dcfce7;
+  color: #16a34a;
+  border-color: #bbf7d0;
+}
+
+.admin-section-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.85rem 0;
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+}
+
 /* ── Cards ── */
 .admin-card {
   background: var(--card);

--- a/apps/web/public/admin.css
+++ b/apps/web/public/admin.css
@@ -119,13 +119,9 @@
   border-color: #bbf7d0;
 }
 
+/* Modifier for .admin-section-title: page-level section separator with a rule above */
 .admin-section-heading {
   font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin: 0 0 0.85rem 0;
   border-top: 1px solid var(--border);
   padding-top: 1.25rem;
 }

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Admin — Evaluation Batches</title>
+  <title>Admin Console</title>
   <meta name="theme-color" content="#b91c1c">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -95,8 +95,75 @@
     <!-- ── Page content ────────────────────────────────────────────────── -->
     <div class="page-content">
       <main class="admin-shell">
-        <h1 class="admin-heading">Evaluation Batches</h1>
+        <h1 class="admin-heading">Admin Console</h1>
         <div id="user-info">Checking auth…</div>
+
+        <!-- ── Function launchpad ── -->
+        <div class="admin-launchpad">
+          <a href="#eval-batches" class="admin-tile">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm9.707 5.707a1 1 0 00-1.414-1.414L9 12.586l-1.293-1.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">Evaluation Batches</div>
+              <div class="admin-tile-desc">Submit and track transcript evaluation jobs</div>
+            </div>
+            <span class="admin-tile-badge live">Live</span>
+          </a>
+          <div class="admin-tile admin-tile-soon">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">Session Analytics</div>
+              <div class="admin-tile-desc">Usage trends, session durations, and engagement metrics</div>
+            </div>
+            <span class="admin-tile-badge">Soon</span>
+          </div>
+          <div class="admin-tile admin-tile-soon">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">User Management</div>
+              <div class="admin-tile-desc">View registered users, manage roles, and admin flags</div>
+            </div>
+            <span class="admin-tile-badge">Soon</span>
+          </div>
+          <div class="admin-tile admin-tile-soon">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">System Health</div>
+              <div class="admin-tile-desc">API latency, error rates, and server status</div>
+            </div>
+            <span class="admin-tile-badge">Soon</span>
+          </div>
+          <div class="admin-tile admin-tile-soon">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">Audit Log</div>
+              <div class="admin-tile-desc">Admin actions, session events, and access history</div>
+            </div>
+            <span class="admin-tile-badge">Soon</span>
+          </div>
+          <div class="admin-tile admin-tile-soon">
+            <div class="admin-tile-icon">
+              <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/></svg>
+            </div>
+            <div class="admin-tile-body">
+              <div class="admin-tile-title">Prompt Manager</div>
+              <div class="admin-tile-desc">Preview and A/B test tutor prompt versions</div>
+            </div>
+            <span class="admin-tile-badge">Soon</span>
+          </div>
+        </div>
+
+        <!-- ── Evaluation Batches ─────────────────────────────────────────── -->
+        <h2 class="admin-section-heading" id="eval-batches">Evaluation Batches</h2>
 
         <div class="admin-card">
           <h2 class="admin-section-title">Submit New Batch</h2>

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -163,7 +163,7 @@
         </div>
 
         <!-- ── Evaluation Batches ─────────────────────────────────────────── -->
-        <h2 class="admin-section-heading" id="eval-batches">Evaluation Batches</h2>
+        <h2 class="admin-section-title admin-section-heading" id="eval-batches">Evaluation Batches</h2>
 
         <div class="admin-card">
           <h2 class="admin-section-title">Submit New Batch</h2>

--- a/apps/web/public/settings.css
+++ b/apps/web/public/settings.css
@@ -14,7 +14,7 @@
 
 .settings-card {
   width: 100%;
-  max-width: 600px;
+  max-width: 860px;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- **#242**: Widened `.settings-card` `max-width` from 600px → 860px so the settings page uses comparable real estate to history and admin.
- **#243**: Restructured `/admin.html` from the bare batch-eval screen into an **Admin Console** launchpad. Added a card grid at the top with six tiles — Evaluation Batches (Live, scroll-links to the existing section below) plus Session Analytics, User Management, System Health, Audit Log, and Prompt Manager (all carrying a "Soon" badge as placeholder destinations for future admin surfaces). Page title renamed "Admin — Evaluation Batches" → "Admin Console".
- `.admin-section-heading` is a modifier on top of `.admin-section-title` (only the differentiating font-size and border-top), not a duplicate class.

## Closes
- #242
- #243

## Test plan
- [ ] Visit `/settings.html` — card is noticeably wider than before (up to 860px).
- [ ] Visit `/admin.html` as an admin — see the launchpad card grid at top.
- [ ] "Evaluation Batches" tile scrolls the page down to the existing batch controls.
- [ ] Five "Soon" tiles are visible but non-interactive.
- [ ] Submit Batch / Poll / Recent Batches all still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)