### PR TITLE
fix: preserve session on all internal nav + settings layout parity (#241, #242)

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -100,8 +100,6 @@
   const sidebarDisplayName = $('sidebar-display-name');
   const sidebarAvatarInitials = $('sidebar-avatar-initials');
   const sidebarGrade       = $('sidebar-grade');
-  const sidebarSettings    = $('sidebar-settings');
-  const sidebarHistory     = $('sidebar-history');
 
   // ── Config ────────────────────────────────────────────────────────────────
   async function fetchConfig() {
@@ -1122,16 +1120,23 @@
     }
   }
 
-  function navigateTo(url) {
+  // Preserve the active tutor session on any internal navigation.
+  // Delegated on document so it covers every <a href="/…"> — sidebar, dropdown,
+  // and any future internal link added to the tutor page.
+  document.addEventListener('click', e => {
+    // Respect modifier/middle clicks so cmd/ctrl-click still opens new tabs.
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const a = e.target.closest('a[href]');
+    if (!a) return;
+    const href = a.getAttribute('href');
+    if (!href || !href.startsWith('/') || href.startsWith('//')) return;
     saveResumeIfActive();
-    window.location.href = url;
-  }
+    // Let the browser navigate normally — no preventDefault.
+  });
 
-  menuSettings.addEventListener('click', () => { closeAccountDropdown(); navigateTo('/settings.html'); });
-  menuHistory.addEventListener('click',  () => { closeAccountDropdown(); navigateTo('/history.html'); });
-
-  if (sidebarSettings) sidebarSettings.addEventListener('click', e => { e.preventDefault(); navigateTo('/settings.html'); });
-  if (sidebarHistory)  sidebarHistory.addEventListener('click',  e => { e.preventDefault(); navigateTo('/history.html'); });
+  // Dropdown menu items are <button>s, not <a>, so they need explicit handlers.
+  menuSettings.addEventListener('click', () => { closeAccountDropdown(); saveResumeIfActive(); window.location.href = '/settings.html'; });
+  menuHistory.addEventListener('click',  () => { closeAccountDropdown(); saveResumeIfActive(); window.location.href = '/history.html'; });
   menuLogout.addEventListener('click', () => {
     closeAccountDropdown();
     handleLogout();

--- a/apps/web/public/settings.css
+++ b/apps/web/public/settings.css
@@ -14,7 +14,6 @@
 
 .settings-card {
   width: 100%;
-  max-width: 860px;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -33,18 +32,6 @@
   margin: 0;
   font-size: 1.3rem;
   font-weight: 700;
-}
-
-.settings-back-link {
-  color: var(--accent);
-  font-size: 0.85rem;
-  text-decoration: none;
-  font-weight: 500;
-}
-
-.settings-back-link:hover {
-  color: var(--accent-hover);
-  text-decoration: underline;
 }
 
 .settings-loading {

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -95,7 +95,6 @@
         <div class="settings-card">
           <div class="settings-header">
             <h1 class="settings-title">Settings</h1>
-            <a href="/" id="btn-back-link" class="settings-back-link">Back to tutor</a>
           </div>
 
           <div id="settings-loading" class="settings-loading">Loading settings...</div>

--- a/apps/web/public/settings.js
+++ b/apps/web/public/settings.js
@@ -70,11 +70,6 @@
     // accepts updateUser({ password }) because the session itself was just
     // issued by the recovery flow.
     if (currentPasswordField) currentPasswordField.style.display = "none";
-    var backLinkEl = document.getElementById("btn-back-link");
-    if (backLinkEl) {
-      backLinkEl.textContent = "Cancel — go to login";
-      backLinkEl.href = "/login.html";
-    }
     if (newPasswordEl) newPasswordEl.scrollIntoView({ behavior: "smooth", block: "center" });
   }
 


### PR DESCRIPTION
## Summary
Addresses two reopened issues from the prior round of fixes.

### #241 — Session preservation on **all** internal navigation
Replaces the per-link click handlers with a single document-level delegated listener that fires `saveResumeIfActive()` for every `<a href="/…">` click. This now covers the Admin link and any future internal link added to the tutor page automatically.

- Modifier/middle clicks are respected so cmd/ctrl-click still opens new tabs.
- Dropdown menu items (`<button>`s) keep their explicit handlers.
- The handler does **not** preventDefault — it piggybacks on the browser's native navigation after the synchronous `sessionStorage.setItem()` completes.

### #242 — Settings page layout parity with History
- Drop `.settings-card { max-width: 860px }` so the card fills the content pane like `.history-card`.
- Remove the "Back to tutor" header link for consistency across pages (sidebar handles all navigation).
- Drop the now-unused `.settings-back-link` CSS rule and the `settings.js` code block that rewrote the link into "Cancel — go to login" during password recovery.

## Closes
- #241
- #242

## Test plan
- [ ] From `/`, start a conversation → click Admin in sidebar → return via Tutor link → session restored (previously broken).
- [ ] Same flow via Settings, History, and the account dropdown → each restores the session.
- [ ] Cmd-click Settings link → new tab opens (not intercepted).
- [ ] `/settings.html` card now stretches to fill the content pane, matching `/history.html`.
- [ ] Password-recovery flow (click link in reset email) still works — user sets new password without needing the old "Cancel — go to login" affordance; sidebar provides the exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)