### PR TITLE
fix: stop duplicate emails at session-end and batch eval (#250)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The model appends `[END_SESSION_AVAILABLE]` on its own line when a conversation 
 
 ### In-memory session store + database
 
-Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — recording a `source: 'timeout'` feedback row if none exists, sending an email transcript (including feedback), and marking the session ended in the DB.  When a session is explicitly ended via `DELETE /api/sessions/:id`, the same feedback fetch happens before the transcript email is sent.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.  Transcript evaluation runs out-of-band via the admin-gated batch evaluator (see `apps/api/src/routes/admin-evaluations.ts`).
+Sessions live in memory (`apps/api/src/lib/session-store.ts`) during an active conversation.  After each turn, messages are also persisted to Supabase so nothing is lost if the server restarts.  The inactivity sweep runs every 60 seconds and reaps sessions idle longer than 10 minutes — recording a `source: 'timeout'` feedback row if none exists, sending a **student-only** transcript email (gated by `profiles.email_transcripts_enabled`), and marking the session ended in the DB.  When a session is explicitly ended via `DELETE /api/sessions/:id`, the same student-only email flow runs.  No admin email is sent at session end; the admin copy with evaluation data is sent later by the batch evaluator.  Session rows, messages, and feedback are **not deleted** — they are retained for analysis.  `ended_at` is set on the session row to mark completion.  Transcript evaluation runs out-of-band via the admin-gated batch evaluator (see `apps/api/src/routes/admin-evaluations.ts`).
 
 The inactivity timeout (`INACTIVITY_MS`) is defined as a constant in `apps/api/src/index.ts` and served via `GET /api/config` as `inactivityMs` so the frontend stays in sync with the server-side sweep.  The frontend uses the same value to trigger its own auto-end flow after the same duration of client-side inactivity.
 
@@ -327,7 +327,7 @@ Returns `404` if not found.
 
 ### DELETE /api/sessions/:sessionId
 
-End a session.  Sends transcript email if transcript exists and email not yet sent.  Removes the in-memory session and sets `ended_at` on the DB row.  Session data (messages, feedback) is **retained** for analysis.
+End a session.  Sends the student's transcript email (gated by `profiles.email_transcripts_enabled`) if a transcript exists.  Removes the in-memory session and sets `ended_at` on the DB row.  Session data (messages, feedback) is **retained** for analysis.  No admin email is sent at this point — the admin copy is sent later when batch evaluation completes.
 
 **Query parameters**
 
@@ -406,11 +406,11 @@ Submit end-of-session feedback.  Saves one row to `session_feedback`.  No email 
 
 Admin-gated endpoints for the batched evaluation subsystem. All require a valid Bearer token whose JWT `app_metadata.is_admin` claim is true — otherwise they return `403 { ok: false, error: "admin_only" }`. The admin check is enforced by `requireAdmin` middleware in [apps/api/src/middleware/require-admin.ts](apps/api/src/middleware/require-admin.ts).
 
-Results are written to `session_evaluations` and `sessions.evaluated`. For each succeeded result, `sendTranscript()` delivers an admin transcript email; a student-facing copy is sent fire-and-forget via `sendUserTranscript()` when the session belongs to a registered user with transcripts enabled. `email_sent` is checked before dispatch to avoid duplicates.
+Results are written to `session_evaluations` and `sessions.evaluated`. For each succeeded result, `sendTranscript()` delivers an **admin-only** transcript email (the student already received their copy at session end). `email_sent` is set to prevent a later re-send for the same session.
 
 - `POST /api/admin/evaluations/batches` — body `{ limit?: number }` (default 50, capped at 100). Picks up sessions where `evaluated=false AND ended_at IS NOT NULL` that aren't already claimed by a batch in `submitted`/`ended` state. Builds a request per session via `buildEvaluationRequestParams()`, submits to Anthropic's Messages Batches API, and persists an `evaluation_batches` row with status `submitted`. Returns `{ ok: true, id, anthropicBatchId, sessionCount }` or `{ ok: true, sessionCount: 0 }` if nothing is pending.
 - `GET /api/admin/evaluations/batches` — returns the 50 most recent batch rows (newest first) as `{ ok: true, batches: [...] }`.
-- `GET /api/admin/evaluations/batches/:id` — idempotent status-then-finalize. Loads the batch row (404 if missing); if `status=submitted`, polls Anthropic and updates `request_counts` (+ flips to `ended` when complete); if `status=ended`, downloads results and runs `processBatchResults()` — writes evaluations, flips `sessions.evaluated=true`, sends admin + user transcript emails, and marks the batch `processed`. Returns the final batch row plus an `outcome` summary `{ succeeded, errored, skipped, emailsSent }`.
+- `GET /api/admin/evaluations/batches/:id` — idempotent status-then-finalize. Loads the batch row (404 if missing); if `status=submitted`, polls Anthropic and updates `request_counts` (+ flips to `ended` when complete); if `status=ended`, downloads results and runs `processBatchResults()` — writes evaluations, flips `sessions.evaluated=true`, sends **admin-only** transcript emails with evaluations, and marks the batch `processed`. Returns the final batch row plus an `outcome` summary `{ succeeded, errored, skipped, emailsSent }`.
 
 ---
 
@@ -553,7 +553,7 @@ These apply to every Claude Code session in this repo.
 | `apps/api/scripts/gen-build-info.js` | Generates `build-info.json` (commit SHA + timestamp) at build time; called by the API `build` script |
 | `apps/api/build-info.json` | Generated build metadata (gitignored); read at startup by the config route |
 | `apps/api/src/routes/config.ts` | `GET /api/config` |
-| `apps/api/src/lib/evaluation.ts` | `buildEvaluationPayload()` — maps result to email shape; `buildTranscriptEmailPayload()` — assembles full email payload from session data; helpers for timeout-feedback, marking emails sent, and student-facing transcript dispatch |
+| `apps/api/src/lib/evaluation.ts` | `buildEvaluationPayload()` — maps result to email shape; `getOrCreateTimeoutFeedback()` — records a source:'timeout' feedback row on session end for analytics; `sendUserTranscriptIfApplicable()` — student-facing transcript dispatch respecting `profiles.email_transcripts_enabled` |
 | `apps/api/src/lib/session-store.ts` | In-memory session cache (`Map<id, Session>`) |
 | `apps/api/src/lib/stream.ts` | SSE helpers (`initSSE`, `sendEvent`, `sendHeartbeat`) |
 | `apps/api/src/lib/geo.ts` | `extractClientInfo()` — IP, geolocation, user-agent extraction |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,7 +479,7 @@ Do not add a build step to this package.  Do not introduce a framework.  If comp
 5. **Build before testing API changes.**  Run `npm run build` from the root, then `npm run api`.
 6. **Never expose secrets through `/api/config`.**  That route is intentionally public.
 7. **Do not modify** `templates/tutor-prompt-v7.md`, `templates/tutor-prompt-v6.md`, `templates/physics-geometry-9th-grade-v6.md`, `tests/`, `docs/methodology.md`, `docs/model-selection.md`, or `docs/lessons-learned.md` without explicit instruction.  These are source-of-truth documents.
-8. **Transcript emails must be idempotent.**  The `email_sent` flag and `markEmailSent()` method exist precisely to prevent duplicate emails during the inactivity sweep and explicit session deletion.
+8. **Transcript emails must be idempotent.**  The in-memory `reapingSet` (`markReaping`/`isReaping`/`unmarkReaping` in `apps/api/src/lib/session-store.ts`) is the bidirectional guard that keeps the inactivity sweep and the explicit `DELETE /api/sessions/:id` handler from dispatching a second student transcript email. The DB `sessions.email_sent` column is the admin-side guard: it's checked in `processBatchResults()` before the admin transcript is sent and set to `true` on success.
 9. **SSE errors must close the connection.**  If you add a new error path in a streaming route, send the error event and then call `res.end()`.
 10. **In-memory session IDs are client-generated UUIDs.**  Never generate them server-side.  The client owns the session ID lifecycle.
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -84,7 +84,7 @@ apps/api/src/
 │   ├── require-auth.ts     ← Bearer token verification middleware
 │   └── require-admin.ts    ← Admin-only gating (chains after require-auth)
 └── lib/
-    ├── evaluation.ts       ← buildEvaluationPayload(), buildTranscriptEmailPayload(), timeout-feedback + email helpers
+    ├── evaluation.ts       ← buildEvaluationPayload(), getOrCreateTimeoutFeedback(), sendUserTranscriptIfApplicable()
     ├── batch-evaluation.ts ← findPendingEvaluations(), createEvaluationBatchForPending(), processBatchResults()
     ├── session-store.ts    ← In-memory Map<sessionId, Session>
     ├── stream.ts           ← SSE helpers (initSSE, sendEvent, sendHeartbeat)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,7 +12,6 @@ import {
   createSupabaseClient,
   createSupabaseAnonClient,
   markSessionEnded,
-  getUserInfoForSession,
 } from "@ai-tutor/db";
 import { corsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/errors.js";
@@ -26,8 +25,7 @@ import { createAuthRouter } from "./routes/auth.js";
 import { createHistoryRouter } from "./routes/history.js";
 import { createAdminEvaluationsRouter } from "./routes/admin-evaluations.js";
 import { getAllSessions, removeSession, markReaping, unmarkReaping, isReaping } from "./lib/session-store.js";
-import { sendTranscript } from "@ai-tutor/email";
-import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
+import { getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -124,7 +122,7 @@ app.use(express.static(path.join(__dirname, "../../web/public")));
 
 // Routes
 app.use("/api/chat", createChatRouter(tutorClient, db, promptMap, defaultPromptName, config.model, config.extendedThinking));
-app.use("/api/sessions", createSessionsRouter(db, emailConfig, config));
+app.use("/api/sessions", createSessionsRouter(db, emailConfig));
 app.use("/api/transcript", createTranscriptEmailRouter(db, { apiKey: emailConfig.apiKey, from: emailConfig.from }));
 app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
@@ -163,33 +161,23 @@ setInterval(() => {
         }
       };
 
-      if (!session.emailSent && session.transcript.length > 0) {
+      if (session.transcript.length > 0) {
         void (async () => {
           try {
-            const [feedback, userInfo] = await Promise.all([
-              getOrCreateTimeoutFeedback(db, sessionId, "sweep"),
-              getUserInfoForSession(db, sessionId).catch(() => null),
-            ]);
+            // Record a timeout-feedback row for analytics (picked up later by
+            // batch eval when the admin transcript is sent).
+            await getOrCreateTimeoutFeedback(db, sessionId, "sweep");
 
-            const payload = buildTranscriptEmailPayload(
-              session, sessionId, null, feedback,
-              { model: config.model, promptName: defaultPromptName, extendedThinking: config.extendedThinking },
-              userInfo,
-            );
-            await sendTranscript(emailConfig, payload);
-            if (emailConfig.apiKey && emailConfig.to) {
-              await markEmailSentPersisted(session, db, sessionId, "sweep");
-            }
-            // Send a student-facing copy (fire-and-forget).
+            // Student-facing transcript is the only email sent at session end.
+            // Gated by profiles.email_transcripts_enabled inside the helper.
             const summary = session.getSessionSummary();
-            void sendUserTranscriptIfApplicable(
+            await sendUserTranscriptIfApplicable(
               sessionId, summary.transcript, summary.startedAt, summary.durationMs,
               emailConfig.from, db,
             );
           } catch (err) {
             console.error(`[sweep] Failed to process session ${sessionId}:`, err);
           } finally {
-            // Mark ended_at only after the email has completed (or failed).
             await finishReap();
           }
         })();

--- a/apps/api/src/lib/batch-evaluation.ts
+++ b/apps/api/src/lib/batch-evaluation.ts
@@ -23,7 +23,7 @@ import {
   type DbEvaluationBatch,
   type UserSessionProfile,
 } from "@ai-tutor/db";
-import { buildEvaluationPayload, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./evaluation.js";
+import { buildEvaluationPayload, getOrCreateTimeoutFeedback } from "./evaluation.js";
 
 /** Hard cap on sessions per batch — defensive ceiling well below Anthropic's 10k limit. */
 export const MAX_BATCH_SIZE = 100;
@@ -152,8 +152,7 @@ function transcriptFromMessages(messages: DbMessage[]): TranscriptEmailPayload["
 }
 
 /**
- * Assemble the transcript email payload from DB rows, mirroring what
- * `buildTranscriptEmailPayload()` produces from an in-memory `Session`.
+ * Assemble the admin transcript email payload from DB rows.
  * Files are always empty — they're not persisted beyond the live session.
  */
 function buildTranscriptEmailPayloadFromDb(
@@ -282,6 +281,7 @@ export async function processBatchResults(
 
       if (opts.emailConfig.apiKey && opts.emailConfig.to) {
         try {
+          // Admin-only: student already got their transcript at session end.
           await sendTranscript(opts.emailConfig, payload);
           await updateSession(db, sessionId, { email_sent: true });
           outcome.emailsSent += 1;
@@ -291,16 +291,6 @@ export async function processBatchResults(
       } else {
         outcome.skipped += 1;
       }
-
-      // Fire-and-forget student copy. Never throws.
-      void sendUserTranscriptIfApplicable(
-        sessionId,
-        payload.transcript,
-        payload.startedAt,
-        payload.durationMs,
-        opts.emailConfig.from,
-        db,
-      );
     }
 
     const processed = await updateEvaluationBatch(db, batch.id, {

--- a/apps/api/src/lib/batch-evaluation.ts
+++ b/apps/api/src/lib/batch-evaluation.ts
@@ -279,7 +279,13 @@ export async function processBatchResults(
         userProfile,
       );
 
-      if (opts.emailConfig.apiKey && opts.emailConfig.to) {
+      if (!opts.emailConfig.apiKey || !opts.emailConfig.to) {
+        outcome.skipped += 1;
+      } else if (dbSession.email_sent) {
+        // Already sent for this session (e.g., a retry after a partial run).
+        // email_sent is the DB-level idempotency guard for the admin copy.
+        outcome.skipped += 1;
+      } else {
         try {
           // Admin-only: student already got their transcript at session end.
           await sendTranscript(opts.emailConfig, payload);
@@ -288,8 +294,6 @@ export async function processBatchResults(
         } catch (err) {
           console.error(`[batch-eval] Failed to send admin transcript for ${sessionId}:`, err);
         }
-      } else {
-        outcome.skipped += 1;
       }
     }
 

--- a/apps/api/src/lib/evaluation.ts
+++ b/apps/api/src/lib/evaluation.ts
@@ -1,8 +1,7 @@
-import type { EvaluationResult, Session } from "@ai-tutor/core";
-import type { TranscriptEmailPayload } from "@ai-tutor/email";
+import type { EvaluationResult } from "@ai-tutor/core";
 import { sendUserTranscript } from "@ai-tutor/email";
-import { updateSession, getSessionFeedback, createSessionFeedback, getUserProfileForSession } from "@ai-tutor/db";
-import type { DbSessionFeedback, UserSessionInfo } from "@ai-tutor/db";
+import { getSessionFeedback, createSessionFeedback, getUserProfileForSession } from "@ai-tutor/db";
+import type { DbSessionFeedback } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 const DIMENSION_LABELS: Record<string, string> = {
@@ -30,37 +29,6 @@ export function buildEvaluationPayload(result: EvaluationResult) {
       rationale: result.rationale[key] ?? "",
     })),
     hasFailures: result.has_failures,
-  };
-}
-
-/**
- * Build the email payload from session data, evaluation, and feedback.
- * Used by both the DELETE handler and the inactivity sweep.
- */
-export function buildTranscriptEmailPayload(
-  session: Session,
-  sessionId: string,
-  evalResult: EvaluationResult | null,
-  feedback: DbSessionFeedback | null,
-  fallbacks?: { model?: string; promptName?: string; extendedThinking?: boolean },
-  userInfo?: UserSessionInfo | null,
-): TranscriptEmailPayload {
-  const summary = session.getSessionSummary();
-  return {
-    transcript: summary.transcript,
-    files: session.files,
-    clientInfo: summary.clientInfo,
-    startedAt: summary.startedAt,
-    lastActivityAt: summary.lastActivityAt,
-    durationMs: summary.durationMs,
-    sessionId,
-    tokenUsage: summary.tokenUsage,
-    evaluation: evalResult ? buildEvaluationPayload(evalResult) : null,
-    studentFeedback: feedback ?? null,
-    model: session.model ?? fallbacks?.model,
-    promptName: session.promptName ?? fallbacks?.promptName,
-    extendedThinking: session.extendedThinking ?? fallbacks?.extendedThinking,
-    userInfo: userInfo ?? null,
   };
 }
 
@@ -93,23 +61,6 @@ export async function getOrCreateTimeoutFeedback(
     }
   }
   return feedback;
-}
-
-/**
- * Mark the session email as sent in both in-memory state and the database.
- * Called after sendTranscript succeeds in both the inactivity sweep and the
- * DELETE handler — extracted here to avoid duplicating the two-step pattern.
- */
-export async function markEmailSentPersisted(
-  session: Session,
-  db: SupabaseClient,
-  sessionId: string,
-  logPrefix: string,
-): Promise<void> {
-  session.markEmailSent();
-  await updateSession(db, sessionId, { email_sent: true }).catch(err =>
-    console.error(`[${logPrefix}] Could not persist email_sent for ${sessionId}:`, err)
-  );
 }
 
 /**

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -4,7 +4,7 @@ import {
   markSessionEnded,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { getSession, removeSession } from "../lib/session-store.js";
+import { getSession, removeSession, isReaping } from "../lib/session-store.js";
 import { getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
@@ -73,15 +73,19 @@ export function createSessionsRouter(
       const session = getSession(sessionId);
 
       try {
-        if (!discard && session && session.transcript.length > 0) {
+        // If the sweep is already tearing down this session, skip the email
+        // here — the sweep will send it. Prevents duplicate student emails.
+        const sweeping = isReaping(sessionId);
+        if (!discard && !sweeping && session && session.transcript.length > 0) {
           // Record a timeout-feedback row for analytics (picked up later by
           // batch eval when the admin transcript is sent).
           await getOrCreateTimeoutFeedback(db, sessionId, "sessions");
 
           // Student-facing transcript is the only email sent at session end.
           // Gated by profiles.email_transcripts_enabled inside the helper.
+          // Fire-and-forget so the response returns without waiting on Resend.
           const summary = session.getSessionSummary();
-          await sendUserTranscriptIfApplicable(
+          void sendUserTranscriptIfApplicable(
             sessionId, summary.transcript, summary.startedAt, summary.durationMs,
             emailConfig.from, db,
           );

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2,13 +2,10 @@ import { Router } from "express";
 import {
   getSession as getDbSession,
   markSessionEnded,
-  getUserInfoForSession,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Config } from "@ai-tutor/core";
 import { getSession, removeSession } from "../lib/session-store.js";
-import { sendTranscript } from "@ai-tutor/email";
-import { buildTranscriptEmailPayload, markEmailSentPersisted, getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
+import { getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
 
@@ -21,7 +18,6 @@ export interface EmailConfig {
 export function createSessionsRouter(
   db: SupabaseClient,
   emailConfig: EmailConfig,
-  config: Config,
 ): Router {
   const router = Router();
   const requireAuth = createRequireAuth(db);
@@ -53,8 +49,9 @@ export function createSessionsRouter(
   /**
    * DELETE /api/sessions/:sessionId
    *
-   * Normal flow: sends the transcript email (if not already sent), removes the
-   * in-memory session, and marks ended_at in the database.
+   * Normal flow: sends the user's transcript email (if opted in), removes the
+   * in-memory session, and marks ended_at in the database.  No admin email is
+   * sent here — the admin copy is sent later, once batch evaluation runs.
    *
    * With ?discard=true: skips the email entirely — just removes from memory
    * and marks ended_at.  Used when the user switches model/prompt mid-session
@@ -76,31 +73,21 @@ export function createSessionsRouter(
       const session = getSession(sessionId);
 
       try {
-        if (!discard && session && !session.emailSent && session.transcript.length > 0) {
-          const [feedback, userInfo] = await Promise.all([
-            getOrCreateTimeoutFeedback(db, sessionId, "sessions"),
-            getUserInfoForSession(db, sessionId).catch(() => null),
-          ]);
-          const payload = buildTranscriptEmailPayload(session, sessionId, null, feedback,
-            { model: config.model, promptName: config.defaultPromptName, extendedThinking: config.extendedThinking },
-            userInfo);
-          try {
-            await sendTranscript(emailConfig, payload);
-            if (emailConfig.apiKey && emailConfig.to) {
-              await markEmailSentPersisted(session, db, sessionId, "sessions");
-            }
-          } catch (err) {
-            console.error(`[sessions] Failed to send transcript for ${sessionId}:`, err);
-          }
-          // Send a student-facing copy (fire-and-forget).
+        if (!discard && session && session.transcript.length > 0) {
+          // Record a timeout-feedback row for analytics (picked up later by
+          // batch eval when the admin transcript is sent).
+          await getOrCreateTimeoutFeedback(db, sessionId, "sessions");
+
+          // Student-facing transcript is the only email sent at session end.
+          // Gated by profiles.email_transcripts_enabled inside the helper.
           const summary = session.getSessionSummary();
-          void sendUserTranscriptIfApplicable(
+          await sendUserTranscriptIfApplicable(
             sessionId, summary.transcript, summary.startedAt, summary.durationMs,
             emailConfig.from, db,
           );
         }
       } finally {
-        // Always clean up — even if eval or email throws unexpectedly.
+        // Always clean up — even if email throws unexpectedly.
         removeSession(sessionId);
         try {
           await markSessionEnded(db, sessionId);

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -4,7 +4,7 @@ import {
   markSessionEnded,
 } from "@ai-tutor/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { getSession, removeSession, isReaping } from "../lib/session-store.js";
+import { getSession, removeSession, isReaping, markReaping, unmarkReaping } from "../lib/session-store.js";
 import { getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "../lib/evaluation.js";
 import { UUID_RE } from "../lib/validation.js";
 import { createRequireAuth, type AuthedRequest } from "../middleware/require-auth.js";
@@ -72,10 +72,13 @@ export function createSessionsRouter(
       const discard = req.query["discard"] === "true";
       const session = getSession(sessionId);
 
+      // Claim the teardown slot so the sweep skips this session. Bidirectional
+      // guard: prevents duplicate student emails when DELETE and the sweep
+      // would otherwise both dispatch one.
+      const sweeping = isReaping(sessionId);
+      if (!sweeping) markReaping(sessionId);
+
       try {
-        // If the sweep is already tearing down this session, skip the email
-        // here — the sweep will send it. Prevents duplicate student emails.
-        const sweeping = isReaping(sessionId);
         if (!discard && !sweeping && session && session.transcript.length > 0) {
           // Record a timeout-feedback row for analytics (picked up later by
           // batch eval when the admin transcript is sent).
@@ -98,6 +101,7 @@ export function createSessionsRouter(
         } catch (err) {
           console.error("[sessions] Could not mark DB session as ended:", err);
         }
+        if (!sweeping) unmarkReaping(sessionId);
       }
 
       res.json({ ok: true });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -71,7 +71,6 @@ export class Session {
   startedAt: Date = new Date();
   lastActivityAt: Date = new Date();
   clientInfo: ClientInfo = {};
-  emailSent = false;
   tokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
   /** Claude model ID used for this session. Set on first message. */
   model: string | null = null;
@@ -141,11 +140,6 @@ export class Session {
     this.tokenUsage.outputTokens += output;
   }
 
-  /** Prevent double-send of the session email. */
-  markEmailSent(): void {
-    this.emailSent = true;
-  }
-
   /** Returns a plain object summarizing the session, suitable for email. */
   getSessionSummary(): SessionSummary {
     return {
@@ -170,7 +164,6 @@ export class Session {
     this.files.length = 0;
     this.startedAt = new Date();
     this.lastActivityAt = new Date();
-    this.emailSent = false;
     this.tokenUsage = { inputTokens: 0, outputTokens: 0 };
     this.model = null;
     this.promptName = null;


### PR DESCRIPTION
## Summary
Fixes duplicate transcript emails. Previously both the admin and the user received an email every time a session ended (DELETE or inactivity sweep) and **again** when batch evaluation completed.

### Correct flow after this PR
1. **Session end** (DELETE or sweep) → student-only transcript, gated by `profiles.email_transcripts_enabled`. No admin email here.
2. **Batch eval completion** → admin-only transcript with evaluation data attached. No user email here.

### Code changes
- `apps/api/src/index.ts` sweep path — drop `sendTranscript`/`markEmailSentPersisted`. Keep `getOrCreateTimeoutFeedback` (analytics) and user-transcript dispatch. Drop unused imports.
- `apps/api/src/routes/sessions.ts` DELETE — mirror sweep. Fire-and-forget on user email so DELETE response isn't blocked on Resend. Add `isReaping(sessionId)` guard so DELETE skips when the sweep is already tearing down the same session (prevents duplicate student emails under race). Drop unused `Config` param from `createSessionsRouter`.
- `apps/api/src/lib/batch-evaluation.ts` — drop `sendUserTranscriptIfApplicable` call; the student already got their copy at session end.
- `apps/api/src/lib/evaluation.ts` — delete now-dead `buildTranscriptEmailPayload` and `markEmailSentPersisted` helpers + their imports.
- `packages/core/src/session.ts` — delete orphaned `emailSent` field, `markEmailSent()` method, and `reset()` line. Nothing reads them after the cleanup; dedup for the admin email lives entirely in the DB `email_sent` column.
- `CLAUDE.md` — update session-lifecycle, DELETE docs, and admin-evaluations docs to reflect the new split.

## Closes
- #250

## Test plan
- [ ] End a session (DELETE) → user receives one transcript email (admin does not).
- [ ] Let a session idle out past the inactivity sweep → user receives one transcript email (admin does not).
- [ ] Run batch eval on processed sessions → admin receives one transcript email per session (user does not get a second copy).
- [ ] Opt out via Settings → "Receive session transcript emails" OFF → no user email at session end (admin still gets theirs at batch eval).
- [ ] Race: click "End session" while the inactivity sweep is already tearing down → user receives exactly one email.
- [ ] `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)