### PR TITLE
fix: align page frame, logo, and hamburger across secondary pages (#253)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,7 +521,7 @@ These apply to every Claude Code session in this repo.
 | `docs/model-selection.md` | Model selection analysis — v7 (archived v1 version at `docs/archive/model-selection-v1.md`) |
 | `docs/lessons-learned.md` | Key findings — v7 (archived v1 version at `docs/archive/lessons-learned-v1.md`) |
 | `docs/archive/` | Archived versions of superseded docs |
-| `docs/ui-style-guide.md` | Active UI style guide — Warm Red palette, typography, layout, and component specs implemented in `styles.css` and `login.css`. |
+| `docs/ui-style-guide.md` | Active UI style guide — Warm Red palette, typography, layout, and component specs implemented in `styles.css` (chat page) and `layout.css` (admin/settings/history pages); login page styles in `login.css`. |
 | `docs/deployment.md` | Render.com and local deployment instructions |
 | `packages/core/src/config.ts` | `loadConfig()` — reads and validates all env vars |
 | `packages/core/src/prompt-loader.ts` | `loadPromptFile()` — loads and strips a prompt file; `loadSystemPrompt()` — wraps `loadPromptFile()` and appends global system instructions |
@@ -569,7 +569,7 @@ These apply to every Claude Code session in this repo.
 | `apps/web/public/login.html` | Login/register/forgot-password page. Unauthenticated users are redirected here. |
 | `apps/web/public/login.css` | Styles for `login.html`. Self-contained dark theme mirroring `styles.css` palette. |
 | `apps/web/public/login.js` | Tabbed login/register/forgot panels. Calls the three server-side proxy endpoints for rate-limited operations; delegates hash callbacks (signup, recovery) to supabase-js's `detectSessionInUrl`. Listens for `PASSWORD_RECOVERY` to redirect into the settings page. |
-| `apps/web/public/layout.css` | Shared design tokens (`:root` variables), base resets, app-shell layout (`.app-header`, `.app-body`, `.page-sidebar`, `.page-content`), and mobile breakpoints (≤768px). Loaded before per-page stylesheets by admin.html, settings.html, and history.html. |
+| `apps/web/public/layout.css` | Shared design tokens (`:root` variables), base resets, app-shell layout (`.app-header`, `.app-body`, `.page-sidebar`, `.page-content`), shared component CSS (`.menu-btn` hamburger), and mobile breakpoints (≤768px). Loaded before per-page stylesheets by admin.html, settings.html, and history.html. |
 | `apps/web/public/settings.html` | Settings page — account info, preferences, email change, password change. Loads layout.css, settings.css, supabase-js, auth.js. |
 | `apps/web/public/settings.js` | Uses supabase-js directly: `auth.updateUser` for password/email changes (with `currentPassword` verification when not in recovery), and direct `profiles` upsert under RLS for transcript preferences. Email-change flow passes `emailRedirectTo: window.location.origin + "/settings.html"` and listens for `USER_UPDATED`/`EMAIL_CHANGE` events on `onAuthStateChange` to refresh the displayed email after confirmation. |
 | `apps/web/public/history.html` | Session history page. Loads layout.css, history.css, supabase-js, auth.js. |

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -15,11 +15,10 @@
 
   <!-- ── Header ─────────────────────────────────────────────────────────── -->
   <div class="app-header">
-    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation"
-            style="width:36px;height:36px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;cursor:pointer;flex-shrink:0;border-radius:8px;border:none;background:transparent;padding:0;">
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
     </button>
     <div class="logo-box">
       <svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-hidden="true">

--- a/apps/web/public/history.html
+++ b/apps/web/public/history.html
@@ -15,11 +15,10 @@
 
   <!-- ── Header ─────────────────────────────────────────────────────────── -->
   <div class="app-header">
-    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation"
-            style="width:36px;height:36px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;cursor:pointer;flex-shrink:0;border-radius:8px;border:none;background:transparent;padding:0;">
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
     </button>
     <div class="logo-box">
       <svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-hidden="true">

--- a/apps/web/public/layout.css
+++ b/apps/web/public/layout.css
@@ -75,6 +75,24 @@ html, body {
 }
 .app-header .header-spacer { flex: 1; }
 
+/* ── Hamburger menu button ──
+ * Mirrors the `.menu-btn` rule in styles.css so admin, settings, and history
+ * pages can use `<button class="menu-btn">` without inline styles.  Keep these
+ * two definitions in sync — see docs/ui-style-guide.md. */
+.menu-btn {
+  width: 36px; height: 36px;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 5px; cursor: pointer; flex-shrink: 0;
+  border-radius: 8px; border: none; background: transparent; padding: 0;
+}
+.menu-btn span {
+  display: block; width: 20px; height: 2px;
+  background: rgba(255,255,255,0.6); border-radius: 2px;
+  transition: background .2s;
+}
+.menu-btn:hover span { background: #fff; }
+
 /* ── App body ── */
 .app-body {
   display: flex; flex: 1; min-height: 0;
@@ -152,17 +170,18 @@ html, body {
 
 /* ── Mobile breakpoints ── */
 @media (max-width: 768px) {
+  .app-header { height: 56px; }
   .app-body {
     flex-direction: column;
     height: auto;
-    min-height: calc(100vh - 64px);
+    min-height: calc(100vh - 56px);
     overflow-y: auto;
   }
   .page-sidebar {
     display: none;
   }
   .page-content {
-    min-height: calc(100vh - 64px);
+    min-height: calc(100vh - 56px);
     overflow-y: visible;
   }
 }

--- a/apps/web/public/settings.html
+++ b/apps/web/public/settings.html
@@ -15,11 +15,10 @@
 
   <!-- ── Header ─────────────────────────────────────────────────────────── -->
   <div class="app-header">
-    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation"
-            style="width:36px;height:36px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;cursor:pointer;flex-shrink:0;border-radius:8px;border:none;background:transparent;padding:0;">
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
-      <span style="display:block;width:20px;height:2px;background:rgba(255,255,255,0.6);border-radius:2px;"></span>
+    <button class="menu-btn" id="btn-sidebar-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
     </button>
     <div class="logo-box">
       <svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-hidden="true">

--- a/docs/ui-style-guide.md
+++ b/docs/ui-style-guide.md
@@ -125,10 +125,10 @@ Inline SVG lightbulb with a yellow lightning bolt inside. Used in three sizes:
 [☰]  [logo-box + Axiom / AI TUTOR]  |  [page title]  ···  [+ New session]  [AC ▾ Alex Chen]
 ```
 
-- Height: `64px`
+- Height: `64px` (desktop) / `56px` (mobile, ≤768px for `.app-header`; ≤600px for the chat page `header`)
 - Background: `var(--header-bg)` (`#b91c1c`)
 - All text white; muted elements at 35–70% opacity
-- Hamburger: 3 lines, `rgba(255,255,255,0.6)`, hover → full white
+- Hamburger: 3 lines, `rgba(255,255,255,0.6)`, hover → full white. Use `<button class="menu-btn">` with three empty `<span>` children — no inline styles. The `.menu-btn` rule is defined in **both** `styles.css` (for the chat page) and `layout.css` (for admin/settings/history); keep the two definitions in sync.
 - Page title: Nunito 700, 15px, `rgba(255,255,255,0.7)`, separated by a 1px white/10% divider
 - **+ New session button**: `var(--accent)` bg, white text, `border-radius: 8px`, subtle red shadow
 - **User chip**: `rgba(255,255,255,0.07)` bg, 1px `rgba(255,255,255,0.1)` border, `border-radius: 10px`


### PR DESCRIPTION
## Summary

Fixes #253. Aligns the shared header frame used by `admin.html`, `settings.html`, and `history.html` with the chat page (`index.html`).

- Adds a `.menu-btn` rule to `layout.css` mirroring the one in `styles.css`, so the hamburger button can be written as `<button class="menu-btn">` with three empty spans on every page — no inline styles.
- Removes the duplicated 8-property inline-style block from the hamburger button on `admin.html`, `settings.html`, and `history.html`.
- Reduces `.app-header` height to 56px at the `@media (max-width: 768px)` breakpoint in `layout.css`, matching the chat page's mobile header reduction. Updates the two `calc(100vh - 64px)` references in the same media block to `calc(100vh - 56px)` so the body keeps filling the viewport.
- Updates `docs/ui-style-guide.md` to document that `.menu-btn` lives in both stylesheets and to note the desktop vs mobile header heights.

No API, TypeScript, or JS changes.

## Test plan

- [ ] Load `/`, `/settings.html`, `/history.html`, `/admin.html` at desktop width (≥1280px) — header height, logo box, Axiom wordmark, "AI Tutor" sub-label, and hamburger all render identically.
- [ ] Resize to mobile width (≤600px) — all four pages show a 56px header without overflow or gap below the header.
- [ ] Inspect the hamburger button on each secondary page — no `style=""` attribute, `.menu-btn` class resolves to the rule from the corresponding stylesheet.
- [ ] Click the hamburger on each secondary page — sidebar still collapses/expands as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)