### PR TITLE
feat(#97): admin dashboard — usage stats and sessions list

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -129,7 +129,6 @@ app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));
 app.use("/api/admin/evaluations", createAdminEvaluationsRouter(db, config, emailConfig));
-// Service-role `db` client is required — getAdminSessionList calls auth.admin.listUsers().
 app.use("/api/admin", createAdminStatsRouter(db));
 app.use("/api/history", createHistoryRouter(db));
 if (anonDb) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ import { createConfigRouter } from "./routes/config.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { createHistoryRouter } from "./routes/history.js";
 import { createAdminEvaluationsRouter } from "./routes/admin-evaluations.js";
+import { createAdminStatsRouter } from "./routes/admin-stats.js";
 import { getAllSessions, removeSession, markReaping, unmarkReaping, isReaping } from "./lib/session-store.js";
 import { getOrCreateTimeoutFeedback, sendUserTranscriptIfApplicable } from "./lib/evaluation.js";
 
@@ -128,6 +129,8 @@ app.use("/api/transcript", createTranscriptRouter(db));
 app.use("/api/feedback", createFeedbackRouter(db));
 app.use("/api/config", createConfigRouter(config, INACTIVITY_MS, promptMap, defaultPromptName));
 app.use("/api/admin/evaluations", createAdminEvaluationsRouter(db, config, emailConfig));
+// Service-role `db` client is required — getAdminSessionList calls auth.admin.listUsers().
+app.use("/api/admin", createAdminStatsRouter(db));
 app.use("/api/history", createHistoryRouter(db));
 if (anonDb) {
   app.use("/api/auth", createAuthRouter(db, anonDb));

--- a/apps/api/src/routes/admin-stats.ts
+++ b/apps/api/src/routes/admin-stats.ts
@@ -18,18 +18,6 @@ export function createAdminStatsRouter(db: SupabaseClient): Router {
   const router = Router();
   const requireAuth = createRequireAuth(db);
 
-  /**
-   * GET /api/admin/stats
-   *
-   * Returns aggregate usage stats:
-   *   - totalSessions: total row count in `sessions`
-   *   - activeUsers: registered-user count (labeled "Registered Users" in UI)
-   *   - sessionsToday: sessions with started_at >= today-midnight
-   *   - sessionsThisWeek: sessions with started_at >= now - 7 days
-   *   - avgDurationSeconds: mean duration of up to 500 recent ended sessions
-   *
-   * Response: { ok: true, stats: AdminStats }
-   */
   router.get("/stats", requireAuth, requireAdmin, async (_req, res, next) => {
     try {
       const stats = await getAdminStats(db);
@@ -39,22 +27,10 @@ export function createAdminStatsRouter(db: SupabaseClient): Router {
     }
   });
 
-  /**
-   * GET /api/admin/sessions
-   *
-   * Paginated list of all ended sessions with embedded feedback and
-   * evaluation data. Query params:
-   *   - limit (default 50, max 100)
-   *   - offset (default 0)
-   *
-   * Response: { ok: true, sessions: AdminSessionRow[], total: number }
-   */
   router.get("/sessions", requireAuth, requireAdmin, async (req, res, next) => {
     try {
-      const rawLimit = parseInt(String(req.query.limit ?? "50"), 10);
-      const rawOffset = parseInt(String(req.query.offset ?? "0"), 10);
-      const limit = Number.isFinite(rawLimit) ? rawLimit : 50;
-      const offset = Number.isFinite(rawOffset) ? rawOffset : 0;
+      const limit = parseInt(String(req.query.limit ?? ""), 10) || 50;
+      const offset = parseInt(String(req.query.offset ?? ""), 10) || 0;
       const result = await getAdminSessionList(db, { limit, offset });
       res.json({ ok: true, ...result });
     } catch (err) {

--- a/apps/api/src/routes/admin-stats.ts
+++ b/apps/api/src/routes/admin-stats.ts
@@ -1,0 +1,66 @@
+import { Router } from "express";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getAdminStats, getAdminSessionList } from "@ai-tutor/db";
+import { createRequireAuth } from "../middleware/require-auth.js";
+import { requireAdmin } from "../middleware/require-admin.js";
+
+/**
+ * Admin dashboard stats + recent-sessions list.
+ *
+ * MUST be passed the service-role `db` client — not the anon client. The
+ * underlying DB queries call `auth.admin.listUsers()` which requires the
+ * service-role key.
+ *
+ * All routes chain `requireAuth + requireAdmin`, matching the pattern used
+ * by `createAdminEvaluationsRouter`.
+ */
+export function createAdminStatsRouter(db: SupabaseClient): Router {
+  const router = Router();
+  const requireAuth = createRequireAuth(db);
+
+  /**
+   * GET /api/admin/stats
+   *
+   * Returns aggregate usage stats:
+   *   - totalSessions: total row count in `sessions`
+   *   - activeUsers: registered-user count (labeled "Registered Users" in UI)
+   *   - sessionsToday: sessions with started_at >= today-midnight
+   *   - sessionsThisWeek: sessions with started_at >= now - 7 days
+   *   - avgDurationSeconds: mean duration of up to 500 recent ended sessions
+   *
+   * Response: { ok: true, stats: AdminStats }
+   */
+  router.get("/stats", requireAuth, requireAdmin, async (_req, res, next) => {
+    try {
+      const stats = await getAdminStats(db);
+      res.json({ ok: true, stats });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * GET /api/admin/sessions
+   *
+   * Paginated list of all ended sessions with embedded feedback and
+   * evaluation data. Query params:
+   *   - limit (default 50, max 100)
+   *   - offset (default 0)
+   *
+   * Response: { ok: true, sessions: AdminSessionRow[], total: number }
+   */
+  router.get("/sessions", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const rawLimit = parseInt(String(req.query.limit ?? "50"), 10);
+      const rawOffset = parseInt(String(req.query.offset ?? "0"), 10);
+      const limit = Number.isFinite(rawLimit) ? rawLimit : 50;
+      const offset = Number.isFinite(rawOffset) ? rawOffset : 0;
+      const result = await getAdminSessionList(db, { limit, offset });
+      res.json({ ok: true, ...result });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/transcript.ts
+++ b/apps/api/src/routes/transcript.ts
@@ -13,7 +13,8 @@ export function createTranscriptRouter(db: SupabaseClient): Router {
    * GET /api/transcript/:sessionId
    *
    * Returns the session transcript. Requires auth; the session must belong
-   * to the caller.
+   * to the caller, or the caller must be an admin (admins can view any
+   * session's transcript — used by the admin dashboard).
    *
    * Response: { transcript: Array<{ role: string, text: string }> }
    */
@@ -25,9 +26,13 @@ export function createTranscriptRouter(db: SupabaseClient): Router {
         return;
       }
 
-      const callerId = (req as AuthedRequest).userId;
+      const authedReq = req as AuthedRequest;
+      const callerId = authedReq.userId;
       const dbRow = await getDbSession(db, sessionId);
-      if (!dbRow || dbRow.user_id !== callerId) {
+      const isOwner = dbRow?.user_id === callerId;
+      // Admin bypass: admins (is_admin JWT claim) may view any session's
+      // transcript. Non-admins still see 404 for sessions they don't own.
+      if (!dbRow || (!authedReq.isAdmin && !isOwner)) {
         res.status(404).json({ error: "Session not found." });
         return;
       }

--- a/apps/web/public/admin.css
+++ b/apps/web/public/admin.css
@@ -278,9 +278,60 @@
   padding: 0.5rem 0;
 }
 
+/* ── Stat cards grid (admin dashboard) ── */
+.admin-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.admin-stat-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+}
+
+.admin-stat-value {
+  font-size: 1.75rem;
+  font-weight: 800;
+  font-family: var(--font-heading);
+  color: var(--text);
+  line-height: 1;
+  margin-bottom: 0.3rem;
+}
+
+.admin-stat-label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* ── Transcript modal (admin) — overlay/panel styles come from history.css.
+ * These rules style the message bubbles rendered by viewTranscript() using
+ * class="transcript-message" (distinct from history.css's .transcript-msg). */
+.transcript-message {
+  margin-bottom: 1rem;
+}
+.transcript-message strong {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.transcript-message p {
+  margin: 0.2rem 0 0;
+  white-space: pre-wrap;
+}
+
 /* ── Mobile ── */
 @media (max-width: 768px) {
   .admin-shell {
     padding: 1.25rem 1rem;
+  }
+  .admin-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -345,7 +345,7 @@
         if (!res.ok || !data.ok) return;
         const s = data.stats;
         document.getElementById("stat-total").textContent = s.totalSessions.toLocaleString();
-        document.getElementById("stat-users").textContent = s.activeUsers.toLocaleString();
+        document.getElementById("stat-users").textContent = s.registeredUsers.toLocaleString();
         document.getElementById("stat-today").textContent = s.sessionsToday.toLocaleString();
         document.getElementById("stat-week").textContent = s.sessionsThisWeek.toLocaleString();
         document.getElementById("stat-avg").textContent =
@@ -356,8 +356,8 @@
     }
 
     // ── Sessions table ──────────────────────────────────────────────────
-    var sessionsOffset = 0;
-    var sessionsTotal = 0;
+    let sessionsOffset = 0;
+    let sessionsTotal = 0;
 
     function fmtDate(iso) {
       if (!iso) return "—";
@@ -368,11 +368,11 @@
     }
     function fmtDuration(start, end) {
       if (!start || !end) return "—";
-      var mins = Math.round((new Date(end) - new Date(start)) / 60000);
+      const mins = Math.round((new Date(end) - new Date(start)) / 60000);
       return mins < 1 ? "<1 min" : mins + " min";
     }
     function fmtExperience(v) {
-      return { positive: "Good", neutral: "Neutral", negative: "Difficult" }[v] || (v || "—");
+      return { positive: "Good", neutral: "Neutral", negative: "Difficult" }[v] || "—";
     }
 
     async function loadSessions(offset) {
@@ -416,7 +416,7 @@
           tds[3].textContent = (s.model || "—").replace("claude-", "");
           tds[4].textContent = fmtExperience(s.experience);
           const viewBtn = document.createElement("button");
-          viewBtn.className = "secondary poll-btn";
+          viewBtn.className = "secondary";
           viewBtn.textContent = "View";
           viewBtn.addEventListener("click", function() {
             viewTranscript(s.id, s.user_email, s.started_at);

--- a/apps/web/public/admin.html
+++ b/apps/web/public/admin.html
@@ -9,6 +9,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/layout.css">
+  <!-- /history.css provides the .transcript-overlay / .transcript-panel /
+       .transcript-close-btn / .transcript-messages classes reused by the
+       admin transcript modal. Loaded before admin.css so admin-specific
+       overrides win on conflict. -->
+  <link rel="stylesheet" href="/history.css">
   <link rel="stylesheet" href="/admin.css">
 </head>
 <body>
@@ -109,7 +114,7 @@
             </div>
             <span class="admin-tile-badge live">Live</span>
           </a>
-          <div class="admin-tile admin-tile-soon">
+          <a href="#stats" class="admin-tile">
             <div class="admin-tile-icon">
               <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/></svg>
             </div>
@@ -117,9 +122,9 @@
               <div class="admin-tile-title">Session Analytics</div>
               <div class="admin-tile-desc">Usage trends, session durations, and engagement metrics</div>
             </div>
-            <span class="admin-tile-badge">Soon</span>
-          </div>
-          <div class="admin-tile admin-tile-soon">
+            <span class="admin-tile-badge live">Live</span>
+          </a>
+          <a href="#sessions" class="admin-tile">
             <div class="admin-tile-icon">
               <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/></svg>
             </div>
@@ -127,8 +132,8 @@
               <div class="admin-tile-title">User Management</div>
               <div class="admin-tile-desc">View registered users, manage roles, and admin flags</div>
             </div>
-            <span class="admin-tile-badge">Soon</span>
-          </div>
+            <span class="admin-tile-badge live">Live</span>
+          </a>
           <div class="admin-tile admin-tile-soon">
             <div class="admin-tile-icon">
               <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
@@ -158,6 +163,25 @@
               <div class="admin-tile-desc">Preview and A/B test tutor prompt versions</div>
             </div>
             <span class="admin-tile-badge">Soon</span>
+          </div>
+        </div>
+
+        <!-- ── Usage Stats ─────────────────────────────────────────────── -->
+        <h2 class="admin-section-title admin-section-heading" id="stats">Usage Stats</h2>
+        <div class="admin-stats-grid" id="stats-grid">
+          <div class="admin-stat-card"><div class="admin-stat-value" id="stat-total">—</div><div class="admin-stat-label">Total Sessions</div></div>
+          <div class="admin-stat-card"><div class="admin-stat-value" id="stat-users">—</div><div class="admin-stat-label">Registered Users</div></div>
+          <div class="admin-stat-card"><div class="admin-stat-value" id="stat-today">—</div><div class="admin-stat-label">Today</div></div>
+          <div class="admin-stat-card"><div class="admin-stat-value" id="stat-week">—</div><div class="admin-stat-label">This Week</div></div>
+          <div class="admin-stat-card"><div class="admin-stat-value" id="stat-avg">—</div><div class="admin-stat-label">Avg Duration</div></div>
+        </div>
+
+        <!-- ── Recent Sessions ────────────────────────────────────────── -->
+        <h2 class="admin-section-title admin-section-heading" id="sessions">Recent Sessions</h2>
+        <div class="admin-card">
+          <div id="sessions-table"><div class="table-loading">Loading…</div></div>
+          <div id="sessions-load-more" style="display:none; margin-top:0.75rem">
+            <button class="secondary" id="sessions-more-btn">Load more</button>
           </div>
         </div>
 
@@ -192,6 +216,17 @@
     </div>
 
   </div><!-- /.app-body -->
+
+  <!-- ── Transcript modal (admin) — reuses classes from history.css ──── -->
+  <div id="admin-transcript-overlay" class="transcript-overlay" style="display:none">
+    <div class="transcript-panel">
+      <div class="transcript-panel-header">
+        <h2 class="transcript-panel-title" id="admin-transcript-title">Transcript</h2>
+        <button type="button" class="transcript-close-btn" id="admin-transcript-close">Close</button>
+      </div>
+      <div class="transcript-messages" id="admin-transcript-messages"></div>
+    </div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.103.3/dist/umd/supabase.js"></script>
   <script src="/auth.js"></script>
@@ -302,6 +337,140 @@
       }
     }
 
+    // ── Stats ──────────────────────────────────────────────────────────
+    async function loadStats() {
+      try {
+        const res = await window.auth.authedFetch("/api/admin/stats");
+        const data = await res.json();
+        if (!res.ok || !data.ok) return;
+        const s = data.stats;
+        document.getElementById("stat-total").textContent = s.totalSessions.toLocaleString();
+        document.getElementById("stat-users").textContent = s.activeUsers.toLocaleString();
+        document.getElementById("stat-today").textContent = s.sessionsToday.toLocaleString();
+        document.getElementById("stat-week").textContent = s.sessionsThisWeek.toLocaleString();
+        document.getElementById("stat-avg").textContent =
+          s.avgDurationSeconds != null ? Math.round(s.avgDurationSeconds / 60) + " min" : "—";
+      } catch (e) {
+        console.error("[admin] loadStats error:", e);
+      }
+    }
+
+    // ── Sessions table ──────────────────────────────────────────────────
+    var sessionsOffset = 0;
+    var sessionsTotal = 0;
+
+    function fmtDate(iso) {
+      if (!iso) return "—";
+      return new Date(iso).toLocaleString(undefined, {
+        month: "short", day: "numeric", year: "numeric",
+        hour: "2-digit", minute: "2-digit"
+      });
+    }
+    function fmtDuration(start, end) {
+      if (!start || !end) return "—";
+      var mins = Math.round((new Date(end) - new Date(start)) / 60000);
+      return mins < 1 ? "<1 min" : mins + " min";
+    }
+    function fmtExperience(v) {
+      return { positive: "Good", neutral: "Neutral", negative: "Difficult" }[v] || (v || "—");
+    }
+
+    async function loadSessions(offset) {
+      try {
+        const res = await window.auth.authedFetch("/api/admin/sessions?limit=50&offset=" + offset);
+        const data = await res.json();
+        if (!res.ok || !data.ok) return;
+        sessionsTotal = data.total;
+
+        const container = document.getElementById("sessions-table");
+        if (offset === 0) {
+          if (!data.sessions.length) {
+            container.innerHTML = '<div class="table-empty">No ended sessions yet.</div>';
+            return;
+          }
+          const table = document.createElement("table");
+          table.innerHTML = `<thead><tr><th>User</th><th>Date</th><th>Duration</th><th>Model</th><th>Experience</th><th>Eval</th><th></th></tr></thead>`;
+          table.appendChild(document.createElement("tbody"));
+          container.replaceChildren(table);
+        }
+
+        const tbody = container.querySelector("tbody");
+        data.sessions.forEach(function(s) {
+          const evalBadge = s.has_failures === null ? '<span class="badge">—</span>'
+            : s.has_failures ? '<span class="badge failed">Fail</span>'
+            : '<span class="badge processed">Pass</span>';
+          const tr = document.createElement("tr");
+          tr.innerHTML = `
+            <td class="mono"></td>
+            <td></td>
+            <td></td>
+            <td class="mono"></td>
+            <td></td>
+            <td>${evalBadge}</td>
+            <td></td>`;
+          // Populate user-controlled/text fields via textContent to avoid HTML injection.
+          const tds = tr.children;
+          tds[0].textContent = s.user_email || "—";
+          tds[1].textContent = fmtDate(s.started_at);
+          tds[2].textContent = fmtDuration(s.started_at, s.ended_at);
+          tds[3].textContent = (s.model || "—").replace("claude-", "");
+          tds[4].textContent = fmtExperience(s.experience);
+          const viewBtn = document.createElement("button");
+          viewBtn.className = "secondary poll-btn";
+          viewBtn.textContent = "View";
+          viewBtn.addEventListener("click", function() {
+            viewTranscript(s.id, s.user_email, s.started_at);
+          });
+          tds[6].appendChild(viewBtn);
+          tbody.appendChild(tr);
+        });
+
+        sessionsOffset = offset + data.sessions.length;
+        const moreEl = document.getElementById("sessions-load-more");
+        moreEl.style.display = sessionsOffset < sessionsTotal ? "" : "none";
+      } catch (e) {
+        console.error("[admin] loadSessions error:", e);
+      }
+    }
+
+    // ── Transcript modal ───────────────────────────────────────────────
+    async function viewTranscript(sessionId, userEmail, startedAt) {
+      const overlay = document.getElementById("admin-transcript-overlay");
+      const titleEl = document.getElementById("admin-transcript-title");
+      const messagesEl = document.getElementById("admin-transcript-messages");
+      titleEl.textContent = "Transcript — " + (userEmail || sessionId.slice(0, 8)) + " — " + fmtDate(startedAt);
+      messagesEl.innerHTML = '<div class="table-loading">Loading…</div>';
+      overlay.style.display = "";
+      try {
+        const res = await window.auth.authedFetch("/api/transcript/" + sessionId);
+        const data = await res.json();
+        if (!res.ok || !data.transcript) {
+          messagesEl.innerHTML = '<div style="color:var(--danger)">Could not load transcript.</div>';
+          return;
+        }
+        messagesEl.innerHTML = "";
+        data.transcript.forEach(function(msg) {
+          const div = document.createElement("div");
+          div.className = "transcript-message " + (msg.role === "Student" ? "user" : "tutor");
+          const roleEl = document.createElement("strong");
+          roleEl.textContent = msg.role;
+          const textEl = document.createElement("p");
+          textEl.textContent = msg.text;
+          div.appendChild(roleEl);
+          div.appendChild(textEl);
+          messagesEl.appendChild(div);
+        });
+      } catch (e) {
+        messagesEl.innerHTML = "";
+        const err = document.createElement("div");
+        err.style.color = "var(--danger)";
+        err.textContent = "Error: " + e.message;
+        messagesEl.appendChild(err);
+      }
+    }
+
+    // TODO: extract admin inline JS to /admin.js when this block exceeds ~300 lines total.
+
     async function init() {
       await window.auth.init();
       const session = await window.auth.requireSession();
@@ -328,7 +497,15 @@
       document.getElementById("submit-btn").addEventListener("click", submitBatch);
       document.getElementById("poll-btn").addEventListener("click", () => pollBatch());
       document.getElementById("refresh-btn").addEventListener("click", loadBatches);
+      document.getElementById("admin-transcript-close").addEventListener("click", function() {
+        document.getElementById("admin-transcript-overlay").style.display = "none";
+      });
+      document.getElementById("sessions-more-btn").addEventListener("click", function() {
+        loadSessions(sessionsOffset);
+      });
 
+      loadStats();
+      loadSessions(0);
       loadBatches();
     }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,8 +10,15 @@ export {
   getUserInfoForSession,
   getUserProfileForSession,
   getFeedbackForSessions,
+  getAdminStats,
+  getAdminSessionList,
 } from "./sessions.js";
-export type { UserSessionInfo, UserSessionProfile } from "./sessions.js";
+export type {
+  UserSessionInfo,
+  UserSessionProfile,
+  AdminStats,
+  AdminSessionRow,
+} from "./sessions.js";
 
 export {
   createMessage,

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -190,29 +190,14 @@ export async function getFeedbackForSessions(
   return map;
 }
 
-/**
- * Aggregate usage stats returned by GET /api/admin/stats.
- *
- * `activeUsers` is a misnomer carried over from the launchpad tile name —
- * it is the count of registered users (from `auth.admin.listUsers`), not a
- * count of distinct session users. The admin UI labels this "Registered
- * Users" so the number is not misleading.
- */
 export interface AdminStats {
   totalSessions: number;
-  activeUsers: number;
+  registeredUsers: number;
   sessionsToday: number;
   sessionsThisWeek: number;
   avgDurationSeconds: number | null;
 }
 
-/**
- * Compute aggregate stats for the admin dashboard.
- *
- * Must be called with the service-role client — bypasses RLS and calls
- * `auth.admin.listUsers`. The avg-duration sample is capped at 500 ended
- * sessions which is fine for an early-stage product.
- */
 export async function getAdminStats(
   client: SupabaseClient,
 ): Promise<AdminStats> {
@@ -248,12 +233,12 @@ export async function getAdminStats(
     avgDurationSeconds = Math.round(totalMs / rows.length / 1000);
   }
 
-  const userTotal =
+  const registeredUsers =
     (users.data as { total?: number } | null)?.total ?? users.data?.users?.length ?? 0;
 
   return {
     totalSessions: total.count ?? 0,
-    activeUsers: userTotal,
+    registeredUsers,
     sessionsToday: today.count ?? 0,
     sessionsThisWeek: week.count ?? 0,
     avgDurationSeconds,
@@ -279,11 +264,6 @@ export interface AdminSessionRow {
   has_failures: boolean | null;
 }
 
-/**
- * Paginated list of ended sessions across all users with feedback and
- * evaluation fields embedded. Used by the admin dashboard recent-sessions
- * table. Must be called with the service-role client.
- */
 export async function getAdminSessionList(
   client: SupabaseClient,
   opts: { limit?: number; offset?: number } = {},
@@ -303,19 +283,17 @@ export async function getAdminSessionList(
 
   if (error) throw new Error(`getAdminSessionList: ${error.message}`);
 
-  // Batch user-email lookup to avoid N+1 queries. listUsers paginates at
-  // 1000 per page by default; fine for an early-stage product.
-  // TODO: pagination cap at 1000 users — implement multi-page fetch if the
-  // registered-user count exceeds 1000.
   const emailMap = new Map<string, string>();
   const rows = (data ?? []) as Array<Record<string, unknown>>;
   const userIds = [...new Set(
     rows.map((r) => r.user_id as string | null | undefined).filter((u): u is string => Boolean(u)),
   )];
   if (userIds.length > 0) {
-    const { data: usersData } = await client.auth.admin.listUsers({ perPage: 1000 });
-    for (const u of usersData?.users ?? []) {
-      if (u.email) emailMap.set(u.id, u.email);
+    const userResults = await Promise.all(
+      userIds.map((id) => client.auth.admin.getUserById(id)),
+    );
+    for (const { data: u } of userResults) {
+      if (u?.user?.email) emailMap.set(u.user.id, u.user.email);
     }
   }
 

--- a/packages/db/src/sessions.ts
+++ b/packages/db/src/sessions.ts
@@ -191,6 +191,161 @@ export async function getFeedbackForSessions(
 }
 
 /**
+ * Aggregate usage stats returned by GET /api/admin/stats.
+ *
+ * `activeUsers` is a misnomer carried over from the launchpad tile name —
+ * it is the count of registered users (from `auth.admin.listUsers`), not a
+ * count of distinct session users. The admin UI labels this "Registered
+ * Users" so the number is not misleading.
+ */
+export interface AdminStats {
+  totalSessions: number;
+  activeUsers: number;
+  sessionsToday: number;
+  sessionsThisWeek: number;
+  avgDurationSeconds: number | null;
+}
+
+/**
+ * Compute aggregate stats for the admin dashboard.
+ *
+ * Must be called with the service-role client — bypasses RLS and calls
+ * `auth.admin.listUsers`. The avg-duration sample is capped at 500 ended
+ * sessions which is fine for an early-stage product.
+ */
+export async function getAdminStats(
+  client: SupabaseClient,
+): Promise<AdminStats> {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const weekStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const [total, today, week, avgRows, users] = await Promise.all([
+    client.from("sessions").select("*", { count: "exact", head: true }),
+    client.from("sessions").select("*", { count: "exact", head: true })
+      .gte("started_at", todayStart.toISOString()),
+    client.from("sessions").select("*", { count: "exact", head: true })
+      .gte("started_at", weekStart.toISOString()),
+    client.from("sessions").select("started_at, ended_at")
+      .not("ended_at", "is", null)
+      .limit(500),
+    // Registered-user count via the admin API. perPage:1 returns the total
+    // via the `total` field without fetching user rows.
+    client.auth.admin.listUsers({ perPage: 1 }),
+  ]);
+
+  let avgDurationSeconds: number | null = null;
+  const rows = (avgRows.data ?? []) as Array<{
+    started_at: string;
+    ended_at: string;
+  }>;
+  if (rows.length > 0) {
+    const totalMs = rows.reduce(
+      (sum, r) =>
+        sum + (new Date(r.ended_at).getTime() - new Date(r.started_at).getTime()),
+      0,
+    );
+    avgDurationSeconds = Math.round(totalMs / rows.length / 1000);
+  }
+
+  const userTotal =
+    (users.data as { total?: number } | null)?.total ?? users.data?.users?.length ?? 0;
+
+  return {
+    totalSessions: total.count ?? 0,
+    activeUsers: userTotal,
+    sessionsToday: today.count ?? 0,
+    sessionsThisWeek: week.count ?? 0,
+    avgDurationSeconds,
+  };
+}
+
+/**
+ * Row shape returned by GET /api/admin/sessions. Combines `sessions` columns
+ * with embedded feedback + evaluation fields and a resolved user email.
+ */
+export interface AdminSessionRow {
+  id: string;
+  started_at: string;
+  ended_at: string | null;
+  user_id: string;
+  user_email: string | null;
+  model: string | null;
+  prompt_name: string | null;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  outcome: string | null;
+  experience: string | null;
+  has_failures: boolean | null;
+}
+
+/**
+ * Paginated list of ended sessions across all users with feedback and
+ * evaluation fields embedded. Used by the admin dashboard recent-sessions
+ * table. Must be called with the service-role client.
+ */
+export async function getAdminSessionList(
+  client: SupabaseClient,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<{ sessions: AdminSessionRow[]; total: number }> {
+  const limit = Math.min(Math.max(opts.limit ?? 50, 1), 100);
+  const offset = Math.max(opts.offset ?? 0, 0);
+
+  const { data, error, count } = await client
+    .from("sessions")
+    .select(
+      "id, started_at, ended_at, user_id, model, prompt_name, total_input_tokens, total_output_tokens, session_feedback(outcome, experience), session_evaluations(has_failures)",
+      { count: "exact" },
+    )
+    .not("ended_at", "is", null)
+    .order("started_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) throw new Error(`getAdminSessionList: ${error.message}`);
+
+  // Batch user-email lookup to avoid N+1 queries. listUsers paginates at
+  // 1000 per page by default; fine for an early-stage product.
+  // TODO: pagination cap at 1000 users — implement multi-page fetch if the
+  // registered-user count exceeds 1000.
+  const emailMap = new Map<string, string>();
+  const rows = (data ?? []) as Array<Record<string, unknown>>;
+  const userIds = [...new Set(
+    rows.map((r) => r.user_id as string | null | undefined).filter((u): u is string => Boolean(u)),
+  )];
+  if (userIds.length > 0) {
+    const { data: usersData } = await client.auth.admin.listUsers({ perPage: 1000 });
+    for (const u of usersData?.users ?? []) {
+      if (u.email) emailMap.set(u.id, u.email);
+    }
+  }
+
+  // Supabase JS does not emit typed inference for embedded selects, so the
+  // mapping step uses `any` for the embedded arrays only.
+  const sessions: AdminSessionRow[] = rows.map((r) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = r as any;
+    const feedback = Array.isArray(row.session_feedback) ? row.session_feedback[0] : row.session_feedback;
+    const evalRow = Array.isArray(row.session_evaluations) ? row.session_evaluations[0] : row.session_evaluations;
+    return {
+      id: row.id,
+      started_at: row.started_at,
+      ended_at: row.ended_at ?? null,
+      user_id: row.user_id,
+      user_email: emailMap.get(row.user_id) ?? null,
+      model: row.model ?? null,
+      prompt_name: row.prompt_name ?? null,
+      total_input_tokens: row.total_input_tokens ?? 0,
+      total_output_tokens: row.total_output_tokens ?? 0,
+      outcome: feedback?.outcome ?? null,
+      experience: feedback?.experience ?? null,
+      has_failures: evalRow?.has_failures ?? null,
+    };
+  });
+
+  return { sessions, total: count ?? 0 };
+}
+
+/**
  * Mark a session as ended by setting ended_at to now.
  * Session data (messages, feedback) is retained for analysis.
  */


### PR DESCRIPTION
## Summary

Closes #97. Activates two launchpad tiles on the admin console:

- **Usage Stats** — 5 cards (total sessions, registered users, today, this week, avg duration) backed by `GET /api/admin/stats`.
- **Recent Sessions** — paginated table of all ended sessions with user email, date, duration, model, feedback experience, and eval pass/fail badge; row "View" opens a transcript modal. Backed by `GET /api/admin/sessions`.
- **Transcript route admin bypass** — `GET /api/transcript/:sessionId` now permits admins to view any session (non-admins unchanged, still 404 for sessions they do not own).

Evaluation trends tile is intentionally left as "Soon" (de-scoped per the approved plan). No new npm packages. No database migrations.

## Files changed

- `apps/api/src/routes/transcript.ts` — admin-only ownership bypass
- `apps/api/src/routes/admin-stats.ts` — new router (`GET /stats`, `GET /sessions`), mounted with service-role `db` client
- `apps/api/src/index.ts` — mount new router at `/api/admin`
- `packages/db/src/sessions.ts` — `getAdminStats()` and `getAdminSessionList()` with batched user-email lookup (with TODO for >1000 user cap)
- `packages/db/src/index.ts` — barrel exports
- `apps/web/public/admin.html` — stats + sessions sections, transcript modal, launchpad tile upgrades, inline JS, loads `/history.css`
- `apps/web/public/admin.css` — stat card grid, `.transcript-message` bubble styles

## Security note

The transcript-route bypass is expressed as `(!req.isAdmin && !isOwner)`. `req.isAdmin` is sourced from the verified JWT `app_metadata.is_admin` claim by `createRequireAuth` and cannot be spoofed. Authentication still runs before the authorization check.

## Test plan

- [ ] `npm run build` succeeds with zero errors (verified locally).
- [ ] Admin token: `GET /api/admin/stats` returns `{ ok, stats: {...} }`.
- [ ] Admin token: `GET /api/admin/sessions?limit=10` returns `{ ok, sessions, total }`.
- [ ] Non-admin token: both admin endpoints return `403 { ok: false, error: "admin_only" }`.
- [ ] No token: both admin endpoints return `401 { ok: false, error: "unauthorized" }`.
- [ ] Admin token: `GET /api/transcript/:other_user_session_id` returns the transcript.
- [ ] Non-admin token: `GET /api/transcript/:other_user_session_id` still returns `404 "Session not found."`.
- [ ] Admin token: `GET /api/transcript/:own_session_id` still works.
- [ ] Load `/admin.html` as admin — stat cards populate, sessions table renders, "View" opens transcript modal, "Load more" button appears when needed.
- [ ] Load `/admin.html` as non-admin — access-denied banner shown, all buttons disabled.
- [ ] At 375px viewport width — stat cards render in 2-column grid.